### PR TITLE
flyway postgresql and oracle migrations for concept sets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,5 +8,7 @@ sandbox/
 /nbactions.xml
 /nbactions-webapi-local.xml
 /nbactions-webapi-mssql.xml
+/nbactions-webapi-postgresql.xml
+/nbactions-webapi-oracle.xml
 /nbactions-debug*
 *~

--- a/src/main/resources/db/migration/oracle/V1.0.1.0__conceptsets.sql
+++ b/src/main/resources/db/migration/oracle/V1.0.1.0__conceptsets.sql
@@ -1,0 +1,23 @@
+-- DROP any existing objects from previous runs
+-- for Oracle only, this section is commented out for reference in case they need to be run manually
+-- the other DBMS create scripts can dynamically drop objects instead
+-- DROP TABLE concept_set;
+-- DROP SEQUENCE concept_set_sequence;
+-- DROP TABLE concept_set_item;
+-- DROP SEQUENCE concept_set_item_sequence;
+
+CREATE SEQUENCE concept_set_sequence MAXVALUE 9223372036854775807 NOCYCLE;
+CREATE TABLE concept_set (
+    concept_set_id   INTEGER NOT NULL,
+    concept_set_name VARCHAR(255) NOT NULL
+);
+
+CREATE SEQUENCE concept_set_item_sequence MAXVALUE 9223372036854775807 NOCYCLE;
+CREATE TABLE concept_set_item (
+    concept_set_item_id INTEGER NOT NULL,
+    concept_set_id      INTEGER NOT NULL,
+    concept_id          INTEGER NOT NULL,
+    is_excluded         INTEGER NOT NULL,
+    include_descendants INTEGER NOT NULL,
+    include_mapped      INTEGER NOT NULL
+);

--- a/src/main/resources/db/migration/postgresql/V1.0.1.0__conceptsets.sql
+++ b/src/main/resources/db/migration/postgresql/V1.0.1.0__conceptsets.sql
@@ -1,0 +1,19 @@
+DROP TABLE IF EXISTS concept_set;
+DROP SEQUENCE IF EXISTS concept_set_sequence;
+CREATE SEQUENCE concept_set_sequence MAXVALUE 9223372036854775807 NO CYCLE;
+CREATE TABLE concept_set (
+    concept_set_id   INTEGER NOT NULL DEFAULT NEXTVAL('concept_set_sequence'),
+    concept_set_name VARCHAR(255) NOT NULL
+);
+
+DROP TABLE IF EXISTS concept_set_item;
+DROP SEQUENCE IF EXISTS concept_set_item_sequence;
+CREATE SEQUENCE concept_set_item_sequence MAXVALUE 9223372036854775807 NO CYCLE;
+CREATE TABLE concept_set_item (
+    concept_set_item_id INTEGER NOT NULL DEFAULT NEXTVAL('concept_set_item_sequence'),
+    concept_set_id      INTEGER NOT NULL,
+    concept_id          INTEGER NOT NULL,
+    is_excluded         INTEGER NOT NULL,
+    include_descendants INTEGER NOT NULL,
+    include_mapped      INTEGER NOT NULL
+);


### PR DESCRIPTION
Here are the flyway postgresql and oracle migrations for the concept sets tables. I tested the flyway migration for the oracle and postgresql DBMSs.