### PR TITLE
Update circe-be to 1.4.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -441,7 +441,7 @@
     <dependency>
       <groupId>org.ohdsi</groupId>
       <artifactId>circe</artifactId>
-      <version>1.3.2</version>
+      <version>1.4.0</version>
     </dependency>
     <dependency>
       <groupId>org.json</groupId>

--- a/src/main/java/org/ohdsi/webapi/cohortdefinition/GenerateCohortTasklet.java
+++ b/src/main/java/org/ohdsi/webapi/cohortdefinition/GenerateCohortTasklet.java
@@ -90,6 +90,8 @@ public class GenerateCohortTasklet implements Tasklet {
       options.cdmSchema = jobParams.get("cdm_database_schema").toString();
       options.targetTable = jobParams.get("target_database_schema").toString() + "." + jobParams.get("target_table").toString();
       options.resultSchema = jobParams.get("results_database_schema").toString();
+      if (jobParams.get("vocabulary_database_schema") != null)
+				options.vocabularySchema = jobParams.get("vocabulary_database_schema").toString();
       options.generateStats = Boolean.valueOf(jobParams.get("generate_stats").toString());
 
       String deleteSql = "DELETE FROM @tableQualifier.cohort_inclusion WHERE cohort_definition_id = @cohortDefinitionId";

--- a/src/main/java/org/ohdsi/webapi/service/CohortDefinitionService.java
+++ b/src/main/java/org/ohdsi/webapi/service/CohortDefinitionService.java
@@ -449,7 +449,8 @@ public class CohortDefinitionService extends AbstractDaoService {
     Source source = getSourceRepository().findBySourceKey(sourceKey);
     String cdmTableQualifier = source.getTableQualifier(SourceDaimon.DaimonType.CDM);    
     String resultsTableQualifier = source.getTableQualifier(SourceDaimon.DaimonType.Results);    
-    
+    String vocabularyTableQualifier = source.getTableQualifierOrNull(SourceDaimon.DaimonType.Vocabulary);
+		
     DefaultTransactionDefinition requresNewTx = new DefaultTransactionDefinition();
     requresNewTx.setPropagationBehavior(TransactionDefinition.PROPAGATION_REQUIRES_NEW);
     TransactionStatus initStatus = this.getTransactionTemplate().getTransactionManager().getTransaction(requresNewTx);
@@ -473,6 +474,8 @@ public class CohortDefinitionService extends AbstractDaoService {
     builder.addString("cdm_database_schema", cdmTableQualifier);
     builder.addString("results_database_schema", resultsTableQualifier);
     builder.addString("target_database_schema", resultsTableQualifier);
+		if (vocabularyTableQualifier != null)
+			builder.addString("vocabulary_database_schema", vocabularyTableQualifier);
     builder.addString("target_dialect", source.getSourceDialect());
     builder.addString("target_table", "cohort");
     builder.addString("cohort_definition_id", ("" + id));

--- a/src/main/java/org/ohdsi/webapi/service/VocabularyService.java
+++ b/src/main/java/org/ohdsi/webapi/service/VocabularyService.java
@@ -171,7 +171,7 @@ public class VocabularyService extends AbstractDaoService {
     String tqValue = source.getTableQualifier(SourceDaimon.DaimonType.Vocabulary);
     ConceptSetExpressionQueryBuilder builder = new ConceptSetExpressionQueryBuilder();
     String query = builder.buildExpressionQuery(conceptSetExpression);
-    PreparedStatementRenderer psr = new PreparedStatementRenderer(source, query, "cdm_database_schema", tqValue);
+    PreparedStatementRenderer psr = new PreparedStatementRenderer(source, query, "vocabulary_database_schema", tqValue);
     String sqlPath = "/resources/vocabulary/sql/lookupIdentifiers.sql";
     String[] searches = new String[]{"identifiers", "CDM_schema"};
     String[] replacements = new String[]{psr.getSql(), tqValue};
@@ -297,7 +297,7 @@ public class VocabularyService extends AbstractDaoService {
 
     ConceptSetExpressionQueryBuilder builder = new ConceptSetExpressionQueryBuilder();
     String query = builder.buildExpressionQuery(conceptSetExpression);
-    PreparedStatementRenderer psr = new PreparedStatementRenderer(source, query, "cdm_database_schema", tableQualifier);
+    PreparedStatementRenderer psr = new PreparedStatementRenderer(source, query, "vocabulary_database_schema", tableQualifier);
     String sqlPath = "/resources/vocabulary/sql/getMappedSourcecodes.sql";
     String[] search = new String[]{"identifiers", "CDM_schema"};
     String[] replace = new String[]{psr.getSql(), tableQualifier};
@@ -570,7 +570,7 @@ public class VocabularyService extends AbstractDaoService {
   @Consumes(MediaType.APPLICATION_JSON)
   public Collection<Long> resolveConceptSetExpression(@PathParam("sourceKey") String sourceKey, ConceptSetExpression conceptSetExpression) {
     Source source = getSourceRepository().findBySourceKey(sourceKey);
-    String tqName = "cdm_database_schema";
+    String tqName = "vocabulary_database_schema";
     String tqValue = source.getTableQualifier(SourceDaimon.DaimonType.Vocabulary);
     ConceptSetExpressionQueryBuilder builder = new ConceptSetExpressionQueryBuilder();
     String query = builder.buildExpressionQuery(conceptSetExpression);

--- a/src/main/java/org/ohdsi/webapi/source/Source.java
+++ b/src/main/java/org/ohdsi/webapi/source/Source.java
@@ -57,13 +57,19 @@ public class Source implements Serializable {
 
   
   public String getTableQualifier(DaimonType daimonType) {
+		String result = getTableQualifierOrNull(daimonType);
+		if (result == null)
+			throw new RuntimeException("DaimonType (" + daimonType + ") not found in Source");
+		return result;
+  }
+	
+	  public String getTableQualifierOrNull(DaimonType daimonType) {
     for (SourceDaimon sourceDaimon : this.getDaimons()) {
       if (sourceDaimon.getDaimonType() == daimonType) {
         return sourceDaimon.getTableQualifier();
       } 
     }
-    
-    throw new RuntimeException("DaimonType (" + daimonType + ") not found in Source");
+		return null;
   }
   
   public String getSourceKey() {


### PR DESCRIPTION
This will update the reference of circe-be to 1.4.0. This includes the payer-plan-period criteria, censor windows, and impala support.

In addition, some tokens in the query builder has been updated, so some WebAPI changes were required for this version.  Also, cohort generation has been updated to check for a Vocabulary daimon type, and if it exists, use it.

