### PR TITLE
Update to circe-be 1.2.1.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -432,7 +432,7 @@
     <dependency>
       <groupId>org.ohdsi</groupId>
       <artifactId>circe</artifactId>
-      <version>1.2.0</version>
+      <version>1.2.1</version>
     </dependency>
   </dependencies>
   <profiles>


### PR DESCRIPTION
Update to 1.2.1 of circe to use row_number() ordering of events instead of dense_rank().
