### PR TITLE
Cohort corelated criteria and Censoring Events

### DIFF
--- a/src/main/java/org/ohdsi/webapi/cohortdefinition/CohortExpression.java
+++ b/src/main/java/org/ohdsi/webapi/cohortdefinition/CohortExpression.java
@@ -42,4 +42,7 @@ public class CohortExpression {
   @JsonProperty("EndStrategy")
   public EndStrategy endStrategy;
   
+  @JsonProperty("CensoringCriteria")
+  public Criteria[] censoringCriteria;
+  
 }

--- a/src/main/java/org/ohdsi/webapi/cohortdefinition/Criteria.java
+++ b/src/main/java/org/ohdsi/webapi/cohortdefinition/Criteria.java
@@ -5,6 +5,7 @@
  */
 package org.ohdsi.webapi.cohortdefinition;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.fasterxml.jackson.annotation.JsonTypeInfo.As;
@@ -32,4 +33,8 @@ import com.fasterxml.jackson.annotation.JsonTypeInfo.As;
 })
 public abstract class Criteria {
   public abstract String accept(IGetCriteriaSqlDispatcher dispatcher);
+  
+  @JsonProperty("CorrelatedCriteria")  
+  public CriteriaGroup CorrelatedCriteria;
+  
 }

--- a/src/main/resources/resources/cohortdefinition/sql/additionalCriteria.sql
+++ b/src/main/resources/resources/cohortdefinition/sql/additionalCriteria.sql
@@ -1,3 +1,4 @@
+-- Begin Correlated Criteria
 SELECT @indexId as index_id, p.person_id, p.event_id
 FROM @eventTable P
 LEFT JOIN
@@ -6,4 +7,4 @@ LEFT JOIN
 ) A on A.person_id = P.person_id and @windowCriteria
 GROUP BY p.person_id, p.event_id
 @occurrenceCriteria
-
+-- End Correlated Criteria

--- a/src/main/resources/resources/cohortdefinition/sql/censoringInsert.sql
+++ b/src/main/resources/resources/cohortdefinition/sql/censoringInsert.sql
@@ -1,0 +1,9 @@
+INSERT INTO #cohort_ends (event_id, person_id, end_date)
+select i.event_id, i.person_id, MIN(c.start_date) as end_date
+FROM #included_events i
+JOIN
+(
+@criteriaQuery
+) C on C.person_id = I.person_id and C.start_date >= I.start_date and C.START_DATE <= I.op_end_date
+GROUP BY i.event_id, i.person_id
+;

--- a/src/main/resources/resources/cohortdefinition/sql/conditionEra.sql
+++ b/src/main/resources/resources/cohortdefinition/sql/conditionEra.sql
@@ -1,4 +1,5 @@
-select C.person_id, C.condition_era_start_date as start_date, C.condition_era_end_date as end_date, C.CONDITION_CONCEPT_ID as TARGET_CONCEPT_ID
+-- Begin Condition Era Criteria
+select C.person_id, C.condition_era_id as event_id, C.condition_era_start_date as start_date, C.condition_era_end_date as end_date, C.CONDITION_CONCEPT_ID as TARGET_CONCEPT_ID
 from 
 (
   select ce.*, ROW_NUMBER() over (PARTITION BY ce.person_id ORDER BY ce.condition_era_start_date, ce.condition_era_id) as ordinal
@@ -7,3 +8,4 @@ from
 ) C
 @joinClause
 @whereClause
+-- End Condition Era Criteria

--- a/src/main/resources/resources/cohortdefinition/sql/conditionOccurrence.sql
+++ b/src/main/resources/resources/cohortdefinition/sql/conditionOccurrence.sql
@@ -1,9 +1,11 @@
-select C.person_id, C.condition_start_date as start_date, COALESCE(C.condition_end_date, DATEADD(day,1,C.condition_start_date)) as end_date, C.CONDITION_CONCEPT_ID as TARGET_CONCEPT_ID
-from 
+-- Begin Condition Occurrence Criteria
+SELECT C.person_id, C.condition_occurrence_id as event_id, C.condition_start_date as start_date, COALESCE(C.condition_end_date, DATEADD(day,1,C.condition_start_date)) as end_date, C.CONDITION_CONCEPT_ID as TARGET_CONCEPT_ID
+FROM 
 (
-        select co.*, ROW_NUMBER() over (PARTITION BY co.person_id ORDER BY co.condition_start_date, co.condition_occurrence_id) as ordinal
-        FROM @cdm_database_schema.CONDITION_OCCURRENCE co
-@codesetClause
+  SELECT co.*, ROW_NUMBER() over (PARTITION BY co.person_id ORDER BY co.condition_start_date, co.condition_occurrence_id) as ordinal
+  FROM @cdm_database_schema.CONDITION_OCCURRENCE co
+  @codesetClause
 ) C
 @joinClause
 @whereClause
