### PR TITLE
Fixes #167

### DIFF
--- a/src/main/java/org/ohdsi/webapi/service/ConceptSetService.java
+++ b/src/main/java/org/ohdsi/webapi/service/ConceptSetService.java
@@ -261,9 +261,9 @@ public class ConceptSetService extends AbstractDaoService {
   @Transactional(rollbackOn = Exception.class, dontRollbackOn = EmptyResultDataAccessException.class)
   @Path("{id}")
   public void deleteConceptSet(@PathParam("id") final int id) throws Exception {
-      // Remove the concept set
+      // Remove any evidence
       try {
-        getConceptSetRepository().delete(id);
+        this.negativeControlRepository.deleteAllByConceptSetId(id);
       } catch (EmptyResultDataAccessException e) {
           // Ignore - there may be no data
           log.debug(e.getMessage());
@@ -271,7 +271,18 @@ public class ConceptSetService extends AbstractDaoService {
       catch (Exception e) {
           throw e;
       }
-
+      
+      // Remove any generation info
+      try {
+        this.conceptSetGenerationInfoRepository.deleteByConceptSetId(id);
+      } catch (EmptyResultDataAccessException e) {
+          // Ignore - there may be no data
+          log.debug(e.getMessage());
+      }
+      catch (Exception e) {
+          throw e;
+      }
+      
       // Remove the concept set items
       try {
         getConceptSetItemRepository().deleteByConceptSetId(id);
@@ -283,20 +294,9 @@ public class ConceptSetService extends AbstractDaoService {
           throw e;
       }
 
-      // Remove any generation info
+      // Remove the concept set
       try {
-        this.conceptSetGenerationInfoRepository.deleteByConceptSetId(id);
-      } catch (EmptyResultDataAccessException e) {
-          // Ignore - there may be no data
-          log.debug(e.getMessage());
-      }
-      catch (Exception e) {
-          throw e;
-      }
-  
-      // Remove any evidence
-      try {
-        this.negativeControlRepository.deleteAllByConceptSetId(id);
+        getConceptSetRepository().delete(id);
       } catch (EmptyResultDataAccessException e) {
           // Ignore - there may be no data
           log.debug(e.getMessage());


### PR DESCRIPTION
The delete command in the original method were causing the following JPA exception:

`org.hibernate.StaleStateException: Batch update returned unexpected row count from update [0]; actual row count: 0; expected: 1`

This was fixed by re-ordering the deletes to clean up records from downstream tables first and then deleting the record from the parent table.  