### PR TITLE
PreparedStatement parameter limits (#244)

### DIFF
--- a/src/main/java/org/ohdsi/webapi/util/PreparedSqlRender.java
+++ b/src/main/java/org/ohdsi/webapi/util/PreparedSqlRender.java
@@ -7,6 +7,7 @@ import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import org.apache.commons.lang.StringUtils;
+import org.ohdsi.webapi.source.Source;
 
 public class PreparedSqlRender {
 
@@ -66,5 +67,23 @@ public class PreparedSqlRender {
       result.addAll(Arrays.asList((Object[]) value));
     }
   }
+	
+	// Given a source, determine how many parameters are allowed for IN clauses
+	// when using prepared statements. This function will return -1 if there
+	// is no known limit otherwise it will return the value based on the 
+	// sourceDialect property of the source object
+	public static int getParameterLimit(Source source) {
+		int returnVal = -1;
+		String sourceDialect = source.getSourceDialect().toLowerCase();
+		
+		if (sourceDialect.equals("oracle")) {
+			returnVal = 990;
+		} else if (sourceDialect.equals("sql server") || sourceDialect.equals("pdw")) {
+			returnVal = 2000;
+		} else if (sourceDialect.equals("postgresql") || sourceDialect.equals("redshift")) {
+			returnVal = 30000;
+		}
+		return returnVal;
+	}
 }
 


### PR DESCRIPTION
Added a static method to the PreparedSqlRender class to return the maximum number of parameters based on the dialect of the source. I don't love having these limits hard-coded into the code base so I'm open to changes around this approach.

The original code in the VocabularyService.java inspected the driver for the OHDSI repository instead of the target data source for the vocabulary query. The changes to those respective methods reflect the following:

1. Retrieve the source information from the OHDSI repository 1 time to prevent redundant calls to obtain information about the target data source.
2. Look up the parameter limit (using static method mentioned above) for that source and use that limit to chunk up the PreparedStatement queries to the source. 

Tagging @pavgra, @mpozhidaeva for awareness and feedback. 