+-- End Condition Occurrence Criteria

--- a/src/main/resources/resources/cohortdefinition/sql/death.sql
+++ b/src/main/resources/resources/cohortdefinition/sql/death.sql
@@ -1,4 +1,5 @@
-select C.person_id, C.death_date as start_date, DATEADD(d,1,C.death_date) as end_date, coalesce(C.cause_concept_id,0) as TARGET_CONCEPT_ID
+-- Begin Death Criteria
+select C.person_id, C.person_id as event_id, C.death_date as start_date, DATEADD(d,1,C.death_date) as end_date, coalesce(C.cause_concept_id,0) as TARGET_CONCEPT_ID
 from 
 (
   select d.*
@@ -7,4 +8,5 @@ from
 ) C
 @joinClause
 @whereClause
+-- End Death Criteria
 

--- a/src/main/resources/resources/cohortdefinition/sql/demographicCriteria.sql
+++ b/src/main/resources/resources/cohortdefinition/sql/demographicCriteria.sql
@@ -1,7 +1,7 @@
+-- Begin Demographic Criteria
 SELECT @indexId as index_id, e.person_id, e.event_id
 FROM @eventTable E
 JOIN @cdm_database_schema.PERSON P ON P.PERSON_ID = E.PERSON_ID
 @whereClause
 GROUP BY e.person_id, e.event_id
-
-
+-- End Demographic Criteria

--- a/src/main/resources/resources/cohortdefinition/sql/deviceExposure.sql
+++ b/src/main/resources/resources/cohortdefinition/sql/deviceExposure.sql
@@ -1,4 +1,5 @@
-select C.person_id, C.device_exposure_start_date as start_date, C.device_exposure_end_date as end_date, C.device_concept_id as TARGET_CONCEPT_ID
+-- Begin Device Exposure Criteria
+select C.person_id, C.device_exposure_id as event_id, C.device_exposure_start_date as start_date, C.device_exposure_end_date as end_date, C.device_concept_id as TARGET_CONCEPT_ID
 from 
 (
   select de.*, ROW_NUMBER() over (PARTITION BY de.person_id ORDER BY de.device_exposure_start_date, de.device_exposure_id) as ordinal
@@ -7,3 +8,4 @@ from
 ) C
 @joinClause
 @whereClause
+-- End Device Exposure Criteria

--- a/src/main/resources/resources/cohortdefinition/sql/doseEra.sql
+++ b/src/main/resources/resources/cohortdefinition/sql/doseEra.sql
@@ -1,4 +1,5 @@
-select C.person_id, C.dose_era_start_date as start_date, C.dose_era_end_date as end_date, C.drug_concept_id as TARGET_CONCEPT_ID
+-- Begin Dose Era Criteria
+select C.person_id, C.dose_era_id as event_id, C.dose_era_start_date as start_date, C.dose_era_end_date as end_date, C.drug_concept_id as TARGET_CONCEPT_ID
 from 
 (
   select de.*, ROW_NUMBER() over (PARTITION BY de.person_id ORDER BY de.dose_era_start_date, de.dose_era_id) as ordinal
@@ -7,3 +8,4 @@ from
 ) C
 @joinClause
 @whereClause
+-- End Dose Era Criteria

--- a/src/main/resources/resources/cohortdefinition/sql/drugEra.sql
+++ b/src/main/resources/resources/cohortdefinition/sql/drugEra.sql
@@ -1,4 +1,5 @@
-select C.person_id, C.drug_era_start_date as start_date, C.drug_era_end_date as end_date, C.drug_concept_id as TARGET_CONCEPT_ID
+-- Begin Drug Era Criteria
+select C.person_id, C.drug_era_id as event_id, C.drug_era_start_date as start_date, C.drug_era_end_date as end_date, C.drug_concept_id as TARGET_CONCEPT_ID
 from 
 (
   select de.*, ROW_NUMBER() over (PARTITION BY de.person_id ORDER BY de.drug_era_start_date, de.drug_era_id) as ordinal
@@ -7,3 +8,4 @@ from
 ) C
 @joinClause
 @whereClause
+-- End Drug Era Criteria

