### PR TITLE
Fix #137

### DIFF
--- a/src/main/java/org/ohdsi/webapi/cohortdefinition/CohortExpressionQueryBuilder.java
+++ b/src/main/java/org/ohdsi/webapi/cohortdefinition/CohortExpressionQueryBuilder.java
@@ -354,6 +354,7 @@ public class CohortExpressionQueryBuilder implements IGetCriteriaSqlDispatcher, 
         intersectClause += "<= " + group.count;
     }
            
+    query = StringUtils.replace(query, "@eventTable", eventTable);
     query = StringUtils.replace(query, "@intersectClause", intersectClause);
     query = StringUtils.replace(query, "@criteriaQueries", StringUtils.join(additionalCriteriaQueries, "\nUNION\n"));
     

--- a/src/main/resources/resources/cohortdefinition/sql/groupQuery.sql
+++ b/src/main/resources/resources/cohortdefinition/sql/groupQuery.sql
@@ -1,10 +1,12 @@
 select @indexId as index_id, event_id
 FROM
 (
-  select event_id FROM
+  select E.event_id 
+  FROM @eventTable E
+  LEFT JOIN
   (
     @criteriaQueries
-  ) CQ
-  GROUP BY event_id
+  ) CQ on E.event_id = CQ.event_id
+  GROUP BY E.event_id
   @intersectClause
 ) G


### PR DESCRIPTION
Updated criteria group query to left join to @eventTable to capture events that matched 0 of the criteria in the group.  This impacts cohort definitions where the criteria groups were looking for people that pet none of the inner criteria (probably a very rare case).

Note: this is causing a problem with one of our feasibility studies we're conducting internally, so if we could get expedited review of this, it would be appreciated.
