### PR TITLE
Prevent 'Divide by zero' error when using 'rangeLowRatio' and' rangeHighRatio' criterias (issue OHDSI/Atlas#69).

### DIFF
--- a/src/main/java/org/ohdsi/webapi/cohortdefinition/CohortExpressionQueryBuilder.java
+++ b/src/main/java/org/ohdsi/webapi/cohortdefinition/CohortExpressionQueryBuilder.java
@@ -1270,13 +1270,13 @@ public class CohortExpressionQueryBuilder implements IGetCriteriaSqlDispatcher, 
     // rangeLowRatio
     if (criteria.rangeLowRatio != null)
     {
-      whereClauses.add(buildNumericRangeClause("(C.value_as_number / C.range_low)",criteria.rangeLowRatio,".4f"));
+      whereClauses.add(buildNumericRangeClause("(C.value_as_number / NULLIF(C.range_low, 0))",criteria.rangeLowRatio,".4f"));
     }
 
     // rangeHighRatio
     if (criteria.rangeHighRatio != null)
     {
-      whereClauses.add(buildNumericRangeClause("(C.value_as_number / C.range_high)",criteria.rangeHighRatio,".4f"));
+      whereClauses.add(buildNumericRangeClause("(C.value_as_number / NULLIF(C.range_high, 0))",criteria.rangeHighRatio,".4f"));
     }
     
     // abnormal


### PR DESCRIPTION

Adding 'rangeLowRatio' and 'rangeHighRatio' criterias may cause 'Divide by zero' error when running in Redshift even if WHERE clause contains a check that 'range_low'/'range_high' is not equals to zero, i.e.

WHERE
	C.range_high > 0.0000
	AND
	(C.value_as_number / C.range_high) > 1.0000