### PR TITLE
Cleanup migration mess from multihomed deployment.  Commenting out sc…

### DIFF
--- a/src/main/java/org/ohdsi/webapi/feasibility/FeasibilityStudy.java
+++ b/src/main/java/org/ohdsi/webapi/feasibility/FeasibilityStudy.java
@@ -17,6 +17,7 @@ package org.ohdsi.webapi.feasibility;
 
 import java.util.ArrayList;
 import java.util.Date;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import javax.persistence.CascadeType;
@@ -80,7 +81,7 @@ public class FeasibilityStudy {
   private CohortDefinition resultRule;  
 
   @OneToMany(fetch= FetchType.LAZY, cascade = CascadeType.ALL, mappedBy = "study", orphanRemoval=true)
-  private Set<StudyGenerationInfo> studyGenerationInfoList;  
+  private Set<StudyGenerationInfo> studyGenerationInfoList = new HashSet<StudyGenerationInfo>();  
   
   @Column(name="created_by")
   private String createdBy;

--- a/src/main/resources/db/migration/postgresql/V1.0.0.7.1__cohort_multihomed_support.sql
+++ b/src/main/resources/db/migration/postgresql/V1.0.0.7.1__cohort_multihomed_support.sql
@@ -1,4 +1,3 @@
-/*
 ALTER TABLE cohort_generation_info DROP CONSTRAINT FK_cohort_generation_info_cohort_definition;
 
 CREATE TABLE tmp_ms_xx_cohort_generation_info (
@@ -11,17 +10,14 @@ CREATE TABLE tmp_ms_xx_cohort_generation_info (
     CONSTRAINT tmp_ms_xx_constraint_PK_cohort_generation_info PRIMARY KEY (id, source_id)
 );
 
-IF EXISTS (SELECT 1 FROM cohort_generation_info LIMIT 1) THEN
-BEGIN
-  INSERT INTO tmp_ms_xx_cohort_generation_info (id, source_id, start_time, execution_duration, status, is_valid)
-  SELECT  id,
-          1,
-          start_time,
-          execution_duration,
-          status,
-          is_valid
-  FROM  cohort_generation_info
-END IF;
+INSERT INTO tmp_ms_xx_cohort_generation_info (id, source_id, start_time, execution_duration, status, is_valid)
+SELECT  id,
+        1,
+        start_time,
+        execution_duration,
+        status,
+        is_valid
+FROM  cohort_generation_info;
 
 DROP TABLE cohort_generation_info;
 
@@ -33,4 +29,3 @@ ALTER TABLE cohort_generation_info
   ADD CONSTRAINT FK_cohort_generation_info_cohort_definition 
   FOREIGN KEY (id) REFERENCES cohort_definition (id) 
   ON DELETE CASCADE ON UPDATE CASCADE;
-*/

--- a/src/main/resources/db/migration/postgresql/V1.0.0.7.2__feasability_multihomed_support.sql.sql
+++ b/src/main/resources/db/migration/postgresql/V1.0.0.7.2__feasability_multihomed_support.sql.sql
@@ -1,4 +1,3 @@
-/*
 ALTER TABLE feasibility_study DROP CONSTRAINT FK_feasibility_study_feas_study_generation_info;
 
 CREATE TABLE tmp_ms_xx_feas_study_generation_info (
@@ -11,17 +10,14 @@ CREATE TABLE tmp_ms_xx_feas_study_generation_info (
     CONSTRAINT tmp_ms_xx_constraint_PK_feas_study_generation_info PRIMARY KEY (study_id,source_id)
 );
 
-IF EXISTS (SELECT 1 FROM feas_study_generation_info LIMIT 1) THEN
-BEGIN
-    INSERT INTO tmp_ms_xx_feas_study_generation_info (study_id, source_id, start_time, execution_duration, status, is_valid)
-    SELECT   study_id,
-             1,
-             start_time,
-             execution_duration,
-             status,
-             is_valid
-    FROM     feas_study_generation_info
-END IF;
+INSERT INTO tmp_ms_xx_feas_study_generation_info (study_id, source_id, start_time, execution_duration, status, is_valid)
+SELECT   study_id,
+         1,
+         start_time,
+         execution_duration,
+         status,
+         is_valid
+FROM feas_study_generation_info;
 
 DROP TABLE feas_study_generation_info;
 
@@ -33,4 +29,3 @@ ALTER TABLE feasibility_study DROP COLUMN generate_info_id;
 
 ALTER TABLE feas_study_generation_info
   ADD CONSTRAINT FK_feas_study_generation_info_feasibility_study FOREIGN KEY (study_id) REFERENCES feasibility_study (id);
-*/

--- a/src/test/java/org/ohdsi/webapi/test/feasibility/StudyInfoTest.java
+++ b/src/test/java/org/ohdsi/webapi/test/feasibility/StudyInfoTest.java
@@ -66,12 +66,7 @@ public class StudyInfoTest {
   @Transactional
   public void testStudyCRUD() {
     
-    DefaultTransactionDefinition requiresNewTx = new DefaultTransactionDefinition();
-    requiresNewTx.setPropagationBehavior(TransactionDefinition.PROPAGATION_REQUIRES_NEW);
-    
     Source source = sourceRepository.findOne(1);
-    
-    TransactionStatus saveTx = this.transactionTemplate.getTransactionManager().getTransaction(requiresNewTx);
     FeasibilityStudy newStudy = new FeasibilityStudy();
     newStudy.setName("Test Info Study");
     newStudy = this.studyRepository.save(newStudy);
@@ -79,12 +74,7 @@ public class StudyInfoTest {
     info.setStatus(GenerationStatus.PENDING);
     newStudy.getStudyGenerationInfoList().add(info);
     this.studyRepository.save(newStudy);
-    this.transactionTemplate.getTransactionManager().commit(saveTx);
-    
-    TransactionStatus updateTx = this.transactionTemplate.getTransactionManager().getTransaction(requiresNewTx);
     newStudy.getStudyGenerationInfoList().clear();
     this.studyRepository.save(newStudy);
-    this.transactionTemplate.getTransactionManager().commit(updateTx);
-    
   }
 }


### PR DESCRIPTION
…ript contents is a good example of how not to solve a migration issue.  In the future, when scripts fail but a deployment must adhere to an arbitrary deadline, the proper solution is to rename the file so that it does not get picked up by the flyway process.

Also fixes Feasibility study test where the collection was not being initialized to an empty set.