### PR TITLE
Correlated subquery fix

### DIFF
--- a/src/main/resources/resources/cohortresults/sql/raw/getCohortBreakdown.sql
+++ b/src/main/resources/resources/cohortresults/sql/raw/getCohortBreakdown.sql
@@ -1,19 +1,43 @@
-select count(distinct subject_id) people,
-		gender, age, conditions, drugs
+select 
+              count(distinct subject_id) people
+              , gender
+              , age
+              , conditions
+              , drugs
 from
-(select c.*, gc.concept_name as gender,
-        cast(floor((year(cohort_start_date) - year_of_birth) / 10) * 10 as varchar(5)) + '-' +
-            cast(floor((year(cohort_start_date) - year_of_birth) / 10 + 1) * 10 - 1 as varchar(5)) as age,
-        (select round(count(*), cast(- floor(log10(abs(count(*) + 0.01))) as int)) 
-         from @tableQualifier.condition_occurrence co 
-         where co.person_id = c.subject_id) as conditions,
-        (select round(count(*), cast(- floor(log10(abs(count(*) + 0.01))) as int))
-         from @tableQualifier.drug_exposure de 
-         where de.person_id = c.subject_id) as drugs
-from @resultsTableQualifier.cohort c
-join @tableQualifier.person p on c.subject_id = p.person_id
-join @tableQualifier.concept gc on p.gender_concept_id = gc.concept_id
-where cohort_definition_id = @cohortDefinitionId
-) cohort_people
+(
+       select 
+                     c.*
+                     , gc.concept_name as gender
+                     , cast(floor((YEAR(cohort_start_date) - year_of_birth) / 10) * 10 as varchar(5)) + '-' +
+                           cast(floor((YEAR(cohort_start_date) - year_of_birth) / 10 + 1) * 10 - 1 as varchar(5)) as age
+                     , conditions.conditions
+                     , drugs.drugs
+       from 
+              @resultsTableQualifier.cohort c
+       join 
+              (
+                     select person_id, 
+                           ROUND(count(*), CAST(- floor(LOG10(abs(count(*) + 0.01)))  AS INT)) conditions
+                     from @tableQualifier.condition_occurrence co
+                     group by person_id
+              )  as conditions
+       on c.subject_id = conditions.person_id
+       join 
+              (
+                     select person_id, 
+                           ROUND(count(*), CAST(- floor(LOG10(abs(count(*) + 0.01)))  AS INT)) drugs
+                     from @tableQualifier.drug_exposure de 
+                     group by person_id
+              ) as drugs
+       			on c.subject_id = drugs.person_id
+       join 
+              @tableQualifier.person p 
+       			on c.subject_id = p.person_id
+       join 
+              @tableQualifier.concept gc 
+       			on p.gender_concept_id = gc.concept_id
+       where cohort_definition_id = @cohortDefinitionId
+) as f
 group by gender, age, conditions, drugs
 order by 1 desc

--- a/src/main/resources/resources/cohortresults/sql/raw/getCohortBreakdown.sql
+++ b/src/main/resources/resources/cohortresults/sql/raw/getCohortBreakdown.sql
@@ -1,43 +1,32 @@
-select 
-              count(distinct subject_id) people
-              , gender
-              , age
-              , conditions
-              , drugs
+select count(distinct subject_id) as people,
+			gender, age, conditions, drugs
 from
