### PR TITLE
Clearer distinction between DataSource handling (CDM vs OHDSI)

### DIFF
--- a/src/main/java/org/ohdsi/webapi/DataAccessConfig.java
+++ b/src/main/java/org/ohdsi/webapi/DataAccessConfig.java
@@ -4,11 +4,13 @@ import javax.persistence.EntityManagerFactory;
 import javax.sql.DataSource;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Primary;
 import org.springframework.core.env.Environment;
 import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
+import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.jdbc.datasource.DriverManagerDataSource;
 import org.springframework.orm.jpa.JpaTransactionManager;
 import org.springframework.orm.jpa.LocalContainerEntityManagerFactoryBean;
@@ -31,7 +33,7 @@ public class DataAccessConfig {
     
     @Bean
     @Primary
-    public DataSource primaryDataSource() {
+    public DataSource cdmDataSource() {
         
         String driver = this.env.getRequiredProperty("datasource.driverClassName");
         String url = this.env.getRequiredProperty("datasource.url");
@@ -58,7 +60,18 @@ public class DataAccessConfig {
     }
     
     @Bean
-    public EntityManagerFactory entityManagerFactory() {
+    @Primary
+    public JdbcTemplate cdmJdbcTemplate(@Qualifier("cdmDataSource") DataSource cdmDataSource){
+        return new JdbcTemplate(cdmDataSource);
+    }
+    
+    @Bean
+    public JdbcTemplate ohdsiJdbcTemplate(@Qualifier("ohdsiDataSource") DataSource ohdsiDataSource){
+        return new JdbcTemplate(ohdsiDataSource);
+    }
+    
+    @Bean
+    public EntityManagerFactory entityManagerFactory(@Qualifier("ohdsiDataSource") DataSource ohdsiDataSource) {
         
         HibernateJpaVendorAdapter vendorAdapter = new HibernateJpaVendorAdapter();
         vendorAdapter.setGenerateDdl(false);
@@ -69,7 +82,7 @@ public class DataAccessConfig {
         LocalContainerEntityManagerFactoryBean factory = new LocalContainerEntityManagerFactoryBean();
         factory.setJpaVendorAdapter(vendorAdapter);
         factory.setPackagesToScan("org.ohdsi.webapi");
-        factory.setDataSource(primaryDataSource());
+        factory.setDataSource(ohdsiDataSource);
         factory.afterPropertiesSet();
         
         return factory.getObject();
@@ -78,10 +91,10 @@ public class DataAccessConfig {
     @Bean
     @Primary
     //This is needed so that JpaTransactionManager is used for autowiring, instead of DataSourceTransactionManager
-    public PlatformTransactionManager jpaTransactionManager() {//EntityManagerFactory entityManagerFactory) {
+    public PlatformTransactionManager jpaTransactionManager(@Qualifier("ohdsiDataSource") DataSource ohdsiDataSource) {
     
         JpaTransactionManager txManager = new JpaTransactionManager();
-        txManager.setEntityManagerFactory(entityManagerFactory());
+        txManager.setEntityManagerFactory(entityManagerFactory(ohdsiDataSource));
         return txManager;
     }
     

--- a/src/main/java/org/ohdsi/webapi/FlywayConfig.java
+++ b/src/main/java/org/ohdsi/webapi/FlywayConfig.java
@@ -18,7 +18,7 @@ public class FlywayConfig {
     @Bean
     @ConfigurationProperties(prefix="flyway.datasource")
     @FlywayDataSource
-    public DataSource secondaryDataSource() {
+    public DataSource ohdsiDataSource() {
         return DataSourceBuilder.create().build();
     }
 }

--- a/src/main/java/org/ohdsi/webapi/JobConfig.java
+++ b/src/main/java/org/ohdsi/webapi/JobConfig.java
@@ -21,6 +21,7 @@ import org.springframework.batch.core.repository.support.JobRepositoryFactoryBea
 import org.springframework.batch.core.repository.support.MapJobRepositoryFactoryBean;
 import org.springframework.batch.support.transaction.ResourcelessTransactionManager;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -45,6 +46,7 @@ public class JobConfig {
     private String isolationLevelForCreate;
     
     @Autowired
+    @Qualifier("ohdsiDataSource")
     private DataSource dataSource;
     
     @Bean
@@ -84,14 +86,14 @@ public class JobConfig {
         
         private JobExplorer jobExplorer;
         
-        @Autowired
+        //        @Autowired
         public void setDataSource(final DataSource dataSource) {
             this.dataSource = dataSource;
-//            this.transactionManager = new DataSourceTransactionManager(dataSource);
+            //            this.transactionManager = new DataSourceTransactionManager(dataSource);
         }
         
         @Autowired
-        public void setTransactionManager(final PlatformTransactionManager transactionManager){
+        public void setTransactionManager(final PlatformTransactionManager transactionManager) {
             this.transactionManager = transactionManager;
         }
         

--- a/src/main/java/org/ohdsi/webapi/WebApi.java
+++ b/src/main/java/org/ohdsi/webapi/WebApi.java
@@ -1,6 +1,7 @@
 package org.ohdsi.webapi;
 
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration;
 import org.springframework.boot.autoconfigure.orm.jpa.HibernateJpaAutoConfiguration;
 import org.springframework.boot.autoconfigure.velocity.VelocityAutoConfiguration;
 import org.springframework.boot.builder.SpringApplicationBuilder;
@@ -9,7 +10,8 @@ import org.springframework.boot.context.web.SpringBootServletInitializer;
 /**
  * Launch as java application or deploy as WAR (@link {@link WebApplication} will source this file).
  */
-@SpringBootApplication(exclude={HibernateJpaAutoConfiguration.class,VelocityAutoConfiguration.class})
+@SpringBootApplication(exclude = { DataSourceAutoConfiguration.class, HibernateJpaAutoConfiguration.class,
+        VelocityAutoConfiguration.class })
 public class WebApi extends SpringBootServletInitializer {
     
     @Override

--- a/src/main/java/org/ohdsi/webapi/service/AbstractDaoService.java
+++ b/src/main/java/org/ohdsi/webapi/service/AbstractDaoService.java
@@ -10,11 +10,11 @@ import java.util.Map;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.jdbc.core.RowMapper;
 import org.springframework.transaction.support.TransactionTemplate;
-import org.springframework.util.StringUtils;
 
 /**
  *
@@ -45,7 +45,12 @@ public abstract class AbstractDaoService {
     private String cdmVersion;
     
     @Autowired
+    @Qualifier("cdmJdbcTemplate")
     private JdbcTemplate jdbcTemplate;
+    
+    @Autowired
+    @Qualifier("ohdsiJdbcTemplate")
+    private JdbcTemplate ohdsiJdbcTemplate;
     
     @Autowired
     private TransactionTemplate transactionTemplate;
@@ -55,11 +60,12 @@ public abstract class AbstractDaoService {
     
     /**
      * if cdmDatabase is provided, return cdmDatabase.cdmSchema, else return cdmSchema.
+     * 
      * @return the cdmSchema
      */
     public String getCdmSchema() {
-      String schema = (cdmDatabase != null && cdmDatabase.length() > 0) ? cdmDatabase + "." : "";
-      return schema + cdmSchema;
+        String schema = (cdmDatabase != null && cdmDatabase.length() > 0) ? cdmDatabase + "." : "";
+        return schema + cdmSchema;
     }
     
     /**
@@ -98,7 +104,10 @@ public abstract class AbstractDaoService {
     }
     
     /**
-     * @return the jdbcTemplate
+     * Returns JdbcTemplate for CDM schema (potentially read-only). See {@link #ohdsiJdbcTemplate}
+     * for JdbcTemplate connected to ohdsi/results DataSource.
+     * 
+     * @return the jdbcTemplate for the cdm schema
      */
     public JdbcTemplate getJdbcTemplate() {
         return jdbcTemplate;
@@ -117,63 +126,60 @@ public abstract class AbstractDaoService {
     public void setSourceDialect(String sourceDialect) {
         this.sourceDialect = sourceDialect;
     }
-
-
-	/**
-	 * @return the sourceName
-	 */
-	public String getSourceName() {
-		return sourceName;
-	}
-
-	/**
-	 * @param sourceName the sourceName to set
-	 */
-	public void setSourceName(String sourceName) {
-		this.sourceName = sourceName;
-	}
-
-	/**
-	 * @return the cdmVersion
-	 */
-	public String getCdmVersion() {
-		return cdmVersion;
-	}
-
-	/**
-	 * @param cdmVersion the cdmVersion to set
-	 */
-	public void setCdmVersion(String cdmVersion) {
-		this.cdmVersion = cdmVersion;
-	}
-
-	protected List<Map<String, String>> genericResultSetLoader(String sql) {
-		List<Map<String, String>> results = null;
-		try {
-			results = getJdbcTemplate().query(sql, new RowMapper<Map<String, String>>(){
-
-				@Override
-				public Map<String, String> mapRow(ResultSet rs, int rowNum)
-						throws SQLException {
-					Map<String, String> result = new HashMap<String, String>();
-					ResultSetMetaData metaData = rs.getMetaData();
-					int colCount = metaData.getColumnCount();
-					for (int i = 1; i <= colCount; i++) {
-						String columnLabel = metaData.getColumnLabel(i);
-						String columnValue = String.valueOf(rs.getObject(i));
-						result.put(columnLabel, columnValue);
-					}
-					return result;
-				}
-
-			});
-
-		} catch (Exception e) {
-			log.error("error loading in result set", e);
-		}
-		return results;
-	}
-
+    
+    /**
+     * @return the sourceName
+     */
+    public String getSourceName() {
+        return sourceName;
+    }
+    
+    /**
+     * @param sourceName the sourceName to set
+     */
+    public void setSourceName(String sourceName) {
+        this.sourceName = sourceName;
+    }
+    
+    /**
+     * @return the cdmVersion
+     */
+    public String getCdmVersion() {
+        return cdmVersion;
+    }
+    
+    /**
+     * @param cdmVersion the cdmVersion to set
+     */
+    public void setCdmVersion(String cdmVersion) {
+        this.cdmVersion = cdmVersion;
+    }
+    
+    protected List<Map<String, String>> genericResultSetLoader(String sql) {
+        List<Map<String, String>> results = null;
+        try {
+            results = getJdbcTemplate().query(sql, new RowMapper<Map<String, String>>() {
+                
+                @Override
+                public Map<String, String> mapRow(ResultSet rs, int rowNum) throws SQLException {
+                    Map<String, String> result = new HashMap<String, String>();
+                    ResultSetMetaData metaData = rs.getMetaData();
+                    int colCount = metaData.getColumnCount();
+                    for (int i = 1; i <= colCount; i++) {
+                        String columnLabel = metaData.getColumnLabel(i);
+                        String columnValue = String.valueOf(rs.getObject(i));
+                        result.put(columnLabel, columnValue);
+                    }
+                    return result;
+                }
+                
+            });
+            
+        } catch (Exception e) {
+            log.error("error loading in result set", e);
+        }
+        return results;
+    }
     
     /**
      * @return the transactionTemplate
@@ -181,7 +187,6 @@ public abstract class AbstractDaoService {
     public TransactionTemplate getTransactionTemplate() {
         return transactionTemplate;
     }
-
     
     /**
      * @return the transactionTemplateRequiresNew
@@ -189,7 +194,6 @@ public abstract class AbstractDaoService {
     public TransactionTemplate getTransactionTemplateRequiresNew() {
         return transactionTemplateRequiresNew;
     }
-
     
     /**
      * @param transactionTemplateRequiresNew the transactionTemplateRequiresNew to set
@@ -197,5 +201,12 @@ public abstract class AbstractDaoService {
     public void setTransactionTemplateRequiresNew(TransactionTemplate transactionTemplateRequiresNew) {
         this.transactionTemplateRequiresNew = transactionTemplateRequiresNew;
     }
+
+    
+    /**
+     * @return the ohdsiJdbcTemplate
+     */
+    public JdbcTemplate getOhdsiJdbcTemplate() {
+        return ohdsiJdbcTemplate;
+    }
 }
- 

--- a/src/main/java/org/ohdsi/webapi/service/CohortAnalysisService.java
+++ b/src/main/java/org/ohdsi/webapi/service/CohortAnalysisService.java
@@ -250,7 +250,7 @@ public class CohortAnalysisService extends AbstractDaoService {
         final JobParameters jobParameters = builder.toJobParameters();
         String[] sql = this.getRunCohortAnalysisSqlBatch(task);
         log.info(String.format("Beginning run for cohort analysis task: \n %s", taskString));
-        CohortAnalysisTasklet tasklet = new CohortAnalysisTasklet(sql, getJdbcTemplate(), getTransactionTemplate());
+        CohortAnalysisTasklet tasklet = new CohortAnalysisTasklet(sql, getOhdsiJdbcTemplate(), getTransactionTemplate());
         
         return this.jobTemplate.launchTasklet("cohortAnalysisJob", "cohortAnalysisStep", tasklet, jobParameters);
     }

--- a/src/main/java/org/ohdsi/webapi/service/CohortDefinitionService.java
+++ b/src/main/java/org/ohdsi/webapi/service/CohortDefinitionService.java
@@ -284,7 +284,7 @@ public class CohortDefinitionService extends AbstractDaoService {
               .setSourceDialect(this.getSourceDialect())
               .setTargetDialect(this.getDialect());
       
-      GenerateCohortTasklet tasklet = new GenerateCohortTasklet(task, getJdbcTemplate(), getTransactionTemplate(), cohortDefinitionRepository);
+      GenerateCohortTasklet tasklet = new GenerateCohortTasklet(task, getOhdsiJdbcTemplate(), getTransactionTemplate(), cohortDefinitionRepository);
 
       return this.jobTemplate.launchTasklet("generateCohortJob", "generateCohortStep", tasklet, jobParameters);
     }


### PR DESCRIPTION
@chrisknoll & @fdefalco , I realized that the datasource plumbing wasn't really in line with what I believe to be our intent.  That is, the CDM schema should be read-only and that we want the OHDSI/RESULTS schema  to be transactional.  
Flyway config was right but the Jpa & Job config was really using the default datasource, which was the "CDM DataSource".
So, I tweaked the configuration to make a cleaner distinction between CDM & OHDSI DataSources (including JdbcTemplates).  So, within WebAPI, the idea is that when you need transaction support, you should work with the ohdsiDataSource/ohdsiJdbcTemplate/transactionTemplate/crudrepository (any of) beans.  For example, the /vocabulary/vocabularies endpoint would use the CDM JdbcTemplate (getJdbcTemplate in AbstractDAOService), and the tasklets, etc., that write data, would use the OHDSI JdbcTemplate (getOhdsiJdbcTemplate in AbstractDAOService).
I think this makes sense from the WebAPI perspective and supports variable configurations.  I don't think it was an issue for any of us because we were all configuring WebAPI with DB accounts that were associated with the OHDSI schema, or had a "CDM" account that could write to the OHDSI schema...

To take it a step further, we could rename the "flyway.datasource" properties to represent the ohdsi.datasource but I didn't go there due to the impact to others and their settings.xml.

Let me know any thoughts you all have.