--- a/src/main/resources/resources/cohortdefinition/sql/drugExposure.sql
+++ b/src/main/resources/resources/cohortdefinition/sql/drugExposure.sql
@@ -1,4 +1,5 @@
-select C.person_id, C.drug_exposure_start_date as start_date, COALESCE(C.drug_exposure_end_date, DATEADD(day, 1, C.drug_exposure_start_date)) as end_date, C.drug_concept_id as TARGET_CONCEPT_ID
+-- Begin Drug Exposure Criteria
+select C.person_id, C.drug_exposure_id as event_id, C.drug_exposure_start_date as start_date, COALESCE(C.drug_exposure_end_date, DATEADD(day, 1, C.drug_exposure_start_date)) as end_date, C.drug_concept_id as TARGET_CONCEPT_ID
 from 
 (
   select de.*, ROW_NUMBER() over (PARTITION BY de.person_id ORDER BY de.drug_exposure_start_date, de.drug_exposure_id) as ordinal
@@ -7,3 +8,4 @@ from
 ) C
 @joinClause
 @whereClause
+-- End Drug Exposure Criteria

--- a/src/main/resources/resources/cohortdefinition/sql/eventTableExpression.sql
+++ b/src/main/resources/resources/cohortdefinition/sql/eventTableExpression.sql
@@ -1,0 +1,4 @@
+SELECT Q.person_id, Q.event_id, Q.start_date, Q.end_date, OP.observation_period_start_date as op_start_date, OP.observation_period_end_date as op_end_date
+FROM (@eventQuery) Q
+JOIN @cdm_database_schema.OBSERVATION_PERIOD OP on Q.person_id = OP.person_id 
+  and OP.observation_period_start_date <= Q.start_date and OP.observation_period_end_date >= Q.start_date

--- a/src/main/resources/resources/cohortdefinition/sql/generateCohort.sql
+++ b/src/main/resources/resources/cohortdefinition/sql/generateCohort.sql
@@ -54,6 +54,8 @@ from #included_events;
 
 @strategyInserts
 
+@censoringInserts
+
 DELETE FROM @target_database_schema.@target_cohort_table where cohort_definition_id = @target_cohort_id;
 INSERT INTO @target_database_schema.@target_cohort_table (cohort_definition_id, subject_id, cohort_start_date, cohort_end_date)
 select @target_cohort_id as cohort_definition_id, F.person_id, F.start_date, F.end_date

--- a/src/main/resources/resources/cohortdefinition/sql/groupQuery.sql
+++ b/src/main/resources/resources/cohortdefinition/sql/groupQuery.sql
@@ -1,3 +1,4 @@
+-- Begin Criteria Group
 select @indexId as index_id, person_id, event_id
 FROM
 (
@@ -8,5 +9,6 @@ FROM
     @criteriaQueries
   ) CQ on E.person_id = CQ.person_id and E.event_id = CQ.event_id
   GROUP BY E.person_id, E.event_id
-  @intersectClause
+  @occurrenceCountClause
 ) G
+-- End Criteria Group

--- a/src/main/resources/resources/cohortdefinition/sql/measurement.sql
+++ b/src/main/resources/resources/cohortdefinition/sql/measurement.sql
@@ -1,4 +1,5 @@
-select C.person_id, C.measurement_date as start_date, DATEADD(d,1,C.measurement_date) as END_DATE, C.measurement_concept_id as TARGET_CONCEPT_ID
+-- Begin Measurement Criteria
+select C.person_id, C.measurement_id as event_id, C.measurement_date as start_date, DATEADD(d,1,C.measurement_date) as END_DATE, C.measurement_concept_id as TARGET_CONCEPT_ID
 from 
 (
   select m.*, ROW_NUMBER() over (PARTITION BY m.person_id ORDER BY m.measurement_date, m.measurement_id) as ordinal
@@ -7,3 +8,4 @@ from
 ) C
 @joinClause
 @whereClause
+-- End Measurement Criteria

--- a/src/main/resources/resources/cohortdefinition/sql/observation.sql
+++ b/src/main/resources/resources/cohortdefinition/sql/observation.sql
@@ -1,4 +1,5 @@
-select C.person_id, C.observation_date as start_date, DATEADD(d,1,C.observation_date) as END_DATE, C.observation_concept_id as TARGET_CONCEPT_ID
+-- Begin Observation Criteria
+select C.person_id, C.observation_id as event_id, C.observation_date as start_date, DATEADD(d,1,C.observation_date) as END_DATE, C.observation_concept_id as TARGET_CONCEPT_ID
 from 
 (
   select o.*, ROW_NUMBER() over (PARTITION BY o.person_id ORDER BY o.observation_date, o.observation_id) as ordinal
@@ -7,3 +8,4 @@ from
 ) C
 @joinClause
 @whereClause
+-- End Observation Criteria

--- a/src/main/resources/resources/cohortdefinition/sql/observationPeriod.sql
+++ b/src/main/resources/resources/cohortdefinition/sql/observationPeriod.sql
@@ -1,4 +1,5 @@
-select C.person_id, C.observation_period_start_date as start_date, C.observation_period_end_date as end_date, C.period_type_concept_id as TARGET_CONCEPT_ID
+-- Begin Observation Period Criteria
+select C.person_id, C.observation_period_id as event_id, C.observation_period_start_date as start_date, C.observation_period_end_date as end_date, C.period_type_concept_id as TARGET_CONCEPT_ID
 from 
 (
         select op.*, ROW_NUMBER() over (PARTITION BY op.person_id ORDER BY op.observation_period_start_date) as ordinal
@@ -6,3 +7,4 @@ from
 ) C
 @joinClause
 @whereClause