-(
-       select 
-                     c.*
-                     , gc.concept_name as gender
-                     , cast(floor((YEAR(cohort_start_date) - year_of_birth) / 10) * 10 as varchar(5)) + '-' +
-                           cast(floor((YEAR(cohort_start_date) - year_of_birth) / 10 + 1) * 10 - 1 as varchar(5)) as age
-                     , conditions.conditions
-                     , drugs.drugs
-       from 
-              @resultsTableQualifier.cohort c
-       join 
-              (
-                     select person_id, 
-                           ROUND(count(*), CAST(- floor(LOG10(abs(count(*) + 0.01)))  AS INT)) conditions
-                     from @tableQualifier.condition_occurrence co
-                     group by person_id
-              )  as conditions
-       on c.subject_id = conditions.person_id
-       join 
-              (
-                     select person_id, 
-                           ROUND(count(*), CAST(- floor(LOG10(abs(count(*) + 0.01)))  AS INT)) drugs
-                     from @tableQualifier.drug_exposure de 
-                     group by person_id
-              ) as drugs
-       			on c.subject_id = drugs.person_id
-       join 
-              @tableQualifier.person p 
-       			on c.subject_id = p.person_id
-       join 
-              @tableQualifier.concept gc 
-       			on p.gender_concept_id = gc.concept_id
-       where cohort_definition_id = @cohortDefinitionId
-) as f
+	(select c.*, gc.concept_name as gender,
+			cast(floor((year(cohort_start_date) - year_of_birth) / 10) * 10 as varchar(5)) + '-' +
+				cast(floor((year(cohort_start_date) - year_of_birth) / 10 + 1) * 10 - 1 as varchar(5)) as age,
+			conditions.conditions,
+			drugs.drugs
+	from @resultsTableQualifier.cohort c
+	join 
+		(select person_id,
+				round(count(*),
+				cast(- floor(log10(abs(count(*) + 0.01))) as int)) as conditions
+		 from @tableQualifier.condition_occurrence co
+		 group by person_id
+		) as conditions 
+	on c.subject_id = conditions.person_id
+	join 
+		(select person_id,
+			round(count(*),
+			cast(- floor(log10(abs(count(*) + 0.01))) as int)) drugs
+		from @tableQualifier.drug_exposure de 
+		group by person_id
+		) as drugs
+	on c.subject_id = drugs.person_id
+	join @tableQualifier.person p on c.subject_id = p.person_id
+	join @tableQualifier.concept gc on p.gender_concept_id = gc.concept_id
+	where cohort_definition_id = @cohortDefinitionId
+	) as cohort_people
 group by gender, age, conditions, drugs
 order by 1 desc
+

--- a/src/main/resources/resources/cohortresults/sql/raw/getCohortBreakdownPeople.sql
+++ b/src/main/resources/resources/cohortresults/sql/raw/getCohortBreakdownPeople.sql
@@ -1,39 +1,32 @@
 with breakdown (subject_id, cohort_start_date, cohort_end_date, gender,age,conditions,drugs) as (
     select subject_id, cohort_start_date, cohort_end_date, gender, age, conditions, drugs
     from
-        (
-			select subject_id, cohort_start_date, cohort_end_date,
-					gc.concept_name as gender,
-					cast(floor((year(cohort_start_date) - year_of_birth) / 10) * 10 as varchar(5)) + '-' +
-						cast(floor((year(cohort_start_date) - year_of_birth) / 10 + 1) * 10 - 1 as varchar(5)) as age,
-					conditions.conditions,
-					drugs.drugs
-			from
-				@resultsTableQualifier.cohort c
-			join
-				(
-					select person_id,
-						round(count(*), cast(- floor(log10(abs(count(*) + 0.01))) as int)) conditions
-					from @tableQualifier.condition_occurrence co
-					group by person_id
-				) as conditions
-			on c.subject_id = conditions.person_id
-			join
-				(
-					select person_id,
-						round(count(*), cast(- floor(log10(abs(count(*) + 0.01))) as int)) drugs
-					from @tableQualifier.drug_exposure de
-					group by person_id
-				) as drugs
-			on c.subject_id = drugs.person_id
-			join 
-				@tableQualifier.person p 
-			on c.subject_id = p.person_id
-			join
-				@tableQualifier.concept gc
-			on p.gender_concept_id = gc.concept_id
-			where cohort_definition_id = @cohortDefinitionId
-		) as f		
+        (select subject_id, cohort_start_date, cohort_end_date,
+				gc.concept_name as gender,
+				cast(floor((year(cohort_start_date) - year_of_birth) / 10) * 10 as varchar(5)) + '-' +
+					cast(floor((year(cohort_start_date) - year_of_birth) / 10 + 1) * 10 - 1 as varchar(5)) as age,
+				conditions.conditions,
+				drugs.drugs
+		from @resultsTableQualifier.cohort c
+		join
+			(select person_id,
+					round(count(*),
+					cast(- floor(log10(abs(count(*) + 0.01))) as int)) conditions
+			from @tableQualifier.condition_occurrence co
+			group by person_id
+			) as conditions
+		on c.subject_id = conditions.person_id
+		join
+			(select person_id,
+					round(count(*), cast(- floor(log10(abs(count(*) + 0.01))) as int)) drugs
+			from @tableQualifier.drug_exposure de
+			group by person_id
+			) as drugs
+		on c.subject_id = drugs.person_id
+		join @tableQualifier.person p on c.subject_id = p.person_id
+		join @tableQualifier.concept gc on p.gender_concept_id = gc.concept_id
+		where cohort_definition_id = @cohortDefinitionId
+		) as cohort_people		
     /*whereclause*/
 )
 select * from
