### PR TITLE
Updated sql to match SqlRender

### DIFF
--- a/src/main/resources/resources/cohortresults/sql/raw/getAllResultDistributions.sql
+++ b/src/main/resources/resources/cohortresults/sql/raw/getAllResultDistributions.sql
@@ -1,4 +1,7 @@
-select top 100 *
-from @tableQualifier.heracles_results_dist
-where cohort_definition_id = @cohortDefinitionId
+select ROWCOUNT() OVER (ORDER BY tmp.analysis_id) as rn , *
+FROM ( select *
+        from @tableQualifier.heracles_results_dist
+        where cohort_definition_id = @cohortDefinitionId ) tmp
+Where rn <= 100;
+
 


### PR DESCRIPTION
SqlRender does not support 'TOP' instruction, changed as suggested by @schuemie in OHDSI/SqlRender#38