### PR TITLE
Update mssql-jdbc to 6.2.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -374,7 +374,7 @@
     <dependency>
       <groupId>com.microsoft.sqlserver</groupId>
       <artifactId>mssql-jdbc</artifactId>
-      <version>6.1.0.jre8</version>
+      <version>6.2.2.jre8</version>
     </dependency>
     <dependency>
       <groupId>com.opencsv</groupId>


### PR DESCRIPTION
This is to correct the mssql-jdbc drive conflict discussed here: http://forums.ohdsi.org/t/webapi-jar-conflict/3742