@@ -42,4 +35,3 @@ select * from
  from breakdown
 ) withrows
 where row_limit <= @rows/@groups
-

--- a/src/main/resources/resources/cohortresults/sql/raw/getCohortBreakdownPeople.sql
+++ b/src/main/resources/resources/cohortresults/sql/raw/getCohortBreakdownPeople.sql
@@ -1,21 +1,39 @@
 with breakdown (subject_id, cohort_start_date, cohort_end_date, gender,age,conditions,drugs) as (
     select subject_id, cohort_start_date, cohort_end_date, gender, age, conditions, drugs
     from
-        (select subject_id, cohort_start_date, cohort_end_date,
-                gc.concept_name as gender,
-                cast(floor((year(cohort_start_date) - year_of_birth) / 10) * 10 as varchar(5)) + '-' +
-                    cast(floor((year(cohort_start_date) - year_of_birth) / 10 + 1) * 10 - 1 as varchar(5)) as age,
-                (select round(count(*), cast(- floor(log10(abs(count(*) + 0.01))) as int)) 
-                 from @tableQualifier.condition_occurrence co 
-                 where co.person_id = c.subject_id) as conditions,
-                (select round(count(*), cast(- floor(log10(abs(count(*) + 0.01))) as int))
-                 from @tableQualifier.drug_exposure de 
-                 where de.person_id = c.subject_id) as drugs
-        from @resultsTableQualifier.cohort c
-        join @tableQualifier.person p on c.subject_id = p.person_id
-        join @tableQualifier.concept gc on p.gender_concept_id = gc.concept_id
-        where cohort_definition_id = @cohortDefinitionId
-        ) cohort_people
+        (
+			select subject_id, cohort_start_date, cohort_end_date,
+					gc.concept_name as gender,
+					cast(floor((year(cohort_start_date) - year_of_birth) / 10) * 10 as varchar(5)) + '-' +
+						cast(floor((year(cohort_start_date) - year_of_birth) / 10 + 1) * 10 - 1 as varchar(5)) as age,
+					conditions.conditions,
+					drugs.drugs
+			from
+				@resultsTableQualifier.cohort c
+			join
+				(
+					select person_id,
+						round(count(*), cast(- floor(log10(abs(count(*) + 0.01))) as int)) conditions
+					from @tableQualifier.condition_occurrence co
+					group by person_id
+				) as conditions
+			on c.subject_id = conditions.person_id
+			join
+				(
+					select person_id,
+						round(count(*), cast(- floor(log10(abs(count(*) + 0.01))) as int)) drugs
+					from @tableQualifier.drug_exposure de
+					group by person_id
+				) as drugs
+			on c.subject_id = drugs.person_id
+			join 
+				@tableQualifier.person p 
+			on c.subject_id = p.person_id
+			join
+				@tableQualifier.concept gc
+			on p.gender_concept_id = gc.concept_id
+			where cohort_definition_id = @cohortDefinitionId
+		) as f		
     /*whereclause*/
 )
 select * from
@@ -24,3 +42,4 @@ select * from
  from breakdown
 ) withrows
 where row_limit <= @rows/@groups
+


### PR DESCRIPTION
Some DBMS especially MPP systems do not allow correlated subqueries in aggregates with group by. These queries need to be rewritten. Also, using correlated sub-query may not be considered best practice.  SqlRender cannot translate correlated subquery into a query without subquery. 