### PR TITLE
Initial .gitattributes file. Normalize eol. Fix Flyway checksum validation error

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,15 @@
+* text=auto
+*.sql text eol=lf
+*.xml text
+*.groovy text
+*.java text
+*.html text
+*.css text
+*.js text
+*.vm text
+*.properties text
+
+*.png binary
+*.jpeg binary
+*.jpg binary
+*.gif binary


### PR DESCRIPTION
.gitattributes should help ensure that eol characters are normalized when writing to the repository.  This should prevent messy diffs (e.g. where it looks like the whole file changed) & Flyway checksum validation errors, regardless of the value of 'git config --global core.autocrlf'.

For Flyway, the .gitattributes basically says always convert *.sql to 'lf' when writing to the object database as well as the working directory.
Below are steps to take to “refresh” existing cloned repo, after modifying .gitattributes
1.)	mvn clean (remove target dir)
2.)	git rm –cached –r *
3.)	git reset --hard

To confirm a file had LF, I used *nix `file src/main/resources/db/migration/oracle/V1.0.0.1__schema_create_spring_batch.sql`  The output should mention 'ascii text' (not 'ascii text with CRLF').

For our environment, where the schema was created via Flyway on a Windows machine (with core.autocrlf=true), I then dropped all Flyway managed objects and re-ran migrations.

More on the Flyway issue: https://github.com/flyway/flyway/issues/253
