### PR TITLE
Flyway changes needed for updated LAERTES to work

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,12 +18,12 @@ git-push:
 	git push myfork master
 
 test:
-	wget -O tests/test-general-evidence.json "http://localhost:8080/WebAPI/CS1/evidence/1000640"
-	wget -O tests/test-drug-hoi.json "http://localhost:8080/WebAPI/CS1/evidence/drughoi/1000640-137682"
-	wget -O tests/test-drug.json "http://localhost:8080/WebAPI/CS1/evidence/drug/1000640"
+	wget -O tests/test-general-evidence.json "http://localhost:8080/WebAPI/CS1/evidence/752061"
+	wget -O tests/test-drug-hoi.json "http://localhost:8080/WebAPI/CS1/evidence/drughoi/752061-374013"
+	wget -O tests/test-drug.json "http://localhost:8080/WebAPI/CS1/evidence/drug/752061"
 	wget -O tests/test-hoi.json "http://localhost:8080/WebAPI/CS1/evidence/hoi/320073"
 	wget -O tests/test-info.json "http://localhost:8080/WebAPI/CS1/evidence/info"
-	wget -O tests/test-drug-hoi-eu-spc.json "http://localhost:8080/WebAPI/CS1/evidence/drughoi/40239056-75053" 
+	wget -O tests/test-drug-hoi-eu-spc.json "http://localhost:8080/WebAPI/CS1/evidence/drughoi/904351-4190045" 
 	wget -O tests/test-drug-hoi-splicer.json "http://localhost:8080/WebAPI/CS1/evidence/drughoi/19133853-195588"
 	wget -O tests/test-drug-hoi-faers-counts-and-signals.json "http://localhost:8080/WebAPI/CS1/evidence/drughoi/1154343-433031"
 	wget -O tests/test-drug-hoi-pubmed-mesh-cr.json "http://localhost:8080/WebAPI/CS1/evidence/drughoi/1154343-433031" 
@@ -36,8 +36,8 @@ test:
 	wget -O tests/test-drug-rollup-branded-drug.json "http://localhost:8080/WebAPI/CS1/evidence/drugrollup/brandeddrug/1000640"
 
 test-sparql:
-	wget -O tests/test-rdf-info.json "http://localhost:8080/WebAPI/evidence/rdfinfo"
-	wget -O tests/test-rdf-linkoutdata.json "http://localhost:8080/WebAPI/evidence/linkoutdata/http%3A%252F%252Fdbmi-icode-01.dbmi.pitt.edu%252Fl%252Findex.php%3Fid%3Dsplicer-237164"
+	#wget -O tests/test-rdf-info.json "http://localhost:8080/WebAPI/evidence/rdfinfo"
+	#wget -O tests/test-rdf-linkoutdata.json "http://localhost:8080/WebAPI/evidence/linkoutdata/http%3A%252F%252Fdbmi-icode-01.dbmi.pitt.edu%252Fl%252Findex.php%3Fid%3Dsplicer-splicer-210"
 	wget -O tests/test-rdf-commandlist.json "http://localhost:8080/WebAPI/evidence/?"
 	wget -O tests/test-rdf-evidencesummary.json "http://localhost:8080/WebAPI/CS1/evidence/evidencesummary?conditionID=139900&drugID=1115008&evidenceGroup=Literature"
 	wget -O tests/test-rdf-evidencedetails.json "http://localhost:8080/WebAPI/CS1/evidence/evidencedetails?conditionID=24134&drugID=1115008&evidenceType=SPL_SPLICER_ADR"

--- a/src/main/resources/db/migration/oracle/V1.0.0.6.3__schema-create_laertes.sql
+++ b/src/main/resources/db/migration/oracle/V1.0.0.6.3__schema-create_laertes.sql
@@ -1,0 +1,7 @@
+-- Authors: Richard D Boyce, Erica Voss, Lee Evans
+-- 2014/2015
+-- Postgresql script
+
+ALTER TABLE DRUG_HOI_EVIDENCE MODIFY (STATISTIC_VALUE NUMERIC NULL);
+
+

--- a/src/main/resources/db/migration/postgresql/V1.0.0.6.3__schema-create_laertes.sql
+++ b/src/main/resources/db/migration/postgresql/V1.0.0.6.3__schema-create_laertes.sql
@@ -1,0 +1,5 @@
+-- Authors: Richard D Boyce, Erica Voss, Lee Evans
+-- 2014/2015
+-- Postgresql script
+
+ALTER TABLE DRUG_HOI_EVIDENCE ALTER statistic_value DROP NOT NULL;

--- a/src/main/resources/db/migration/sqlserver/V1.0.0.6.3__schema-create_laertes.sql
+++ b/src/main/resources/db/migration/sqlserver/V1.0.0.6.3__schema-create_laertes.sql
@@ -1,0 +1,8 @@
+-- Authors: Richard D Boyce, Erica Voss, Lee Evans
+-- 2014/2015
+-- Postgresql script
+
+ALTER TABLE DRUG_HOI_EVIDENCE ALTER COLUMN STATISTIC_VALUE columnType NULL;
+
+
+


### PR DESCRIPTION
Hi, the flyway scripts for laertes have a new entry for all three DBMS to remove a null constraint on the drug_hoi_evidence table. These  changes need to be brought into the main branch for the ohdsi cloud services to function. The postgres script has been tested. Not so for oracle or sql server.