### PR TITLE
Fix: run flyway migration before initialization of 'security' bean.

### DIFF
--- a/src/main/java/org/ohdsi/webapi/FlywayConfig.java
+++ b/src/main/java/org/ohdsi/webapi/FlywayConfig.java
@@ -1,6 +1,7 @@
 package org.ohdsi.webapi;
 
 import javax.sql.DataSource;
+import org.flywaydb.core.Flyway;
 
 import org.springframework.boot.autoconfigure.flyway.FlywayDataSource;
 import org.springframework.boot.autoconfigure.jdbc.DataSourceBuilder;
@@ -21,4 +22,13 @@ public class FlywayConfig {
     public DataSource secondaryDataSource() {
         return DataSourceBuilder.create().build();
     }
+
+    @Bean(initMethod = "migrate", name = "flyway")
+    @ConfigurationProperties(prefix="flyway")
+    public Flyway flyway() {
+      Flyway flyway = new Flyway();
+      flyway.setDataSource(secondaryDataSource());
+      return flyway;
+    }
+
 }

--- a/src/main/java/org/ohdsi/webapi/ShiroConfiguration.java
+++ b/src/main/java/org/ohdsi/webapi/ShiroConfiguration.java
@@ -12,6 +12,7 @@ import org.ohdsi.webapi.shiro.management.Security;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.DependsOn;
 
 /**
  * Created by GMalikov on 20.08.2015.
@@ -25,6 +26,7 @@ public class ShiroConfiguration {
   private boolean enabled;
 
   @Bean
+  @DependsOn("flyway")
   public Security security() {
     if (enabled) {
       log.debug("AtlasSecurity module loaded");


### PR DESCRIPTION
This PR fixes the order of initialization. Flyway migrations should go prior to initialization of 'security' bean because it contains calls to database. 