### PR TITLE
Conceptset expression impelmentation

### DIFF
--- a/src/main/java/org/ohdsi/webapi/cohortdefinition/CohortExpressionQueryBuilder.java
+++ b/src/main/java/org/ohdsi/webapi/cohortdefinition/CohortExpressionQueryBuilder.java
@@ -5,6 +5,7 @@
  */
 package org.ohdsi.webapi.cohortdefinition;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import java.util.ArrayList;
 import org.apache.commons.lang3.StringUtils;
 import org.ohdsi.webapi.helper.ResourceHelper;
@@ -41,6 +42,21 @@ public class CohortExpressionQueryBuilder implements ICohortExpressionElementVis
   private final static String SPECIMEN_TEMPLATE = ResourceHelper.GetResourceAsString("/resources/cohortdefinition/sql/specimen.sql");
   private final static String VISIT_OCCURRENCE_TEMPLATE = ResourceHelper.GetResourceAsString("/resources/cohortdefinition/sql/visitOccurrence.sql");
 
+  public static class BuildExpressionQueryOptions {
+    @JsonProperty("cohortId")  
+    public Integer cohortId;
+
+    @JsonProperty("cdmSchema")  
+    public String cdmSchema;
+
+    @JsonProperty("targetSchema")  
+    public String targetSchema;
+
+    @JsonProperty("targetTable")  
+    public String targetTable;
+    
+
+  }  
   private ArrayList<Integer> getConceptIdsFromConcepts(Concept[] concepts) {
     ArrayList<Integer> conceptIdList = new ArrayList<>();
     for (Concept concept : concepts) {
@@ -154,7 +170,6 @@ public class CohortExpressionQueryBuilder implements ICohortExpressionElementVis
       return String.format("%s %s like '%s%s%s'", sqlExpression, negation, prefix, value, postfix);
   }
   
-  
   private String getCodesetQuery(Codeset[] codesets) {
     String codesetQuery = "";
     
@@ -231,13 +246,13 @@ public class CohortExpressionQueryBuilder implements ICohortExpressionElementVis
     return query;
   }
   
-  public String buildExpressionQuery(CohortExpression expression) {
+  public String buildExpressionQuery(CohortExpression expression, BuildExpressionQueryOptions options) {
     String resultSql = COHORT_QUERY_TEMPLATE;
 
     String codesetQuery = getCodesetQuery(expression.codesets);
-    String primaryEventsQuery = getPrimaryEventsQuery(expression.primaryCriteria);
-    
     resultSql = StringUtils.replace(resultSql, "@codesetQuery", codesetQuery);
+
+    String primaryEventsQuery = getPrimaryEventsQuery(expression.primaryCriteria);
     resultSql = StringUtils.replace(resultSql, "@primaryEventsQuery", primaryEventsQuery);
     
     String additionalCriteriaQuery = "";
@@ -255,9 +270,12 @@ public class CohortExpressionQueryBuilder implements ICohortExpressionElementVis
     }
     else
       resultSql = StringUtils.replace(resultSql, "@ResultLimitFilter","");
-    
-    //TODO: what should cohortID be?
-    resultSql = StringUtils.replace(resultSql, "@cohortId", "-1");
+
+    // replease query parameters with tokens
+    resultSql = StringUtils.replace(resultSql, "@CDM_schema", options.cdmSchema);
+    resultSql = StringUtils.replace(resultSql, "@targetSchema", options.targetSchema);
+    resultSql = StringUtils.replace(resultSql, "@targetTable", options.targetTable);
+    resultSql = StringUtils.replace(resultSql, "@cohortDefinitionId", options.cohortId.toString());
     return resultSql;
   }
 

--- a/src/main/java/org/ohdsi/webapi/vocabulary/ConceptSetExpression.java
+++ b/src/main/java/org/ohdsi/webapi/vocabulary/ConceptSetExpression.java
@@ -17,14 +17,6 @@ public class ConceptSetExpression {
     public boolean includeDescendants;
     public boolean includeMapped;
   }
-  
-  public static class Concept {
-    public long conceptId;
-    public String conceptName;
-    public String conceptCode;
-    public String domainId;
-    public String vocabularyId;
-  }
 
   public ConceptSetItem[] items;
   

--- a/src/main/java/org/ohdsi/webapi/vocabulary/ConceptSetExpression.java
+++ b/src/main/java/org/ohdsi/webapi/vocabulary/ConceptSetExpression.java
@@ -1,0 +1,31 @@
+/*
+ * To change this license header, choose License Headers in Project Properties.
+ * To change this template file, choose Tools | Templates
+ * and open the template in the editor.
+ */
+package org.ohdsi.webapi.vocabulary;
+
+/**
+ *
+ * A Class that encapsulates the elements of a Concept Set Expression.
+ */
+public class ConceptSetExpression {
+  public static class ConceptSetItem
+  {
+    public Concept concept;
+    public boolean isExcluded;
+    public boolean includeDescendants;
+    public boolean includeMapped;
+  }
+  
+  public static class Concept {
+    public long conceptId;
+    public String conceptName;
+    public String conceptCode;
+    public String domainId;
+    public String vocabularyId;
+  }
+
+  public ConceptSetItem[] items;
+  
+}

--- a/src/main/java/org/ohdsi/webapi/vocabulary/ConceptSetExpression.java
+++ b/src/main/java/org/ohdsi/webapi/vocabulary/ConceptSetExpression.java
@@ -1,7 +1,15 @@
 /*
- * To change this license header, choose License Headers in Project Properties.
- * To change this template file, choose Tools | Templates
- * and open the template in the editor.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 package org.ohdsi.webapi.vocabulary;
 

--- a/src/main/java/org/ohdsi/webapi/vocabulary/ConceptSetExpressionQueryBuilder.java
+++ b/src/main/java/org/ohdsi/webapi/vocabulary/ConceptSetExpressionQueryBuilder.java
@@ -21,20 +21,20 @@ public class ConceptSetExpressionQueryBuilder {
   private final static String CONCEPT_SET_MAPPED_TEMPLATE = ResourceHelper.GetResourceAsString("/resources/vocabulary/sql/conceptSetMapped.sql");
 
 
-  private ArrayList<Long> getConceptIds(ArrayList<ConceptSetExpression.Concept> concepts)
+  private ArrayList<Long> getConceptIds(ArrayList<Concept> concepts)
   {
     ArrayList<Long> conceptIdList = new ArrayList<>();
-    for (ConceptSetExpression.Concept concept : concepts) {
+    for (Concept concept : concepts) {
       conceptIdList.add(concept.conceptId);
     }
     return conceptIdList;     
   }
   
   private String buildConceptSetQuery(
-          ArrayList<ConceptSetExpression.Concept> concepts,
-          ArrayList<ConceptSetExpression.Concept> descendantConcepts,
-          ArrayList<ConceptSetExpression.Concept> excludeConcepts,
-          ArrayList<ConceptSetExpression.Concept> excludeDescendantConcepts)
+          ArrayList<Concept> concepts,
+          ArrayList<Concept> descendantConcepts,
+          ArrayList<Concept> excludeConcepts,
+          ArrayList<Concept> excludeDescendantConcepts)
   {
     String conceptSetQuery = StringUtils.replace(CONCEPT_SET_QUERY_TEMPLATE, "@conceptIds",StringUtils.join(getConceptIds(concepts), ","));
     if (descendantConcepts.size() > 0) {
@@ -61,15 +61,15 @@ public class ConceptSetExpressionQueryBuilder {
   public String buildExpressionQuery(ConceptSetExpression expression)
   {
     // handle included concepts.
-    ArrayList<ConceptSetExpression.Concept> includeConcepts = new ArrayList<>();
-    ArrayList<ConceptSetExpression.Concept> includeDescendantConcepts = new ArrayList<>();
-    ArrayList<ConceptSetExpression.Concept> excludeConcepts = new ArrayList<>();
-    ArrayList<ConceptSetExpression.Concept> excludeDescendantConcepts = new ArrayList<>();
+    ArrayList<Concept> includeConcepts = new ArrayList<>();
+    ArrayList<Concept> includeDescendantConcepts = new ArrayList<>();
+    ArrayList<Concept> excludeConcepts = new ArrayList<>();
+    ArrayList<Concept> excludeDescendantConcepts = new ArrayList<>();
     
-    ArrayList<ConceptSetExpression.Concept> includeMappedConcepts = new ArrayList<>();
-    ArrayList<ConceptSetExpression.Concept> includeMappedDescendantConcepts = new ArrayList<>();
-    ArrayList<ConceptSetExpression.Concept> excludeMappedConcepts = new ArrayList<>();
-    ArrayList<ConceptSetExpression.Concept> excludeMappedDescendantConcepts = new ArrayList<>();
+    ArrayList<Concept> includeMappedConcepts = new ArrayList<>();
+    ArrayList<Concept> includeMappedDescendantConcepts = new ArrayList<>();
+    ArrayList<Concept> excludeMappedConcepts = new ArrayList<>();
+    ArrayList<Concept> excludeMappedDescendantConcepts = new ArrayList<>();
     
     // populate each sub-set of cocnepts from the flags set in each concept set item
     for (ConceptSetExpression.ConceptSetItem item : expression.items)

--- a/src/main/java/org/ohdsi/webapi/vocabulary/ConceptSetExpressionQueryBuilder.java
+++ b/src/main/java/org/ohdsi/webapi/vocabulary/ConceptSetExpressionQueryBuilder.java
@@ -1,0 +1,118 @@
+/*
+ * To change this license header, choose License Headers in Project Properties.
+ * To change this template file, choose Tools | Templates
+ * and open the template in the editor.
+ */
+package org.ohdsi.webapi.vocabulary;
+
+import java.util.ArrayList;
+import org.apache.commons.lang3.StringUtils;
+import org.ohdsi.webapi.helper.ResourceHelper;
+
+/**
+ *
+ * Unit tests for CocneptSetExpressionQueryBuilder.
+ */
+public class ConceptSetExpressionQueryBuilder {
+
+  private final static String CONCEPT_SET_QUERY_TEMPLATE = ResourceHelper.GetResourceAsString("/resources/vocabulary/sql/conceptSetExpression.sql");
+  private final static String CONCEPT_SET_EXCLUDE_TEMPLATE = ResourceHelper.GetResourceAsString("/resources/vocabulary/sql/conceptSetExclude.sql");
+  private final static String CONCEPT_SET_DESCENDANTS_TEMPLATE = ResourceHelper.GetResourceAsString("/resources/vocabulary/sql/conceptSetDescendants.sql");
+  private final static String CONCEPT_SET_MAPPED_TEMPLATE = ResourceHelper.GetResourceAsString("/resources/vocabulary/sql/conceptSetMapped.sql");
+
+
+  private ArrayList<Long> getConceptIds(ArrayList<ConceptSetExpression.Concept> concepts)
+  {
+    ArrayList<Long> conceptIdList = new ArrayList<>();
+    for (ConceptSetExpression.Concept concept : concepts) {
+      conceptIdList.add(concept.conceptId);
+    }
+    return conceptIdList;     
+  }
+  
+  private String buildConceptSetQuery(
+          ArrayList<ConceptSetExpression.Concept> concepts,
+          ArrayList<ConceptSetExpression.Concept> descendantConcepts,
+          ArrayList<ConceptSetExpression.Concept> excludeConcepts,
+          ArrayList<ConceptSetExpression.Concept> excludeDescendantConcepts)
+  {
+    String conceptSetQuery = StringUtils.replace(CONCEPT_SET_QUERY_TEMPLATE, "@conceptIds",StringUtils.join(getConceptIds(concepts), ","));
+    if (descendantConcepts.size() > 0) {
+      String includeDescendantQuery = StringUtils.replace(CONCEPT_SET_DESCENDANTS_TEMPLATE, "@conceptIds", StringUtils.join(getConceptIds(descendantConcepts), ","));
+      conceptSetQuery = StringUtils.replace(conceptSetQuery,"@descendantQuery", includeDescendantQuery);
+    } else {
+      conceptSetQuery = StringUtils.replace(conceptSetQuery, "@descendantQuery", "");
+    }
+    if (excludeConcepts.size() > 0)
+    {
+      String excludeClause = StringUtils.replace(CONCEPT_SET_EXCLUDE_TEMPLATE,"@conceptIds", StringUtils.join(getConceptIds(excludeConcepts),","));
+      if (excludeDescendantConcepts.size() > 0){
+        String excludeClauseDescendantQuery = StringUtils.replace(CONCEPT_SET_DESCENDANTS_TEMPLATE, "@conceptIds", StringUtils.join(getConceptIds(excludeDescendantConcepts), ","));
+        excludeClause = StringUtils.replace(excludeClause, "@descendantQuery", excludeClauseDescendantQuery);
+      } else {
+        excludeClause = StringUtils.replace(excludeClause, "@descendantQuery", "");
+      }
+      conceptSetQuery += excludeClause;
+    }
+    
+    return conceptSetQuery;
+  }
+  
+  public String buildExpressionQuery(ConceptSetExpression expression)
+  {
+    // handle included concepts.
+    ArrayList<ConceptSetExpression.Concept> includeConcepts = new ArrayList<>();
+    ArrayList<ConceptSetExpression.Concept> includeDescendantConcepts = new ArrayList<>();
+    ArrayList<ConceptSetExpression.Concept> excludeConcepts = new ArrayList<>();
+    ArrayList<ConceptSetExpression.Concept> excludeDescendantConcepts = new ArrayList<>();
+    
+    ArrayList<ConceptSetExpression.Concept> includeMappedConcepts = new ArrayList<>();
+    ArrayList<ConceptSetExpression.Concept> includeMappedDescendantConcepts = new ArrayList<>();
+    ArrayList<ConceptSetExpression.Concept> excludeMappedConcepts = new ArrayList<>();
+    ArrayList<ConceptSetExpression.Concept> excludeMappedDescendantConcepts = new ArrayList<>();
+    
+    // populate each sub-set of cocnepts from the flags set in each concept set item
+    for (ConceptSetExpression.ConceptSetItem item : expression.items)
+    {
+      if (!item.isExcluded)
+      {
+        includeConcepts.add(item.concept);
+
+        if (item.includeDescendants)
+          includeDescendantConcepts.add(item.concept);
+
+        if (item.includeMapped)
+        {
+          includeMappedConcepts.add(item.concept);
+          if (item.includeDescendants)
+            includeMappedDescendantConcepts.add(item.concept);
+        }
+      } else {
+        excludeConcepts.add(item.concept);
+        if (item.includeDescendants)
+          excludeDescendantConcepts.add(item.concept);
+        if (item.includeMapped)
+        {
+          excludeMappedConcepts.add(item.concept);
+          if (item.includeDescendants)
+            excludeMappedDescendantConcepts.add(item.concept);
+        }
+      }
+    }
+    
+    // each ArrayList contains the concepts that are used in the sub-query of the codeset expression query
+    
+    // sanity check: if there are no included concepts, throw exception
+    if (includeConcepts.isEmpty())
+      throw new RuntimeException("Codeset Expression contained zero included concepts.  A codeset expression must contain at least 1 concept that is not excluded.");
+    
+    String conceptSetQuery = buildConceptSetQuery(includeConcepts, includeDescendantConcepts, excludeConcepts, excludeDescendantConcepts);
+    
+    if (includeMappedConcepts.size() > 0){
+      String mappedConceptsQuery = buildConceptSetQuery(includeMappedConcepts, includeMappedDescendantConcepts, excludeMappedConcepts, excludeMappedDescendantConcepts);
+      conceptSetQuery += "\nUNION\n" + StringUtils.replace(CONCEPT_SET_MAPPED_TEMPLATE, "@conceptsetQuery", mappedConceptsQuery);
+    }
+    
+    return conceptSetQuery;
+  }
+}

--- a/src/main/java/org/ohdsi/webapi/vocabulary/ConceptSetExpressionQueryBuilder.java
+++ b/src/main/java/org/ohdsi/webapi/vocabulary/ConceptSetExpressionQueryBuilder.java
@@ -1,8 +1,17 @@
 /*
- * To change this license header, choose License Headers in Project Properties.
- * To change this template file, choose Tools | Templates
- * and open the template in the editor.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
+
 package org.ohdsi.webapi.vocabulary;
 
 import java.util.ArrayList;

--- a/src/main/resources/resources/cohortdefinition/sql/generateCohort.sql
+++ b/src/main/resources/resources/cohortdefinition/sql/generateCohort.sql
@@ -1,8 +1,9 @@
 @codesetQuery
-
 @primaryEventsQuery
 
-select @cohortId as cohort_definition_id, person_id as subject_id, start_date as cohort_start_date, end_date as cohort_end_date
+DELETE FROM @targetSchema.@targetTable where cohort_definition_id = @cohortDefinitionId;
+INSERT INTO @targetSchema.@targetTable (cohort_definition_id, subject_id, cohort_start_date, cohort_end_date)
+select @cohortDefinitionId as cohort_definition_id, person_id as subject_id, start_date as cohort_start_date, end_date as cohort_end_date
 FROM 
 (
   select Raw.*, row_number() over (partition by Raw.person_id order by Raw.start_date @EventSort) as ordinal

--- a/src/main/resources/resources/vocabulary/sql/conceptSetDescendants.sql
+++ b/src/main/resources/resources/vocabulary/sql/conceptSetDescendants.sql
@@ -1,0 +1,7 @@
+  UNION 
+
+  select c.concept_id
+  from @CDM_schema.CONCEPT c
+  join @CDM_schema.CONCEPT_ANCESTOR ca on c.concept_id = ca.descendant_concept_id
+  and ca.ancestor_concept_id in (@conceptIds)
+  and c.invalid_reason is null

--- a/src/main/resources/resources/vocabulary/sql/conceptSetExclude.sql
+++ b/src/main/resources/resources/vocabulary/sql/conceptSetExclude.sql
@@ -1,0 +1,6 @@
+LEFT JOIN
+(
+  select concept_id from @CDM_schema.CONCEPT where concept_id in (@conceptIds)and invalid_reason is null
+  @descendantQuery
+) E ON I.concept_id = E.concept_id
+WHERE E.concept_id is null

--- a/src/main/resources/resources/vocabulary/sql/conceptSetExpression.sql
+++ b/src/main/resources/resources/vocabulary/sql/conceptSetExpression.sql
@@ -1,0 +1,5 @@
+select distinct I.concept_id FROM
+( 
+  select DISTINCT concept_id from @CDM_schema.CONCEPT where concept_id in (@conceptIds) and invalid_reason is null
+  @descendantQuery
+) I

--- a/src/main/resources/resources/vocabulary/sql/conceptSetMapped.sql
+++ b/src/main/resources/resources/vocabulary/sql/conceptSetMapped.sql
@@ -1,0 +1,6 @@
+select distinct cr.concept_id_2
+FROM
+(
+  @conceptsetQuery
+) C
+join @CDM_schema.concept_relationship cr on C.concept_id = cr.concept_id_1 and cr.relationship_id = 'Mapped from'

--- a/src/main/resources/resources/vocabulary/sql/conceptSetMapped.sql
+++ b/src/main/resources/resources/vocabulary/sql/conceptSetMapped.sql
@@ -1,4 +1,4 @@
-select distinct cr.concept_id_2
+select distinct cr.concept_id_2 as concept_id
 FROM
 (
   @conceptsetQuery

--- a/src/test/java/org/ohdsi/webapi/vocabulary/test/ConceptSetExpressionTests.java
+++ b/src/test/java/org/ohdsi/webapi/vocabulary/test/ConceptSetExpressionTests.java
@@ -1,0 +1,133 @@
+/*
+ * To change this license header, choose License Headers in Project Properties.
+ * To change this template file, choose Tools | Templates
+ * and open the template in the editor.
+ */
+package org.ohdsi.webapi.vocabulary.test;
+
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.Assert;
+import org.ohdsi.webapi.vocabulary.ConceptSetExpression;
+import org.ohdsi.webapi.vocabulary.ConceptSetExpressionQueryBuilder;
+
+/**
+ *
+ * @author cknoll1
+ */
+public class ConceptSetExpressionTests {
+
+  private static ConceptSetExpression getTestExpression() {
+    ConceptSetExpression exp = new ConceptSetExpression();
+    exp.items = new ConceptSetExpression.ConceptSetItem[8];
+
+    exp.items[0] = new ConceptSetExpression.ConceptSetItem();
+    exp.items[0].concept = new ConceptSetExpression.Concept();
+    exp.items[0].concept.conceptId = 1;
+    exp.items[0].concept.conceptName = "First Concept";
+    exp.items[0].isExcluded = false;
+    exp.items[0].includeDescendants = false;
+    exp.items[0].includeMapped = false;
+
+    exp.items[1] = new ConceptSetExpression.ConceptSetItem();
+    exp.items[1].concept = new ConceptSetExpression.Concept();
+    exp.items[1].concept.conceptId = 2;
+    exp.items[1].concept.conceptName = "Second Concept";
+    exp.items[1].isExcluded = false;
+    exp.items[1].includeDescendants = true;
+    exp.items[1].includeMapped = false;
+    
+    exp.items[2] = new ConceptSetExpression.ConceptSetItem();
+    exp.items[2].concept = new ConceptSetExpression.Concept();
+    exp.items[2].concept.conceptId = 3;
+    exp.items[2].concept.conceptName = "Third Concept";
+    exp.items[2].isExcluded = false;
+    exp.items[2].includeDescendants = true;
+    exp.items[2].includeMapped = true;
+
+    exp.items[3] = new ConceptSetExpression.ConceptSetItem();
+    exp.items[3].concept = new ConceptSetExpression.Concept();
+    exp.items[3].concept.conceptId = 4;
+    exp.items[3].concept.conceptName = "Forth Concept (Excluded)";
+    exp.items[3].isExcluded = true;
+    exp.items[3].includeDescendants = false;
+    exp.items[3].includeMapped = false;
+
+    exp.items[4] = new ConceptSetExpression.ConceptSetItem();
+    exp.items[4].concept = new ConceptSetExpression.Concept();
+    exp.items[4].concept.conceptId = 5;
+    exp.items[4].concept.conceptName = "Fith Concept (Excluded)";
+    exp.items[4].isExcluded = true;
+    exp.items[4].includeDescendants = true;
+    exp.items[4].includeMapped = false;
+
+    exp.items[5] = new ConceptSetExpression.ConceptSetItem();
+    exp.items[5].concept = new ConceptSetExpression.Concept();
+    exp.items[5].concept.conceptId = 6;
+    exp.items[5].concept.conceptName = "Sixth Concept (Excluded)";
+    exp.items[5].isExcluded = true;
+    exp.items[5].includeDescendants = false;
+    exp.items[5].includeMapped = true;
+
+    exp.items[6] = new ConceptSetExpression.ConceptSetItem();
+    exp.items[6].concept = new ConceptSetExpression.Concept();
+    exp.items[6].concept.conceptId = 7;
+    exp.items[6].concept.conceptName = "Seventh Concept (Excluded)";
+    exp.items[6].isExcluded = true;
+    exp.items[6].includeDescendants = true;
+    exp.items[6].includeMapped = true;
+    
+    exp.items[7] = new ConceptSetExpression.ConceptSetItem();
+    exp.items[7].concept = new ConceptSetExpression.Concept();
+    exp.items[7].concept.conceptId = 8;
+    exp.items[7].concept.conceptName = "Eigth Concept";
+    exp.items[7].isExcluded = false;
+    exp.items[7].includeDescendants = false;
+    exp.items[7].includeMapped = true;
+    
+    return exp;
+  }
+
+  @BeforeClass
+  public static void setUpClass() throws Exception {
+  }
+
+  @AfterClass
+  public static void tearDownClass() throws Exception {
+  }
+
+  @Test
+  public void SimpleConceptSetExpressionBuild() {
+    ConceptSetExpressionQueryBuilder builder = new ConceptSetExpressionQueryBuilder();
+    ConceptSetExpression testExpression = getTestExpression();
+
+    String conceptSetExpressionSql = builder.buildExpressionQuery(testExpression);
+    
+    // included concepts should have (1,2,3,8)
+    Assert.assertTrue(conceptSetExpressionSql.indexOf("(1,2,3,8)") > 0);
+    
+    // included descendants should have (2,3)
+    Assert.assertTrue(conceptSetExpressionSql.indexOf("(2,3)") > 0);
+    
+    // excluded concepts should have (4,5,6,7)
+    Assert.assertTrue(conceptSetExpressionSql.indexOf("(4,5,6,7)") > 0);
+    
+    // excluded descendants should have (5,7)
+    Assert.assertTrue(conceptSetExpressionSql.indexOf("(5,7)") > 0);
+    
+    // mapped concepts should have (3,8)
+    Assert.assertTrue(conceptSetExpressionSql.indexOf("(3,8)") > 0);
+    
+    // mapped descendants should have 3
+    Assert.assertTrue(conceptSetExpressionSql.indexOf("(3)") > 0);
+    
+    // mapped excludes should have (6,7)
+    Assert.assertTrue(conceptSetExpressionSql.indexOf("(6,7)") > 0);
+    
+    // mapped exclude descendants should have (7)
+    Assert.assertTrue(conceptSetExpressionSql.indexOf("(7)") > 0);
+    
+  }
+
+}

--- a/src/test/java/org/ohdsi/webapi/vocabulary/test/ConceptSetExpressionTests.java
+++ b/src/test/java/org/ohdsi/webapi/vocabulary/test/ConceptSetExpressionTests.java
@@ -9,6 +9,7 @@ import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.Assert;
+import org.ohdsi.webapi.vocabulary.Concept;
 import org.ohdsi.webapi.vocabulary.ConceptSetExpression;
 import org.ohdsi.webapi.vocabulary.ConceptSetExpressionQueryBuilder;
 
@@ -23,64 +24,64 @@ public class ConceptSetExpressionTests {
     exp.items = new ConceptSetExpression.ConceptSetItem[8];
 
     exp.items[0] = new ConceptSetExpression.ConceptSetItem();
-    exp.items[0].concept = new ConceptSetExpression.Concept();
-    exp.items[0].concept.conceptId = 1;
+    exp.items[0].concept = new Concept();
+    exp.items[0].concept.conceptId = 1L;
     exp.items[0].concept.conceptName = "First Concept";
     exp.items[0].isExcluded = false;
     exp.items[0].includeDescendants = false;
     exp.items[0].includeMapped = false;
 
     exp.items[1] = new ConceptSetExpression.ConceptSetItem();
-    exp.items[1].concept = new ConceptSetExpression.Concept();
-    exp.items[1].concept.conceptId = 2;
+    exp.items[1].concept = new Concept();
+    exp.items[1].concept.conceptId = 2L;
     exp.items[1].concept.conceptName = "Second Concept";
     exp.items[1].isExcluded = false;
     exp.items[1].includeDescendants = true;
     exp.items[1].includeMapped = false;
     
     exp.items[2] = new ConceptSetExpression.ConceptSetItem();
-    exp.items[2].concept = new ConceptSetExpression.Concept();
-    exp.items[2].concept.conceptId = 3;
+    exp.items[2].concept = new Concept();
+    exp.items[2].concept.conceptId = 3L;
     exp.items[2].concept.conceptName = "Third Concept";
     exp.items[2].isExcluded = false;
     exp.items[2].includeDescendants = true;
     exp.items[2].includeMapped = true;
 
     exp.items[3] = new ConceptSetExpression.ConceptSetItem();
-    exp.items[3].concept = new ConceptSetExpression.Concept();
-    exp.items[3].concept.conceptId = 4;
+    exp.items[3].concept = new Concept();
+    exp.items[3].concept.conceptId = 4L;
     exp.items[3].concept.conceptName = "Forth Concept (Excluded)";
     exp.items[3].isExcluded = true;
     exp.items[3].includeDescendants = false;
     exp.items[3].includeMapped = false;
 
     exp.items[4] = new ConceptSetExpression.ConceptSetItem();
-    exp.items[4].concept = new ConceptSetExpression.Concept();
-    exp.items[4].concept.conceptId = 5;
+    exp.items[4].concept = new Concept();
+    exp.items[4].concept.conceptId = 5L;
     exp.items[4].concept.conceptName = "Fith Concept (Excluded)";
     exp.items[4].isExcluded = true;
     exp.items[4].includeDescendants = true;
     exp.items[4].includeMapped = false;
 
     exp.items[5] = new ConceptSetExpression.ConceptSetItem();
-    exp.items[5].concept = new ConceptSetExpression.Concept();
-    exp.items[5].concept.conceptId = 6;
+    exp.items[5].concept = new Concept();
+    exp.items[5].concept.conceptId = 6L;
     exp.items[5].concept.conceptName = "Sixth Concept (Excluded)";
     exp.items[5].isExcluded = true;
     exp.items[5].includeDescendants = false;
     exp.items[5].includeMapped = true;
 
     exp.items[6] = new ConceptSetExpression.ConceptSetItem();
-    exp.items[6].concept = new ConceptSetExpression.Concept();
-    exp.items[6].concept.conceptId = 7;
+    exp.items[6].concept = new Concept();
+    exp.items[6].concept.conceptId = 7L;
     exp.items[6].concept.conceptName = "Seventh Concept (Excluded)";
     exp.items[6].isExcluded = true;
     exp.items[6].includeDescendants = true;
     exp.items[6].includeMapped = true;
     
     exp.items[7] = new ConceptSetExpression.ConceptSetItem();
-    exp.items[7].concept = new ConceptSetExpression.Concept();
-    exp.items[7].concept.conceptId = 8;
+    exp.items[7].concept = new Concept();
+    exp.items[7].concept.conceptId = 8L;
     exp.items[7].concept.conceptName = "Eigth Concept";
     exp.items[7].isExcluded = false;
     exp.items[7].includeDescendants = false;

--- a/src/test/java/org/ohdsi/webapi/vocabulary/test/ConceptSetExpressionTests.java
+++ b/src/test/java/org/ohdsi/webapi/vocabulary/test/ConceptSetExpressionTests.java
@@ -1,7 +1,15 @@
 /*
- * To change this license header, choose License Headers in Project Properties.
- * To change this template file, choose Tools | Templates
- * and open the template in the editor.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 package org.ohdsi.webapi.vocabulary.test;
 


### PR DESCRIPTION
Unfortunately, this pull also grabbed 2 small changes I made with respect for the cohort definition generation, so I'm sorry for that mistake, please disregard those change

This pull request introduces the ConceptSetExpression to the WebAPI codebase.  This includes new classes to encapsulate the data, and a ConceptSetQueryExpressionBuilder which takes a ConceptSet Expression and creates 'template sql' out of it. (Sql that still should be translated and tokens such as @CDM_schema replaced).  Additionally, I've added a small unit test to verify a test expression contains the proper IN clauses in the output SQL.  

I placed these files under the Vocabulary service since querying concepts seems to be in the domain of the Vocabulary.

