### PR TITLE
Cohort generate job

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -43,6 +43,9 @@
 		<source.name>CDM_NAME</source.name>
 		<cdm.version>5</cdm.version>
 
+                <!-- cohort generation propertise -->
+                <cohort.targetTable>dbo.COHORT</cohort.targetTable>
+
 		<spring.batch.repository.tableprefix>BATCH_</spring.batch.repository.tableprefix>
 		<spring.batch.repository.isolationLevelForCreate>ISOLATION_READ_COMMITTED</spring.batch.repository.isolationLevelForCreate>
 		

--- a/src/main/java/org/ohdsi/webapi/cohortdefinition/CohortDefinition.java
+++ b/src/main/java/org/ohdsi/webapi/cohortdefinition/CohortDefinition.java
@@ -29,12 +29,14 @@ import javax.persistence.NamedAttributeNode;
 import javax.persistence.NamedEntityGraph;
 import javax.persistence.NamedSubgraph;
 import javax.persistence.OneToOne;
+import javax.persistence.Table;
 
 /**
  * JPA Entity for Cohort Definitions
  * @author cknoll1
  */
-@Entity(name = "cohort_definition")
+@Entity(name = "CohortDefinition")
+@Table(name="cohort_definition")
 @NamedEntityGraph(
     name = "CohortDefinition.withDetail",
     attributeNodes = { @NamedAttributeNode(value = "details", subgraph = "detailsGraph") },
@@ -59,7 +61,11 @@ public class CohortDefinition implements Serializable{
   @OneToOne(cascade = CascadeType.ALL, fetch = FetchType.LAZY, optional=false, orphanRemoval = true)
   @JoinColumn(name="id")
   CohortDefinitionDetails details;
-    
+
+  @OneToOne(cascade = CascadeType.ALL, fetch = FetchType.LAZY, optional=true, orphanRemoval = true)
+  @JoinColumn(name="id")
+  CohortGenerationInfo generationInfo;
+  
   @Column(name="created_by")
   private String createdBy;
   
@@ -107,15 +113,6 @@ public class CohortDefinition implements Serializable{
     return this;
   }
   
-  public CohortDefinitionDetails getDetails() {
-    return this.details;
-  }
-
-  public CohortDefinition setDetails(CohortDefinitionDetails details) {
-    this.details = details;
-    return this;
-  }
-
   public String getCreatedBy() {
     return createdBy;
   }
@@ -149,6 +146,24 @@ public class CohortDefinition implements Serializable{
 
   public CohortDefinition setModifiedDate(Date modifiedDate) {
     this.modifiedDate = modifiedDate;
+    return this;
+  }
+  
+  public CohortDefinitionDetails getDetails() {
+    return this.details;
+  }
+
+  public CohortDefinition setDetails(CohortDefinitionDetails details) {
+    this.details = details;
+    return this;
+  }
+
+  public CohortGenerationInfo getGenerationInfo() {
+    return this.generationInfo;
+  }
+  
+  public CohortDefinition setGenerationInfo(CohortGenerationInfo info) {
+    this.generationInfo = info;
     return this;
   }
 }

--- a/src/main/java/org/ohdsi/webapi/cohortdefinition/CohortDefinitionDetails.java
+++ b/src/main/java/org/ohdsi/webapi/cohortdefinition/CohortDefinitionDetails.java
@@ -21,13 +21,15 @@ import javax.persistence.JoinColumn;
 import javax.persistence.Lob;
 import javax.persistence.MapsId;
 import javax.persistence.OneToOne;
+import javax.persistence.Table;
 import org.hibernate.annotations.Type;
 
 /**
  *
  * Stores the LOB/CLOB portion of the cohort definition expression.
  */
-@Entity(name = "cohort_definition_details")
+@Entity(name = "CohortDefinitionDetails")
+@Table(name="cohort_definition_details")
 public class CohortDefinitionDetails implements Serializable {
 
   private static final long serialVersionUID = 1L;

--- a/src/main/java/org/ohdsi/webapi/cohortdefinition/CohortDefinitionDetails.java
+++ b/src/main/java/org/ohdsi/webapi/cohortdefinition/CohortDefinitionDetails.java
@@ -15,17 +15,12 @@
 package org.ohdsi.webapi.cohortdefinition;
 
 import java.io.Serializable;
-import javax.persistence.Column;
 import javax.persistence.Entity;
-import javax.persistence.GeneratedValue;
 import javax.persistence.Id;
 import javax.persistence.JoinColumn;
 import javax.persistence.Lob;
 import javax.persistence.MapsId;
 import javax.persistence.OneToOne;
-import javax.persistence.PrimaryKeyJoinColumn;
-import org.hibernate.annotations.GenericGenerator;
-import org.hibernate.annotations.Parameter;
 import org.hibernate.annotations.Type;
 
 /**
@@ -33,7 +28,7 @@ import org.hibernate.annotations.Type;
  * Stores the LOB/CLOB portion of the cohort definition expression.
  */
 @Entity(name = "cohort_definition_details")
-public class CohortDefinitionDetails  implements Serializable{
+public class CohortDefinitionDetails implements Serializable {
 
   private static final long serialVersionUID = 1L;
   

--- a/src/main/java/org/ohdsi/webapi/cohortdefinition/CohortDefinitionRepository.java
+++ b/src/main/java/org/ohdsi/webapi/cohortdefinition/CohortDefinitionRepository.java
@@ -14,13 +14,11 @@
  */
 package org.ohdsi.webapi.cohortdefinition;
 
-import java.io.Serializable;
-import javax.transaction.Transactional;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.EntityGraph;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.CrudRepository;
-import org.springframework.data.repository.Repository;
 
 /**
  *
@@ -32,5 +30,6 @@ public interface CohortDefinitionRepository extends CrudRepository<CohortDefinit
   // Bug in hibernate, findById should use @EntityGraph, but details are not being feched. Workaround: mark details Fetch.EAGER,
   // but means findAll() will eager load definitions (what the @EntityGraph was supposed to solve)
   @EntityGraph(value = "CohortDefinition.withDetail", type = EntityGraph.EntityGraphType.LOAD)
-  CohortDefinition findById(Integer id);
+  @Query("select cd from CohortDefinition cd where id = ?1")
+  CohortDefinition findOneWithDetail(Integer id);
 }

--- a/src/main/java/org/ohdsi/webapi/cohortdefinition/CohortGenerationInfo.java
+++ b/src/main/java/org/ohdsi/webapi/cohortdefinition/CohortGenerationInfo.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright 2015 Observational Health Data Sciences and Informatics [OHDSI.org].
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.ohdsi.webapi.cohortdefinition;
+
+import java.util.Date;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.MapsId;
+import javax.persistence.OneToOne;
+import javax.persistence.Table;
+
+/**
+ *
+ * @author Chris Knoll <cknoll@ohdsi.org>
+ */
+@Entity(name = "CohortGenerationInfo")
+@Table(name="cohort_generation_info")
+public class CohortGenerationInfo {
+  private static final long serialVersionUID = 1L;
+
+  @Id
+  private Integer id;
+  
+  @MapsId
+  @OneToOne
+  @JoinColumn(name="id")
+  private CohortDefinition definition;
+
+  @Column(name="start_time")
+  private Date startTime;  
+  
+  @Column(name="execution_duration")
+  private Integer executionDuration;    
+  
+  @Column(name="status")
+  private GenerationStatus status;    
+  
+  @Column(name="is_valid")
+  private boolean isValid;
+  
+  
+  public Integer getId() {
+    return id;
+  }
+
+  public CohortGenerationInfo setId(Integer id) {
+    this.id = id;
+    return this;
+  }
+
+  public Date getStartTime() {
+    return startTime;
+  }
+
+  public CohortGenerationInfo setStartTime(Date startTime) {
+    this.startTime = startTime;
+    return this;
+  }
+
+  public Integer getExecutionDuration() {
+    return executionDuration;
+  }
+
+  public CohortGenerationInfo setExecutionDuration(Integer executionDuration) {
+    this.executionDuration = executionDuration;
+    return this;
+  }
+
+  public GenerationStatus getStatus() {
+    return status;
+  }
+
+  public CohortGenerationInfo setStatus(GenerationStatus status) {
+    this.status = status;
+    return this;
+  }
+
+  public boolean isIsValid() {
+    return isValid;
+  }
+
+  public CohortGenerationInfo setIsValid(boolean isValid) {
+    this.isValid = isValid;
+    return this;
+  }
+  
+  public CohortGenerationInfo setCohortDefinition(CohortDefinition definition) {
+    this.definition = definition;
+    return this;
+  }
+}

--- a/src/main/java/org/ohdsi/webapi/cohortdefinition/GenerateCohortTask.java
+++ b/src/main/java/org/ohdsi/webapi/cohortdefinition/GenerateCohortTask.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2015 Observational Health Data Sciences and Informatics <OHDSI.org>.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.ohdsi.webapi.cohortdefinition;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+/**
+ *
+ * @author Chris Knoll <cknoll@ohdsi.org>
+ */
+public class GenerateCohortTask {
+
+  //TODO: Define task-specific paramters
+  
+  @Override
+  public String toString() {
+
+    try {
+      ObjectMapper mapper = new ObjectMapper();
+      return mapper.writeValueAsString(this);
+    } catch (Exception e) {
+      
+    }
+
+    return super.toString();
+
+  }
+}

--- a/src/main/java/org/ohdsi/webapi/cohortdefinition/GenerateCohortTask.java
+++ b/src/main/java/org/ohdsi/webapi/cohortdefinition/GenerateCohortTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Observational Health Data Sciences and Informatics <OHDSI.org>.
+ * Copyright 2015 Observational Health Data Sciences and Informatics [OHDSI.org].
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,6 +16,7 @@
 package org.ohdsi.webapi.cohortdefinition;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import org.ohdsi.webapi.cohortdefinition.CohortExpressionQueryBuilder.BuildExpressionQueryOptions;
 
 /**
  *
@@ -24,6 +25,51 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 public class GenerateCohortTask {
 
   //TODO: Define task-specific paramters
+  private CohortDefinition cohortDefinition;
+  private BuildExpressionQueryOptions options;
+  private String sourceDialect;
+  private String targetDialect;
+    
+  public CohortDefinition getCohortDefinition()
+  {
+    return this.cohortDefinition;
+  }
+  
+  public GenerateCohortTask setCohortDefinition(CohortDefinition cohortDefinition)
+  {
+    this.cohortDefinition = cohortDefinition;
+    return this;
+  }
+  
+  public BuildExpressionQueryOptions getOptions()
+  {
+    return this.options;
+  }
+  
+  public GenerateCohortTask setOptions(BuildExpressionQueryOptions options)
+  {
+    this.options = options;
+    return this;
+  }
+  
+  public String getSourceDialect() {
+    return sourceDialect;
+  }
+
+  public GenerateCohortTask setSourceDialect(String sourceDialect) {
+    this.sourceDialect = sourceDialect;
+    return this;
+    
+  }
+
+  public String getTargetDialect() {
+    return targetDialect;
+  }
+
+  public GenerateCohortTask setTargetDialect(String targetDialect) {
+    this.targetDialect = targetDialect;
+    return this;
+  }
   
   @Override
   public String toString() {
@@ -32,7 +78,7 @@ public class GenerateCohortTask {
       ObjectMapper mapper = new ObjectMapper();
       return mapper.writeValueAsString(this);
     } catch (Exception e) {
-      
+      // ignored, let parent resolve...
     }
 
     return super.toString();

--- a/src/main/java/org/ohdsi/webapi/cohortdefinition/GenerateCohortTasklet.java
+++ b/src/main/java/org/ohdsi/webapi/cohortdefinition/GenerateCohortTasklet.java
@@ -16,6 +16,8 @@
 package org.ohdsi.webapi.cohortdefinition;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.Calendar;
+import java.util.Date;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.ohdsi.sql.SqlSplit;
@@ -25,9 +27,10 @@ import org.springframework.batch.core.scope.context.ChunkContext;
 import org.springframework.batch.core.step.tasklet.Tasklet;
 import org.springframework.batch.repeat.RepeatStatus;
 import org.springframework.jdbc.core.JdbcTemplate;
-import org.springframework.stereotype.Component;
+import org.springframework.transaction.TransactionDefinition;
 import org.springframework.transaction.TransactionException;
 import org.springframework.transaction.TransactionStatus;
+import org.springframework.transaction.support.DefaultTransactionDefinition;
 import org.springframework.transaction.support.TransactionCallback;
 import org.springframework.transaction.support.TransactionTemplate;
 
@@ -39,56 +42,91 @@ public class GenerateCohortTasklet implements Tasklet {
 
   private static final Log log = LogFactory.getLog(GenerateCohortTasklet.class);
 
-    private final static CohortExpressionQueryBuilder expressionQueryBuilder = new CohortExpressionQueryBuilder();
-    
-    private final GenerateCohortTask task;
-    private final JdbcTemplate jdbcTemplate;
-    private final TransactionTemplate transactionTemplate;
-    
-    
-    public GenerateCohortTasklet(GenerateCohortTask task, final JdbcTemplate jdbcTemplate,
-        final TransactionTemplate transactionTemplate) {
-        this.task = task;
-        this.jdbcTemplate = jdbcTemplate;
-        this.transactionTemplate = transactionTemplate;
+  private final static CohortExpressionQueryBuilder expressionQueryBuilder = new CohortExpressionQueryBuilder();
+
+  private final GenerateCohortTask task;
+  private final JdbcTemplate jdbcTemplate;
+  private final TransactionTemplate transactionTemplate;
+  private final CohortDefinitionRepository cohortDefinitionRepository;
+
+  public GenerateCohortTasklet(GenerateCohortTask task, 
+          final JdbcTemplate jdbcTemplate, 
+          final TransactionTemplate transactionTemplate,
+          final CohortDefinitionRepository cohortDefinitionRepository) {
+    this.task = task;
+    this.jdbcTemplate = jdbcTemplate;
+    this.transactionTemplate = transactionTemplate;
+    this.cohortDefinitionRepository = cohortDefinitionRepository;
+  }
+
+  private int[] doTask() {
+    int[] result = null;
+    try {
+      ObjectMapper mapper = new ObjectMapper();
+
+      CohortExpression expression = mapper.readValue(this.task.getCohortDefinition().getDetails().getExpression(), CohortExpression.class);
+      String expressionSql = expressionQueryBuilder.buildExpressionQuery(expression, this.task.getOptions());
+      String translatedSql = SqlTranslate.translateSql(expressionSql, this.task.getSourceDialect(), this.task.getTargetDialect());
+      String[] sqlStatements = SqlSplit.splitSql(translatedSql);
+      result = GenerateCohortTasklet.this.jdbcTemplate.batchUpdate(sqlStatements);
+
+    } catch (Exception e) {
+      throw new RuntimeException(e);
     }
+
+    return result;
+  }
+
+  @Override
+  public RepeatStatus execute(final StepContribution contribution, final ChunkContext chunkContext) throws Exception {
+    Date startTime = Calendar.getInstance().getTime();
     
-    private int[] doTask()
+    DefaultTransactionDefinition initTx = new DefaultTransactionDefinition();
+    initTx.setPropagationBehavior(TransactionDefinition.PROPAGATION_REQUIRES_NEW);
+    TransactionStatus initStatus = this.transactionTemplate.getTransactionManager().getTransaction(initTx);
+    CohortDefinition df = this.cohortDefinitionRepository.findOne(this.task.getCohortDefinition().getId());
+    CohortGenerationInfo info = df.getGenerationInfo();
+    if (info == null)
     {
-      int[] result = null;
-      try {
-        ObjectMapper mapper = new ObjectMapper();
-
-        CohortExpression expression = mapper.readValue(this.task.getCohortDefinition().getDetails().getExpression(), CohortExpression.class);
-        String expressionSql = expressionQueryBuilder.buildExpressionQuery(expression, this.task.getOptions());
-        String translatedSql = SqlTranslate.translateSql(expressionSql, this.task.getSourceDialect(), this.task.getTargetDialect());
-        String[] sqlStatements = SqlSplit.splitSql(translatedSql);
-        result = GenerateCohortTasklet.this.jdbcTemplate.batchUpdate(sqlStatements);
-
-      } catch (Exception e)
-      {
-        throw new RuntimeException(e);
-      }
-      
-      return result;
+      info = new CohortGenerationInfo().setCohortDefinition(df);
+      df.setGenerationInfo(info);
     }
-    @Override
-    public RepeatStatus execute(final StepContribution contribution, final ChunkContext chunkContext) throws Exception {
-        
-        try {
-            final int[] ret = this.transactionTemplate.execute(new TransactionCallback<int[]>() {
-                
-                @Override
-                public int[] doInTransaction(final TransactionStatus status) {
-                  return doTask();
-                }
-            });
-            log.debug("Update count: " + ret.length);
-        } catch (final TransactionException e) {
-            log.error(e.getMessage(), e);
-            throw e;//FAIL job status
+
+    info.setIsValid(false);
+    info.setStartTime(startTime);
+    info.setStatus(GenerationStatus.RUNNING);    
+    df = this.cohortDefinitionRepository.save(df);
+    this.transactionTemplate.getTransactionManager().commit(initStatus);
+    
+    info = df.getGenerationInfo();
+    
+    try {
+      final int[] ret = this.transactionTemplate.execute(new TransactionCallback<int[]>() {
+
+        @Override
+        public int[] doInTransaction(final TransactionStatus status) {
+          return doTask();
         }
-        return RepeatStatus.FINISHED;
+      });
+      log.debug("Update count: " + ret.length);
+      info.setIsValid(true);
+    } catch (final TransactionException e) {
+      info.setIsValid(false);
+      log.error(e.getMessage(), e);
+      throw e;//FAIL job status
     }
-      
+    finally {
+      DefaultTransactionDefinition completeTx = new DefaultTransactionDefinition();
+      completeTx.setPropagationBehavior(TransactionDefinition.PROPAGATION_REQUIRES_NEW);
+      TransactionStatus completeStatus = this.transactionTemplate.getTransactionManager().getTransaction(completeTx);      
+      Date endTime = Calendar.getInstance().getTime();
+      info.setExecutionDuration(new Integer((int)(endTime.getTime() - startTime.getTime())));
+      info.setStatus(GenerationStatus.COMPLETE);
+      this.cohortDefinitionRepository.save(df);
+      this.transactionTemplate.getTransactionManager().commit(completeStatus);
+    }
+
+    return RepeatStatus.FINISHED;
+  }
+
 }

--- a/src/main/java/org/ohdsi/webapi/cohortdefinition/GenerateCohortTasklet.java
+++ b/src/main/java/org/ohdsi/webapi/cohortdefinition/GenerateCohortTasklet.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2015 Observational Health Data Sciences and Informatics <OHDSI.org>.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.ohdsi.webapi.cohortdefinition;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.ohdsi.webapi.cohortanalysis.CohortAnalysisTasklet;
+import org.springframework.batch.core.StepContribution;
+import org.springframework.batch.core.scope.context.ChunkContext;
+import org.springframework.batch.core.step.tasklet.Tasklet;
+import org.springframework.batch.repeat.RepeatStatus;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.transaction.TransactionException;
+import org.springframework.transaction.TransactionStatus;
+import org.springframework.transaction.support.TransactionCallback;
+import org.springframework.transaction.support.TransactionTemplate;
+
+/**
+ *
+ * @author Chris Knoll <cknoll@ohdsi.org>
+ */
+public class GenerateCohortTasklet implements Tasklet {
+
+  private static final Log log = LogFactory.getLog(CohortAnalysisTasklet.class);
+    
+    private final String[] sql;
+    
+    private final JdbcTemplate jdbcTemplate;
+    
+    private final TransactionTemplate transactionTemplate;
+    
+    public GenerateCohortTasklet(final String[] taskSql, final JdbcTemplate jdbcTemplate,
+        final TransactionTemplate transactionTemplate) {
+        this.sql = taskSql;
+        this.jdbcTemplate = jdbcTemplate;
+        this.transactionTemplate = transactionTemplate;
+    }
+    
+    @Override
+    public RepeatStatus execute(final StepContribution contribution, final ChunkContext chunkContext) throws Exception {
+        
+        try {
+            final int[] ret = this.transactionTemplate.execute(new TransactionCallback<int[]>() {
+                
+                @Override
+                public int[] doInTransaction(final TransactionStatus status) {
+                    return GenerateCohortTasklet.this.jdbcTemplate.batchUpdate(GenerateCohortTasklet.this.sql);
+                }
+            });
+            log.debug("Update count: " + ret.length);
+        } catch (final TransactionException e) {
+            log.error(e.getMessage(), e);
+            throw e;//FAIL job status
+        }
+        return RepeatStatus.FINISHED;
+    }
+      
+}

--- a/src/main/java/org/ohdsi/webapi/cohortdefinition/GenerationStatus.java
+++ b/src/main/java/org/ohdsi/webapi/cohortdefinition/GenerationStatus.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2015 Observational Health Data Sciences and Informatics [OHDSI.org].
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.ohdsi.webapi.cohortdefinition;
+
+/**
+ *
+ * @author Chris Knoll <cknoll@ohdsi.org>
+ */
+public enum GenerationStatus {
+  PENDING,
+  RUNNING,
+  COMPLETE
+}  

--- a/src/main/java/org/ohdsi/webapi/cohortdefinition/GenerationStatusConverter.java
+++ b/src/main/java/org/ohdsi/webapi/cohortdefinition/GenerationStatusConverter.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2015 Observational Health Data Sciences and Informatics [OHDSI.org].
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.ohdsi.webapi.cohortdefinition;
+
+import javax.persistence.AttributeConverter;
+import javax.persistence.Converter;
+
+/**
+ *
+ * @author Chris Knoll <cknoll@ohdsi.org>
+ */
+@Converter(autoApply = true)
+public class GenerationStatusConverter implements AttributeConverter<GenerationStatus, Integer>{
+
+  @Override
+  public Integer convertToDatabaseColumn(GenerationStatus status) {
+    switch (status) {
+      case PENDING:
+        return 0;
+      case RUNNING:
+        return 1;
+      case COMPLETE:
+        return 2;
+      default:
+        throw new IllegalArgumentException("Unknown value: " + status);
+    }
+  }
+
+  @Override
+  public GenerationStatus convertToEntityAttribute(Integer statusValue) {
+    switch (statusValue) {
+      case 0: return GenerationStatus.PENDING;
+      case 1: return GenerationStatus.RUNNING;
+      case 2: return GenerationStatus.COMPLETE;
+      default: throw new IllegalArgumentException("Unknown status value: " + statusValue);
+    }
+  }
+  
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -60,3 +60,6 @@ server.context-path=/WebAPI
 #Disabled to support Basic Auth and RESTful interface
 #http://docs.spring.io/spring-security/site/docs/3.2.x-SNAPSHOT/reference/html5/#when-to-use-csrf-protection
 csrf.disable=true
+
+#cohortTargetTable
+cohort.targetTable=${cohort.targetTable}

--- a/src/main/resources/db/migration/oracle/V1.0.0.3.1__cohort_generation.sql
+++ b/src/main/resources/db/migration/oracle/V1.0.0.3.1__cohort_generation.sql
@@ -1,11 +1,11 @@
-ALTER TABLE dbo.cohort_definition_details
+ALTER TABLE cohort_definition_details
   DROP CONSTRAINT FK_cdd_cd
 ;
 
-ALTER TABLE dbo.cohort_definition_details 
+ALTER TABLE cohort_definition_details 
   ADD CONSTRAINT FK_cdd_cd 
     FOREIGN KEY ( id) 
-    REFERENCES dbo.cohort_definition (id)
+    REFERENCES cohort_definition (id)
       ON DELETE CASCADE
 ;
 

--- a/src/main/resources/db/migration/oracle/V1.0.0.3.1__cohort_generation.sql
+++ b/src/main/resources/db/migration/oracle/V1.0.0.3.1__cohort_generation.sql
@@ -1,0 +1,22 @@
+ALTER TABLE dbo.cohort_definition_details
+  DROP CONSTRAINT FK_cdd_cd
+;
+
+ALTER TABLE dbo.cohort_definition_details 
+  ADD CONSTRAINT FK_cdd_cd 
+    FOREIGN KEY ( id) 
+    REFERENCES dbo.cohort_definition (id)
+      ON DELETE CASCADE
+;
+
+CREATE TABLE cohort_generation_info(
+  id Number(10) NOT NULL,
+  start_time Timestamp(3) NOT NULL,
+  execution_duration Number(10) NULL,
+  status Number(10) NOT NULL,
+  is_valid Number(1) NOT NULL,
+  CONSTRAINT PK_cohort_generation_info PRIMARY KEY ( id),
+  CONSTRAINT FK_cgi_cd FOREIGN KEY(id)
+    REFERENCES cohort_definition (id)
+    ON DELETE CASCADE
+);

--- a/src/main/resources/db/migration/postgresql/V1.0.0.3.1__cohort_generation.sql
+++ b/src/main/resources/db/migration/postgresql/V1.0.0.3.1__cohort_generation.sql
@@ -15,7 +15,7 @@ CREATE TABLE cohort_generation_info(
   execution_duration int NULL,
   status int NOT NULL,
   is_valid Boolean NOT NULL,
-  CONSTRAINT PK_cohort_generation_info PRIMARY KEY ( id ASC),
+  CONSTRAINT PK_cohort_generation_info PRIMARY KEY (id),
   CONSTRAINT FK_cohort_generation_info_cohort_definition FOREIGN KEY(id)
     REFERENCES cohort_definition (id)
     ON UPDATE CASCADE

--- a/src/main/resources/db/migration/postgresql/V1.0.0.3.1__cohort_generation.sql
+++ b/src/main/resources/db/migration/postgresql/V1.0.0.3.1__cohort_generation.sql
@@ -1,0 +1,23 @@
+ALTER TABLE dbo.cohort_definition_details
+  DROP CONSTRAINT FK_cohort_definition_details_cohort_definition
+;
+
+ALTER TABLE dbo.cohort_definition_details 
+  ADD CONSTRAINT FK_cohort_definition_details_cohort_definition 
+    FOREIGN KEY (id) 
+    REFERENCES dbo.cohort_definition (id)
+      ON DELETE CASCADE
+;
+
+CREATE TABLE cohort_generation_info(
+  id int NOT NULL,
+  start_time Timestamp(3) NOT NULL,
+  execution_duration int NULL,
+  status int NOT NULL,
+  is_valid Boolean NOT NULL,
+  CONSTRAINT PK_cohort_generation_info PRIMARY KEY ( id ASC),
+  CONSTRAINT FK_cohort_generation_info_cohort_definition FOREIGN KEY(id)
+    REFERENCES cohort_definition (id)
+    ON UPDATE CASCADE
+    ON DELETE CASCADE
+);

--- a/src/main/resources/db/migration/postgresql/V1.0.0.3.1__cohort_generation.sql
+++ b/src/main/resources/db/migration/postgresql/V1.0.0.3.1__cohort_generation.sql
@@ -1,11 +1,11 @@
-ALTER TABLE dbo.cohort_definition_details
+ALTER TABLE cohort_definition_details
   DROP CONSTRAINT FK_cohort_definition_details_cohort_definition
 ;
 
-ALTER TABLE dbo.cohort_definition_details 
+ALTER TABLE cohort_definition_details 
   ADD CONSTRAINT FK_cohort_definition_details_cohort_definition 
     FOREIGN KEY (id) 
-    REFERENCES dbo.cohort_definition (id)
+    REFERENCES cohort_definition (id)
       ON DELETE CASCADE
 ;
 

--- a/src/main/resources/db/migration/sqlserver/V1.0.0.3.1__cohort_generation.sql
+++ b/src/main/resources/db/migration/sqlserver/V1.0.0.3.1__cohort_generation.sql
@@ -1,0 +1,35 @@
+IF (EXISTS (SELECT * 
+                 FROM INFORMATION_SCHEMA.REFERENTIAL_CONSTRAINTS 
+                 WHERE CONSTRAINT_SCHEMA = 'dbo' 
+                 AND  CONSTRAINT_NAME = 'FK_cohort_definition_details_cohort_definition'))
+BEGIN
+ALTER TABLE dbo.cohort_definition_details
+  DROP CONSTRAINT FK_cohort_definition_details_cohort_definition
+END;
+
+ALTER TABLE dbo.cohort_definition_details 
+  ADD CONSTRAINT FK_cohort_definition_details_cohort_definition 
+    FOREIGN KEY ( id) 
+    REFERENCES dbo.cohort_definition (id)
+      ON UPDATE CASCADE
+      ON DELETE CASCADE
+;
+
+IF (NOT EXISTS (SELECT * 
+                 FROM INFORMATION_SCHEMA.TABLES 
+                 WHERE TABLE_SCHEMA = 'dbo' 
+                 AND  TABLE_NAME = 'cohort_generation_info'))
+BEGIN
+CREATE TABLE [dbo].[cohort_generation_info](
+  [id] [int] NOT NULL,
+  [start_time] [datetime] NOT NULL,
+  [execution_duration] [int] NULL,
+  [status] [int] NOT NULL,
+  [is_valid] [bit] NOT NULL,
+  CONSTRAINT [PK_cohort_generation_info] PRIMARY KEY CLUSTERED ( [id] ASC),
+  CONSTRAINT [FK_cohort_generation_info_cohort_definition] FOREIGN KEY([id])
+    REFERENCES [dbo].[cohort_definition] ([id])
+    ON UPDATE CASCADE
+    ON DELETE CASCADE
+) ON [PRIMARY]
+END;

--- a/src/main/resources/resources/cohortdefinition/sql/conditionOccurrence.sql
+++ b/src/main/resources/resources/cohortdefinition/sql/conditionOccurrence.sql
@@ -1,4 +1,4 @@
-select C.person_id, C.condition_start_date as start_date, C.condition_end_date as end_date, C.CONDITION_CONCEPT_ID as TARGET_CONCEPT_ID
+select C.person_id, C.condition_start_date as start_date, COALESCE(C.condition_end_date, DATEADD(day,1,C.condition_start_date)) as end_date, C.CONDITION_CONCEPT_ID as TARGET_CONCEPT_ID
 from 
 (
         select co.*, ROW_NUMBER() over (PARTITION BY co.person_id ORDER BY co.condition_start_date) as ordinal

--- a/src/main/resources/resources/cohortdefinition/sql/generateCohort.sql
+++ b/src/main/resources/resources/cohortdefinition/sql/generateCohort.sql
@@ -1,8 +1,8 @@
 @codesetQuery
 @primaryEventsQuery
 
-DELETE FROM @targetSchema.@targetTable where cohort_definition_id = @cohortDefinitionId;
-INSERT INTO @targetSchema.@targetTable (cohort_definition_id, subject_id, cohort_start_date, cohort_end_date)
+DELETE FROM @targetTable where cohort_definition_id = @cohortDefinitionId;
+INSERT INTO @targetTable (cohort_definition_id, subject_id, cohort_start_date, cohort_end_date)
 select @cohortDefinitionId as cohort_definition_id, person_id as subject_id, start_date as cohort_start_date, end_date as cohort_end_date
 FROM 
 (


### PR DESCRIPTION
This pull request introduces cohort generation capability.  This has been tested on MS Sql only.  Our postgres database does not have CDM tables with data, and I do not have access to an Oracle instance. Those of us who have those environments, please check out this branch and let me know of any issues.

Main points:
New Task: GenerateCohortTask - encapsulates the params to the GenerateCohortTasklet
New Tasklet: GenerateCohortTasklet - takes the cohort definition as a parameter, and converts it to SQL. Then executes SQL against database.
New application.properties field: cohort.targetTable. Set this to the table the GenerateCohortTasklet will write to.  This is specified in the default pom.xml as dbo.COHORT, but we can make this a placeholder value with instructions to override in settings.xml.
New CohrotDefinitionService endpoint: /{id}/generate.  GET request which triggers the cohort generation.

To Do:
I think we need a status table for cohort generation to track things like execution duration, cohort counts and error messages. I know the job subsystem has a record of executions but I was thinking of tracking more task-specific status.

Need testing on other platforms.