+-- End Observation Period Criteria

--- a/src/main/resources/resources/cohortdefinition/sql/primaryEventsQuery.sql
+++ b/src/main/resources/resources/cohortdefinition/sql/primaryEventsQuery.sql
@@ -1,3 +1,4 @@
+-- Begin Primary Events
 select row_number() over (PARTITION BY P.person_id order by P.start_date) as event_id, P.person_id, P.start_date, P.end_date, OP.observation_period_start_date as op_start_date, OP.observation_period_end_date as op_end_date
 FROM
 (
@@ -9,4 +10,4 @@ FROM
 ) P
 JOIN @cdm_database_schema.observation_period OP on P.person_id = OP.person_id and P.start_date >=  OP.observation_period_start_date and P.start_date <= op.observation_period_end_date
 WHERE @primaryEventsFilter
-
+-- End Primary Events

--- a/src/main/resources/resources/cohortdefinition/sql/procedureOccurrence.sql
+++ b/src/main/resources/resources/cohortdefinition/sql/procedureOccurrence.sql
@@ -1,4 +1,5 @@
-select C.person_id, C.procedure_date as start_date, DATEADD(d,1,C.procedure_date) as END_DATE, C.procedure_concept_id as TARGET_CONCEPT_ID
+-- Begin Procedure Occurrence Criteria
+select C.person_id, C.procedure_occurrence_id as event_id, C.procedure_date as start_date, DATEADD(d,1,C.procedure_date) as END_DATE, C.procedure_concept_id as TARGET_CONCEPT_ID
 from 
 (
   select po.*, ROW_NUMBER() over (PARTITION BY po.person_id ORDER BY po.procedure_date, po.procedure_occurrence_id) as ordinal
@@ -7,3 +8,4 @@ from
 ) C
 @joinClause
 @whereClause
+-- End Procedure Occurrence Criteria

--- a/src/main/resources/resources/cohortdefinition/sql/specimen.sql
+++ b/src/main/resources/resources/cohortdefinition/sql/specimen.sql
@@ -1,4 +1,5 @@
-select C.person_id, C.specimen_date as start_date, DATEADD(d,1,C.specimen_date) as end_date, C.specimen_concept_id as TARGET_CONCEPT_ID
+-- Begin Specimen Criteria
+select C.person_id, C.specimen_id as event_id, C.specimen_date as start_date, DATEADD(d,1,C.specimen_date) as end_date, C.specimen_concept_id as TARGET_CONCEPT_ID
 from 
 (
   select s.*, ROW_NUMBER() over (PARTITION BY s.person_id ORDER BY s.specimen_date, s.specimen_id) as ordinal
@@ -7,3 +8,4 @@ from
 ) C
 @joinClause
 @whereClause
+-- End Specimen Criteria

--- a/src/main/resources/resources/cohortdefinition/sql/visitOccurrence.sql
+++ b/src/main/resources/resources/cohortdefinition/sql/visitOccurrence.sql
@@ -1,4 +1,5 @@
-select C.person_id, C.visit_start_date as start_date, C.visit_end_date as end_date, C.visit_concept_id as TARGET_CONCEPT_ID
+-- Begin Visit Occurrence Criteria
+select C.person_id, C.visit_occurrence_id as event_id, C.visit_start_date as start_date, C.visit_end_date as end_date, C.visit_concept_id as TARGET_CONCEPT_ID
 from 
 (
   select vo.*, ROW_NUMBER() over (PARTITION BY vo.person_id ORDER BY vo.visit_start_date, vo.visit_occurrence_id) as ordinal
@@ -7,4 +8,4 @@ from
 ) C
 @joinClause
 @whereClause
-
+-- End Visit Occurrence Criteria


### PR DESCRIPTION
This PR includes two new features to cohort defintions:

1. Correlated Criteria: It is now possible to select people based on criteria that is additionally qualified to other criteria relative to the former criteria.  For example:  select condition occurrences that have a drug exposure within 30d after diagnosis, which have a procedure within 30d after the drug exposure.

2. Censoring Events:  It is now possible to select events from the domain tables and cause a person to exit the cohort before the default exit criteria if the censoring event is found after the index and before the default exit date.  For example:  cohort entry begins with a diagnosis and ends 365d after diagnosis date, but the person should exit the cohort  at the first occurrence of a biopsy procedure.

