### PR TITLE
Entity sequence

### DIFF
--- a/src/main/java/org/ohdsi/webapi/cohortcomparison/ComparativeCohortAnalysis.java
+++ b/src/main/java/org/ohdsi/webapi/cohortcomparison/ComparativeCohortAnalysis.java
@@ -19,7 +19,9 @@ import java.util.Date;
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
 import javax.persistence.Id;
+import javax.persistence.SequenceGenerator;
 import javax.persistence.Table;
 
 /**
@@ -30,7 +32,8 @@ import javax.persistence.Table;
 public class ComparativeCohortAnalysis implements Serializable {
 
     @Id
-    @GeneratedValue
+    @SequenceGenerator(name = "cca_seq", sequenceName = "cca_sequence", allocationSize = 1)
+    @GeneratedValue(generator = "cca_seq", strategy = GenerationType.SEQUENCE)
     @Column(name = "cca_id")
     private Integer analysisId;
 

--- a/src/main/java/org/ohdsi/webapi/cohortdefinition/CohortDefinition.java
+++ b/src/main/java/org/ohdsi/webapi/cohortdefinition/CohortDefinition.java
@@ -15,22 +15,18 @@
 package org.ohdsi.webapi.cohortdefinition;
 
 import java.io.Serializable;
-import java.util.ArrayList;
-import java.util.Collection;
 import java.util.Date;
-import java.util.List;
 import java.util.Set;
 import javax.persistence.Access;
 import javax.persistence.AccessType;
 import javax.persistence.CascadeType;
-import javax.persistence.CollectionTable;
 import javax.persistence.Column;
-import javax.persistence.ElementCollection;
 import javax.persistence.Entity;
 import javax.persistence.EnumType;
 import javax.persistence.Enumerated;
 import javax.persistence.FetchType;
 import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import javax.persistence.JoinColumn;
 import javax.persistence.NamedAttributeNode;
@@ -38,7 +34,7 @@ import javax.persistence.NamedEntityGraph;
 import javax.persistence.NamedSubgraph;
 import javax.persistence.OneToMany;
 import javax.persistence.OneToOne;
-import javax.persistence.OrderColumn;
+import javax.persistence.SequenceGenerator;
 import javax.persistence.Table;
 
 /**
@@ -57,7 +53,8 @@ public class CohortDefinition implements Serializable{
   private static final long serialVersionUID = 1L;
     
   @Id
-  @GeneratedValue
+  @SequenceGenerator(name = "cohort_definition_seq",sequenceName = "cohort_definition_sequence", allocationSize = 1)
+  @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "cohort_definition_seq")
   @Access(AccessType.PROPERTY) 
   private Integer id;
   

--- a/src/main/java/org/ohdsi/webapi/conceptset/ConceptSet.java
+++ b/src/main/java/org/ohdsi/webapi/conceptset/ConceptSet.java
@@ -16,14 +16,12 @@
 package org.ohdsi.webapi.conceptset;
 
 import java.io.Serializable;
-import java.util.Collection;
-import javax.persistence.CascadeType;
 import javax.persistence.Column;
 import javax.persistence.Entity;
-import javax.persistence.FetchType;
 import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
 import javax.persistence.Id;
-import javax.persistence.OneToMany;
+import javax.persistence.SequenceGenerator;
 import javax.persistence.Table;
 
 /**
@@ -35,7 +33,8 @@ import javax.persistence.Table;
 public class ConceptSet implements Serializable {
   
   @Id
-  @GeneratedValue  
+  @SequenceGenerator(name = "concept_set_seq", sequenceName = "concept_set_sequence", allocationSize = 1)
+  @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "concept_set_seq")
   @Column(name="concept_set_id")    
   private int id;
   

--- a/src/main/java/org/ohdsi/webapi/conceptset/ConceptSetItem.java
+++ b/src/main/java/org/ohdsi/webapi/conceptset/ConceptSetItem.java
@@ -15,12 +15,13 @@
  */
 package org.ohdsi.webapi.conceptset;
 
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import java.io.Serializable;
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
 import javax.persistence.Id;
+import javax.persistence.SequenceGenerator;
 import javax.persistence.Table;
 
 /**
@@ -33,8 +34,9 @@ import javax.persistence.Table;
 public class ConceptSetItem implements Serializable{
   
   @Id
-  @GeneratedValue  
-  @Column(name="concept_set_item_id")    
+  @SequenceGenerator(name = "concept_set_item_seq", sequenceName = "concept_set_item_sequence", allocationSize = 1)
+  @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "concept_set_item_seq")
+  @Column(name="concept_set_item_id")
   private int id;
   
   @Column(name="concept_set_id")

--- a/src/main/java/org/ohdsi/webapi/evidence/NegativeControlRecord.java
+++ b/src/main/java/org/ohdsi/webapi/evidence/NegativeControlRecord.java
@@ -11,7 +11,9 @@ import javax.persistence.AccessType;
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
 import javax.persistence.Id;
+import javax.persistence.SequenceGenerator;
 import javax.persistence.Table;
 
 /**
@@ -23,7 +25,8 @@ import javax.persistence.Table;
 public class NegativeControlRecord implements Serializable {
 
     @Id
-    @GeneratedValue  
+    @SequenceGenerator(name = "concept_set_negative_controls_seq", sequenceName = "negative_controls_sequence", allocationSize = 1)
+    @GeneratedValue(generator = "concept_set_negative_controls_seq", strategy = GenerationType.SEQUENCE)
     @Access(AccessType.PROPERTY) 
     @Column(name = "id")
     private int id;

--- a/src/main/java/org/ohdsi/webapi/feasibility/FeasibilityStudy.java
+++ b/src/main/java/org/ohdsi/webapi/feasibility/FeasibilityStudy.java
@@ -29,6 +29,7 @@ import javax.persistence.ElementCollection;
 import javax.persistence.Entity;
 import javax.persistence.FetchType;
 import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import javax.persistence.JoinColumn;
 import javax.persistence.NamedAttributeNode;
@@ -37,6 +38,7 @@ import javax.persistence.NamedEntityGraphs;
 import javax.persistence.OneToMany;
 import javax.persistence.OneToOne;
 import javax.persistence.OrderColumn;
+import javax.persistence.SequenceGenerator;
 import javax.persistence.Table;
 import org.ohdsi.webapi.cohortdefinition.CohortDefinition;
 
@@ -64,7 +66,8 @@ import org.ohdsi.webapi.cohortdefinition.CohortDefinition;
 public class FeasibilityStudy {
   
   @Id
-  @GeneratedValue
+  @SequenceGenerator(name = "feasibility_study_seq", sequenceName = "feasibility_study_sequence", allocationSize = 1)
+  @GeneratedValue(generator = "feasibility_study_seq", strategy = GenerationType.SEQUENCE)
   @Column(name="id")
   @Access(AccessType.PROPERTY) 
   private Integer id; 

--- a/src/main/java/org/ohdsi/webapi/ircalc/IncidenceRateAnalysis.java
+++ b/src/main/java/org/ohdsi/webapi/ircalc/IncidenceRateAnalysis.java
@@ -26,10 +26,12 @@ import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.FetchType;
 import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import javax.persistence.JoinColumn;
 import javax.persistence.OneToMany;
 import javax.persistence.OneToOne;
+import javax.persistence.SequenceGenerator;
 import javax.persistence.Table;
 
 /**
@@ -43,7 +45,8 @@ public class IncidenceRateAnalysis implements Serializable {
   private static final long serialVersionUID = 1L;
   
   @Id
-  @GeneratedValue
+  @SequenceGenerator(name = "ir_analysis_seq", sequenceName = "ir_analysis_sequence", allocationSize = 1)
+  @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "ir_analysis_seq")
   @Column(name="id")
   @Access(AccessType.PROPERTY) 
   private Integer id; 

--- a/src/main/java/org/ohdsi/webapi/prediction/PatientLevelPredictionAnalysis.java
+++ b/src/main/java/org/ohdsi/webapi/prediction/PatientLevelPredictionAnalysis.java
@@ -9,7 +9,9 @@ import java.util.Date;
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
 import javax.persistence.Id;
+import javax.persistence.SequenceGenerator;
 import javax.persistence.Table;
 import org.ohdsi.circe.vocabulary.ConceptSetExpression;
 
@@ -22,7 +24,8 @@ import org.ohdsi.circe.vocabulary.ConceptSetExpression;
 public class PatientLevelPredictionAnalysis {
 	
     @Id
-    @GeneratedValue
+	@SequenceGenerator(name = "plp_seq", sequenceName = "plp_sequence", allocationSize = 1)
+    @GeneratedValue(generator = "plp_seq", strategy = GenerationType.SEQUENCE)
     @Column(name = "plp_id")
     private Integer analysisId;
 

--- a/src/main/resources/db/migration/oracle/V2.2.5.20180215105415__separate-sequences.sql
+++ b/src/main/resources/db/migration/oracle/V2.2.5.20180215105415__separate-sequences.sql
@@ -4,7 +4,7 @@ DECLARE
   stmt VARCHAR2(255);
 BEGIN
   stmt := 'CREATE SEQUENCE ${ohdsiSchema}.cca_sequence START WITH ';
-  SELECT nvl(max(cca_id), 1) INTO val FROM ${ohdsiSchema}.cca;
+  SELECT nvl2(max(cca_id), max(cca_id) + 1, 1) INTO val FROM ${ohdsiSchema}.cca;
   EXECUTE IMMEDIATE stmt || val;
 END;
 /
@@ -15,50 +15,34 @@ DECLARE
   stmt VARCHAR2(255);
 BEGIN
   stmt := 'CREATE SEQUENCE ${ohdsiSchema}.cohort_definition_sequence START WITH ';
-  SELECT nvl(max(id), 1) INTO val FROM ${ohdsiSchema}.cohort_definition;
+  SELECT nvl2(max(id), max(id) + 1, 1) INTO val FROM ${ohdsiSchema}.cohort_definition;
   EXECUTE IMMEDIATE stmt || val;
 END;
 /
 
+DROP SEQUENCE ${ohdsiSchema}.CONCEPT_SET_SEQUENCE;
+
 -- concept_set
 DECLARE
-  diff INTEGER;
   val INTEGER;
   stmt VARCHAR2(255);
 BEGIN
-  stmt := 'ALTER SEQUENCE ${ohdsiSchema}.concept_set_sequence INCREMENT BY ';
-  BEGIN
-    SELECT ${ohdsiSchema}.concept_set_sequence.NEXTVAL INTO val FROM ${ohdsiSchema}.concept_set;
-    EXCEPTION WHEN NO_DATA_FOUND THEN
-      val := 1;
-  END;
-  SELECT (nvl(max(concept_set_id), 1) - val) INTO diff FROM ${ohdsiSchema}.concept_set;
-  IF diff > 0 THEN
-    EXECUTE IMMEDIATE stmt || val;
-    SELECT ${ohdsiSchema}.concept_set_sequence.NEXTVAL INTO val FROM ${ohdsiSchema}.concept_set;
-    EXECUTE IMMEDIATE stmt || 1;
-  END IF;
+  stmt := 'CREATE SEQUENCE ${ohdsiSchema}.concept_set_sequence START WITH ';
+  SELECT nvl2(max(concept_set_id), max(concept_set_id) + 1, 1) INTO val FROM ${ohdsiSchema}.concept_set;
+  EXECUTE IMMEDIATE stmt || val;
 END;
 /
 
+DROP SEQUENCE ${ohdsiSchema}.CONCEPT_SET_ITEM_SEQUENCE;
+
 -- concept_set_item
 DECLARE
-  diff INTEGER;
   val INTEGER;
   stmt VARCHAR2(255);
 BEGIN
-  stmt := 'ALTER SEQUENCE ${ohdsiSchema}.concept_set_item_sequence INCREMENT BY ';
-  BEGIN
-    SELECT ${ohdsiSchema}.concept_set_item_sequence.NEXTVAL INTO val FROM ${ohdsiSchema}.concept_set_item;
-    EXCEPTION WHEN NO_DATA_FOUND THEN
-      val := 1;
-  END;
-  SELECT (nvl(max(concept_set_id), 1) - val) INTO diff FROM ${ohdsiSchema}.concept_set_item;
-  IF diff > 0 THEN
-    EXECUTE IMMEDIATE stmt || val;
-    SELECT ${ohdsiSchema}.concept_set_item_sequence.NEXTVAL INTO val FROM ${ohdsiSchema}.concept_set_item;
-    EXECUTE IMMEDIATE stmt || 1;
-  END IF;
+  stmt := 'CREATE SEQUENCE ${ohdsiSchema}.concept_set_item_sequence START WITH ';
+  SELECT nvl2(max(concept_set_item_id), max(concept_set_item_id) + 1, 1) INTO val FROM ${ohdsiSchema}.concept_set_item;
+  EXECUTE IMMEDIATE stmt || val;
 END;
 /
 
@@ -68,7 +52,7 @@ DECLARE
   stmt VARCHAR2(255);
 BEGIN
   stmt := 'CREATE SEQUENCE ${ohdsiSchema}.negative_controls_sequence START WITH ';
-  SELECT nvl(max(id), 1) INTO val FROM ${ohdsiSchema}.concept_set_negative_controls;
+  SELECT nvl2(max(id), max(id) + 1, 1) INTO val FROM ${ohdsiSchema}.concept_set_negative_controls;
   EXECUTE IMMEDIATE stmt || val;
 END;
 /
@@ -79,7 +63,7 @@ DECLARE
   stmt VARCHAR2(255);
 BEGIN
   stmt := 'CREATE SEQUENCE ${ohdsiSchema}.feasibility_study_sequence START WITH ';
-  SELECT nvl(max(id), 1) INTO val FROM ${ohdsiSchema}.feasibility_study;
+  SELECT nvl2(max(id), max(id) + 1, 1) INTO val FROM ${ohdsiSchema}.feasibility_study;
   EXECUTE IMMEDIATE stmt || val;
 END;
 /
@@ -90,7 +74,7 @@ DECLARE
   stmt VARCHAR2(255);
 BEGIN
   stmt := 'CREATE SEQUENCE ${ohdsiSchema}.ir_analysis_sequence START WITH ';
-  SELECT nvl(max(id), 1) INTO val FROM ${ohdsiSchema}.ir_analysis;
+  SELECT nvl2(max(id), max(id) + 1, 1) INTO val FROM ${ohdsiSchema}.ir_analysis;
   EXECUTE IMMEDIATE stmt || val;
 END;
 /
@@ -101,7 +85,7 @@ DECLARE
   stmt VARCHAR2(255);
 BEGIN
   stmt := 'CREATE SEQUENCE ${ohdsiSchema}.plp_sequence START WITH ';
-  SELECT nvl(max(plp_id), 1) INTO val FROM ${ohdsiSchema}.plp;
+  SELECT nvl2(max(plp_id), max(plp_id) + 1, 1) INTO val FROM ${ohdsiSchema}.plp;
   EXECUTE IMMEDIATE stmt || val;
 END;
 /

--- a/src/main/resources/db/migration/oracle/V2.2.5.20180215105415__separate-sequences.sql
+++ b/src/main/resources/db/migration/oracle/V2.2.5.20180215105415__separate-sequences.sql
@@ -1,0 +1,107 @@
+-- cca
+DECLARE
+  val INTEGER;
+  stmt VARCHAR2(255);
+BEGIN
+  stmt := 'CREATE SEQUENCE ${ohdsiSchema}.cca_sequence START WITH ';
+  SELECT nvl(max(cca_id), 1) INTO val FROM ${ohdsiSchema}.cca;
+  EXECUTE IMMEDIATE stmt || val;
+END;
+/
+
+-- cohort_definition
+DECLARE
+  val INTEGER;
+  stmt VARCHAR2(255);
+BEGIN
+  stmt := 'CREATE SEQUENCE ${ohdsiSchema}.cohort_definition_sequence START WITH ';
+  SELECT nvl(max(id), 1) INTO val FROM ${ohdsiSchema}.cohort_definition;
+  EXECUTE IMMEDIATE stmt || val;
+END;
+/
+
+-- concept_set
+DECLARE
+  diff INTEGER;
+  val INTEGER;
+  stmt VARCHAR2(255);
+BEGIN
+  stmt := 'ALTER SEQUENCE ${ohdsiSchema}.concept_set_sequence INCREMENT BY ';
+  BEGIN
+    SELECT ${ohdsiSchema}.concept_set_sequence.NEXTVAL INTO val FROM ${ohdsiSchema}.concept_set;
+    EXCEPTION WHEN NO_DATA_FOUND THEN
+      val := 1;
+  END;
+  SELECT (nvl(max(concept_set_id), 1) - val) INTO diff FROM ${ohdsiSchema}.concept_set;
+  IF diff > 0 THEN
+    EXECUTE IMMEDIATE stmt || val;
+    SELECT ${ohdsiSchema}.concept_set_sequence.NEXTVAL INTO val FROM ${ohdsiSchema}.concept_set;
+    EXECUTE IMMEDIATE stmt || 1;
+  END IF;
+END;
+/
+
+-- concept_set_item
+DECLARE
+  diff INTEGER;
+  val INTEGER;
+  stmt VARCHAR2(255);
+BEGIN
+  stmt := 'ALTER SEQUENCE ${ohdsiSchema}.concept_set_item_sequence INCREMENT BY ';
+  BEGIN
+    SELECT ${ohdsiSchema}.concept_set_item_sequence.NEXTVAL INTO val FROM ${ohdsiSchema}.concept_set_item;
+    EXCEPTION WHEN NO_DATA_FOUND THEN
+      val := 1;
+  END;
+  SELECT (nvl(max(concept_set_id), 1) - val) INTO diff FROM ${ohdsiSchema}.concept_set_item;
+  IF diff > 0 THEN
+    EXECUTE IMMEDIATE stmt || val;
+    SELECT ${ohdsiSchema}.concept_set_item_sequence.NEXTVAL INTO val FROM ${ohdsiSchema}.concept_set_item;
+    EXECUTE IMMEDIATE stmt || 1;
+  END IF;
+END;
+/
+
+-- concept_set_negative_controls
+DECLARE
+  val INTEGER;
+  stmt VARCHAR2(255);
+BEGIN
+  stmt := 'CREATE SEQUENCE ${ohdsiSchema}.negative_controls_sequence START WITH ';
+  SELECT nvl(max(id), 1) INTO val FROM ${ohdsiSchema}.concept_set_negative_controls;
+  EXECUTE IMMEDIATE stmt || val;
+END;
+/
+
+-- feasibility_study
+DECLARE
+  val INTEGER;
+  stmt VARCHAR2(255);
+BEGIN
+  stmt := 'CREATE SEQUENCE ${ohdsiSchema}.feasibility_study_sequence START WITH ';
+  SELECT nvl(max(id), 1) INTO val FROM ${ohdsiSchema}.feasibility_study;
+  EXECUTE IMMEDIATE stmt || val;
+END;
+/
+
+-- ir_analysis
+DECLARE
+  val INTEGER;
+  stmt VARCHAR2(255);
+BEGIN
+  stmt := 'CREATE SEQUENCE ${ohdsiSchema}.ir_analysis_sequence START WITH ';
+  SELECT nvl(max(id), 1) INTO val FROM ${ohdsiSchema}.ir_analysis;
+  EXECUTE IMMEDIATE stmt || val;
+END;
+/
+
+-- plp
+DECLARE
+  val INTEGER;
+  stmt VARCHAR2(255);
+BEGIN
+  stmt := 'CREATE SEQUENCE ${ohdsiSchema}.plp_sequence START WITH ';
+  SELECT nvl(max(plp_id), 1) INTO val FROM ${ohdsiSchema}.plp;
+  EXECUTE IMMEDIATE stmt || val;
+END;
+/

--- a/src/main/resources/db/migration/postgresql/V2.2.5.20180215105415__separate-sequences.sql
+++ b/src/main/resources/db/migration/postgresql/V2.2.5.20180215105415__separate-sequences.sql
@@ -1,24 +1,23 @@
-CREATE SEQUENCE IF NOT EXISTS ${ohdsiSchema}.cca_sequence;
+CREATE SEQUENCE ${ohdsiSchema}.cca_sequence;
 SELECT setval('${ohdsiSchema}.cca_sequence', coalesce(max(cca_id), 1)) FROM ${ohdsiSchema}.cca;
 
-CREATE SEQUENCE IF NOT EXISTS ${ohdsiSchema}.cohort_definition_sequence;
+CREATE SEQUENCE ${ohdsiSchema}.cohort_definition_sequence;
 SELECT setval('${ohdsiSchema}.cohort_definition_sequence', coalesce(max(id), 1)) FROM ${ohdsiSchema}.cohort_definition;
 
-CREATE SEQUENCE IF NOT EXISTS ${ohdsiSchema}.concept_set_sequence;
+-- concept_set_sequence already exists - no need to create
 SELECT setval('${ohdsiSchema}.concept_set_sequence', coalesce(max(concept_set_id), 1)) FROM ${ohdsiSchema}.concept_set;
 
-CREATE SEQUENCE IF NOT EXISTS ${ohdsiSchema}.concept_set_item_sequence;
+-- concept_set_item_sequence already exists - no need to create
 SELECT setval('${ohdsiSchema}.concept_set_item_sequence', coalesce(max(concept_set_item_id), 1)) FROM ${ohdsiSchema}.concept_set_item;
 
-CREATE SEQUENCE IF NOT EXISTS ${ohdsiSchema}.negative_controls_sequence;
+-- concept_set_negative_controls_sequence already exists - no need to create
 SELECT setval('${ohdsiSchema}.concept_set_negative_controls_sequence', coalesce(max(id), 1)) FROM ${ohdsiSchema}.concept_set_negative_controls;
 
-CREATE SEQUENCE IF NOT EXISTS ${ohdsiSchema}.feasibility_study_sequence;
+CREATE SEQUENCE ${ohdsiSchema}.feasibility_study_sequence;
 SELECT setval('${ohdsiSchema}.feasibility_study_sequence', coalesce(max(id), 1)) FROM ${ohdsiSchema}.feasibility_study;
 
-CREATE SEQUENCE IF NOT EXISTS ${ohdsiSchema}.ir_analysis_sequence;
+CREATE SEQUENCE ${ohdsiSchema}.ir_analysis_sequence;
 SELECT setval('${ohdsiSchema}.ir_analysis_sequence', coalesce(max(id), 1)) FROM ${ohdsiSchema}.ir_analysis;
 
-CREATE SEQUENCE IF NOT EXISTS ${ohdsiSchema}.plp_sequence;
+CREATE SEQUENCE ${ohdsiSchema}.plp_sequence;
 SELECT setval('${ohdsiSchema}.plp_sequence', coalesce(max(plp_id), 1)) FROM ${ohdsiSchema}.plp;
-

--- a/src/main/resources/db/migration/postgresql/V2.2.5.20180215105415__separate-sequences.sql
+++ b/src/main/resources/db/migration/postgresql/V2.2.5.20180215105415__separate-sequences.sql
@@ -1,0 +1,24 @@
+CREATE SEQUENCE IF NOT EXISTS ${ohdsiSchema}.cca_sequence;
+SELECT setval('${ohdsiSchema}.cca_sequence', coalesce(max(cca_id), 1)) FROM ${ohdsiSchema}.cca;
+
+CREATE SEQUENCE IF NOT EXISTS ${ohdsiSchema}.cohort_definition_sequence;
+SELECT setval('${ohdsiSchema}.cohort_definition_sequence', coalesce(max(id), 1)) FROM ${ohdsiSchema}.cohort_definition;
+
+CREATE SEQUENCE IF NOT EXISTS ${ohdsiSchema}.concept_set_sequence;
+SELECT setval('${ohdsiSchema}.concept_set_sequence', coalesce(max(concept_set_id), 1)) FROM ${ohdsiSchema}.concept_set;
+
+CREATE SEQUENCE IF NOT EXISTS ${ohdsiSchema}.concept_set_item_sequence;
+SELECT setval('${ohdsiSchema}.concept_set_item_sequence', coalesce(max(concept_set_item_id), 1)) FROM ${ohdsiSchema}.concept_set_item;
+
+CREATE SEQUENCE IF NOT EXISTS ${ohdsiSchema}.negative_controls_sequence;
+SELECT setval('${ohdsiSchema}.concept_set_negative_controls_sequence', coalesce(max(id), 1)) FROM ${ohdsiSchema}.concept_set_negative_controls;
+
+CREATE SEQUENCE IF NOT EXISTS ${ohdsiSchema}.feasibility_study_sequence;
+SELECT setval('${ohdsiSchema}.feasibility_study_sequence', coalesce(max(id), 1)) FROM ${ohdsiSchema}.feasibility_study;
+
+CREATE SEQUENCE IF NOT EXISTS ${ohdsiSchema}.ir_analysis_sequence;
+SELECT setval('${ohdsiSchema}.ir_analysis_sequence', coalesce(max(id), 1)) FROM ${ohdsiSchema}.ir_analysis;
+
+CREATE SEQUENCE IF NOT EXISTS ${ohdsiSchema}.plp_sequence;
+SELECT setval('${ohdsiSchema}.plp_sequence', coalesce(max(plp_id), 1)) FROM ${ohdsiSchema}.plp;
+

--- a/src/main/resources/db/migration/postgresql/V2.2.5.20180215105415__separate-sequences.sql
+++ b/src/main/resources/db/migration/postgresql/V2.2.5.20180215105415__separate-sequences.sql
@@ -10,8 +10,8 @@ SELECT setval('${ohdsiSchema}.concept_set_sequence', coalesce(max(concept_set_id
 -- concept_set_item_sequence already exists - no need to create
 SELECT setval('${ohdsiSchema}.concept_set_item_sequence', coalesce(max(concept_set_item_id), 1)) FROM ${ohdsiSchema}.concept_set_item;
 
--- concept_set_negative_controls_sequence already exists - no need to create
-SELECT setval('${ohdsiSchema}.concept_set_negative_controls_sequence', coalesce(max(id), 1)) FROM ${ohdsiSchema}.concept_set_negative_controls;
+-- negative_controls_sequence already exists - no need to create
+SELECT setval('${ohdsiSchema}.negative_controls_sequence', coalesce(max(id), 1)) FROM ${ohdsiSchema}.concept_set_negative_controls;
 
 CREATE SEQUENCE ${ohdsiSchema}.feasibility_study_sequence;
 SELECT setval('${ohdsiSchema}.feasibility_study_sequence', coalesce(max(id), 1)) FROM ${ohdsiSchema}.feasibility_study;

--- a/src/main/resources/db/migration/sqlserver/V2.2.0.20180215143000__remove_password.sql
+++ b/src/main/resources/db/migration/sqlserver/V2.2.0.20180215143000__remove_password.sql
@@ -1,2 +1,2 @@
-ALTER TABLE ${ohdsiSchema}.sec_user DROP COLUMN IF EXISTS password; 
-ALTER TABLE ${ohdsiSchema}.sec_user DROP COLUMN IF EXISTS salt; 
+ALTER TABLE ${ohdsiSchema}.sec_user DROP COLUMN password; 
+ALTER TABLE ${ohdsiSchema}.sec_user DROP COLUMN salt; 

--- a/src/main/resources/db/migration/sqlserver/V2.2.5.20180215105415__separate-sequences.sql
+++ b/src/main/resources/db/migration/sqlserver/V2.2.5.20180215105415__separate-sequences.sql
@@ -1,0 +1,315 @@
+CREATE SEQUENCE ${ohdsiSchema}.cca_sequence;
+GO
+
+ALTER TABLE ${ohdsiSchema}.cca ADD cca_id_tmp INT;
+GO
+
+UPDATE ${ohdsiSchema}.cca SET cca_id_tmp = cca_id;
+GO
+
+ALTER TABLE ${ohdsiSchema}.cca DROP COLUMN cca_id;
+GO
+
+EXEC sp_rename '[${ohdsiSchema}].cca.cca_id_tmp', 'cca_id', 'COLUMN';
+GO
+
+ALTER TABLE ${ohdsiSchema}.cca ALTER COLUMN cca_id INT NOT NULL;
+GO
+
+ALTER TABLE ${ohdsiSchema}.cca ADD CONSTRAINT PK_cca_cca_id PRIMARY KEY CLUSTERED(cca_id);
+GO
+
+DECLARE @cca_id_val INT;
+DECLARE @sql NVARCHAR(MAX);
+SELECT @cca_id_val = coalesce(MAX(cca_id), 1) FROM ${ohdsiSchema}.cca;
+SET @sql = N'ALTER SEQUENCE ${ohdsiSchema}.cca_sequence RESTART WITH ' + CAST(@cca_id_val as NVARCHAR(20)) + ';';
+EXEC sp_executesql @sql;
+GO
+
+CREATE SEQUENCE ${ohdsiSchema}.cohort_definition_sequence;
+GO
+
+ALTER TABLE ${ohdsiSchema}.cohort_definition ADD id_tmp INT;
+GO
+
+UPDATE ${ohdsiSchema}.cohort_definition SET id_tmp = id;
+GO
+
+ALTER TABLE ${ohdsiSchema}.feasibility_study DROP CONSTRAINT FK_feasibility_study_cohort_definition_result;
+GO
+
+ALTER TABLE ${ohdsiSchema}.feasibility_study DROP CONSTRAINT [FK_feasibility_study_cohort_definition_index];
+GO
+
+ALTER TABLE ${ohdsiSchema}.cohort_definition_details DROP CONSTRAINT FK_cohort_definition_details_cohort_definition;
+GO
+
+ALTER TABLE ${ohdsiSchema}.cohort_generation_info DROP CONSTRAINT FK_cohort_generation_info_cohort_definition;
+GO
+
+DECLARE @sql NVARCHAR(MAX), @pk NVARCHAR(512);
+SELECT @pk = name FROM sys.key_constraints where [type] = 'PK' AND parent_object_id = OBJECT_ID('${ohdsiSchema}.cohort_definition');
+SET @sql = 'ALTER TABLE ${ohdsiSchema}.cohort_definition DROP CONSTRAINT ' + @pk + ';';
+EXEC sp_executesql @sql;
+GO
+
+ALTER TABLE ${ohdsiSchema}.cohort_definition DROP COLUMN id;
+GO
+
+EXEC sp_rename '${ohdsiSchema}.cohort_definition.id_tmp', 'id', 'COLUMN';
+GO
+
+ALTER TABLE ${ohdsiSchema}.cohort_definition ALTER COLUMN id INT NOT NULL;
+GO
+
+ALTER TABLE ${ohdsiSchema}.cohort_definition ADD CONSTRAINT PK_cohort_definition_id PRIMARY KEY CLUSTERED(id);
+GO
+
+ALTER TABLE ${ohdsiSchema}.feasibility_study ADD CONSTRAINT [FK_feasibility_study_cohort_definition_result] FOREIGN KEY([result_def_id])
+  REFERENCES [${ohdsiSchema}].[cohort_definition] ([id]);
+GO
+
+ALTER TABLE ${ohdsiSchema}.feasibility_study ADD CONSTRAINT [FK_feasibility_study_cohort_definition_index] FOREIGN KEY([index_def_id])
+  REFERENCES [${ohdsiSchema}].[cohort_definition] ([id]);
+GO
+
+ALTER TABLE ${ohdsiSchema}.cohort_definition_details
+  ADD CONSTRAINT FK_cohort_definition_details_cohort_definition
+    FOREIGN KEY (id) REFERENCES ${ohdsiSchema}.cohort_definition (id)
+  ON UPDATE CASCADE
+  ON DELETE CASCADE;
+GO
+
+ALTER TABLE ${ohdsiSchema}.cohort_generation_info ADD CONSTRAINT [FK_cohort_generation_info_cohort_definition] FOREIGN KEY([id])
+REFERENCES [${ohdsiSchema}].[cohort_definition] ([id])
+  ON UPDATE CASCADE
+  ON DELETE CASCADE;
+GO
+
+DECLARE @sql NVARCHAR(MAX);
+DECLARE @cohort_definition_id_val INT;
+SELECT @cohort_definition_id_val = coalesce(MAX(id), 1) FROM ${ohdsiSchema}.cohort_definition;
+SET @sql = N'ALTER SEQUENCE ${ohdsiSchema}.cohort_definition_sequence RESTART WITH ' + CAST(@cohort_definition_id_val AS NVARCHAR(20)) + ';';
+EXEC sp_executesql @sql;
+GO
+
+CREATE SEQUENCE ${ohdsiSchema}.concept_set_sequence;
+GO
+
+ALTER TABLE ${ohdsiSchema}.concept_set ADD concept_set_id_tmp INT;
+GO
+
+UPDATE ${ohdsiSchema}.concept_set SET concept_set_id_tmp = concept_set_id;
+GO
+
+ALTER TABLE ${ohdsiSchema}.concept_set_generation_info DROP CONSTRAINT FK_concept_set_generation_info_concept_set;
+GO
+
+DECLARE @sql NVARCHAR(MAX), @pk NVARCHAR(512);
+SELECT @pk = name FROM sys.key_constraints where [type] = 'PK' AND parent_object_id = OBJECT_ID('${ohdsiSchema}.concept_set');
+SET @sql = 'ALTER TABLE ${ohdsiSchema}.concept_set DROP CONSTRAINT ' + @pk + ';';
+EXEC sp_executesql @sql;
+GO
+
+ALTER TABLE ${ohdsiSchema}.concept_set DROP COLUMN concept_set_id;
+GO
+
+EXEC sp_rename '${ohdsiSchema}.concept_set.concept_set_id_tmp', 'concept_set_id', 'COLUMN';
+GO
+
+ALTER TABLE ${ohdsiSchema}.concept_set ALTER COLUMN concept_set_id INT NOT NULL;
+GO
+
+ALTER TABLE ${ohdsiSchema}.concept_set ADD CONSTRAINT PK_concept_set_concept_set_id PRIMARY KEY CLUSTERED(concept_set_id);
+GO
+
+ALTER TABLE ${ohdsiSchema}.concept_set_generation_info ADD CONSTRAINT [FK_concept_set_generation_info_concept_set] FOREIGN KEY([concept_set_id])
+  REFERENCES [${ohdsiSchema}].[concept_set] ([concept_set_id])
+  ON UPDATE CASCADE
+  ON DELETE CASCADE;
+GO
+
+DECLARE @sql NVARCHAR(MAX);
+DECLARE @concept_set_id_val INT;
+SELECT @concept_set_id_val = coalesce(MAX(concept_set_id), 1) FROM ${ohdsiSchema}.concept_set;
+SET @sql = N'ALTER SEQUENCE ${ohdsiSchema}.concept_set_sequence RESTART WITH ' + CAST(@concept_set_id_val AS NVARCHAR(20)) + ';';
+EXEC sp_executesql @sql;
+GO
+
+CREATE SEQUENCE ${ohdsiSchema}.concept_set_item_sequence;
+GO
+
+ALTER TABLE ${ohdsiSchema}.concept_set_item ADD concept_set_item_id_tmp INT;
+GO
+
+UPDATE ${ohdsiSchema}.concept_set_item SET concept_set_item_id_tmp = concept_set_item_id;
+GO
+
+ALTER TABLE ${ohdsiSchema}.concept_set_item DROP COLUMN concept_set_item_id;
+GO
+
+EXEC sp_rename '${ohdsiSchema}.concept_set_item.concept_set_item_id_tmp', 'concept_set_item_id', 'COLUMN';
+GO
+
+ALTER TABLE ${ohdsiSchema}.concept_set_item ALTER COLUMN concept_set_item_id INT NOT NULL;
+GO
+
+ALTER TABLE ${ohdsiSchema}.concept_set_item ADD CONSTRAINT PK_concept_set_item_concept_set_item_id PRIMARY KEY CLUSTERED(concept_set_item_id);
+GO
+
+DECLARE @sql NVARCHAR(MAX);
+DECLARE @concept_set_item_id_val INT;
+SELECT @concept_set_item_id_val = coalesce(MAX(concept_set_item_id), 1) FROM ${ohdsiSchema}.concept_set_item;
+SET @sql = N'ALTER SEQUENCE ${ohdsiSchema}.concept_set_item_sequence RESTART WITH ' + CAST(@concept_set_item_id_val AS NVARCHAR(20)) + ';'
+EXEC sp_executesql @sql;
+GO
+
+CREATE SEQUENCE ${ohdsiSchema}.negative_controls_sequence;
+GO
+
+ALTER TABLE ${ohdsiSchema}.concept_set_negative_controls ADD id_tmp INT;
+GO
+
+UPDATE ${ohdsiSchema}.concept_set_negative_controls SET id_tmp = id;
+GO
+
+DECLARE @sql NVARCHAR(MAX), @pk NVARCHAR(512);
+SELECT @pk = name FROM sys.key_constraints where [type] = 'PK' AND parent_object_id = OBJECT_ID('${ohdsiSchema}.concept_set_negative_controls');
+SET @sql = 'ALTER TABLE ${ohdsiSchema}.concept_set_negative_controls DROP CONSTRAINT ' + @pk + ';';
+EXEC sp_executesql @sql;
+GO
+
+ALTER TABLE ${ohdsiSchema}.concept_set_negative_controls DROP COLUMN id;
+GO
+
+EXEC sp_rename '${ohdsiSchema}.concept_set_negative_controls.id_tmp', 'id', 'COLUMN';
+GO
+
+ALTER TABLE ${ohdsiSchema}.concept_set_negative_controls ALTER COLUMN id INT NOT NULL;
+GO
+
+ALTER TABLE ${ohdsiSchema}.concept_set_negative_controls ADD CONSTRAINT PK_concept_set_negative_controls_id PRIMARY KEY CLUSTERED(id);
+GO
+
+DECLARE @sql NVARCHAR(MAX);
+DECLARE @id_val INT;
+SELECT @id_val = coalesce(MAX(id), 1) FROM ${ohdsiSchema}.concept_set_negative_controls;
+SET @sql = N'ALTER SEQUENCE ${ohdsiSchema}.negative_controls_sequence RESTART WITH ' + CAST(@id_val AS NVARCHAR(20)) + ';';
+EXEC sp_executesql @sql;
+GO
+
+CREATE SEQUENCE ${ohdsiSchema}.feasibility_study_sequence;
+GO
+
+ALTER TABLE ${ohdsiSchema}.feasibility_study ADD id_tmp INT;
+GO
+
+UPDATE ${ohdsiSchema}.feasibility_study SET id_tmp = id;
+GO
+
+ALTER TABLE ${ohdsiSchema}.feasibility_inclusion DROP CONSTRAINT FK_feasibility_inclusion_feasibility_study;
+GO
+
+ALTER TABLE ${ohdsiSchema}.feas_study_generation_info DROP CONSTRAINT FK_feas_study_generation_info_feasibility_study;
+GO
+
+DECLARE @sql NVARCHAR(MAX), @pk NVARCHAR(512);
+SELECT @pk = name FROM sys.key_constraints where [type] = 'PK' AND parent_object_id = OBJECT_ID('${ohdsiSchema}.feasibility_study');
+SET @sql = 'ALTER TABLE ${ohdsiSchema}.feasibility_study DROP CONSTRAINT ' + @pk + ';';
+EXEC sp_executesql @sql;
+GO
+
+ALTER TABLE ${ohdsiSchema}.feasibility_study DROP COLUMN id;
+GO
+
+EXEC sp_rename '${ohdsiSchema}.feasibility_study.id_tmp', 'id', 'COLUMN';
+GO
+
+ALTER TABLE ${ohdsiSchema}.feasibility_study ALTER COLUMN id INT NOT NULL;
+GO
+
+ALTER TABLE ${ohdsiSchema}.feasibility_study ADD CONSTRAINT PK_feasibility_study_id PRIMARY KEY CLUSTERED(id);
+GO
+
+ALTER TABLE ${ohdsiSchema}.feasibility_inclusion ADD CONSTRAINT FK_feasibility_inclusion_feasibility_study
+  FOREIGN KEY (study_id) REFERENCES ${ohdsiSchema}.feasibility_study (id);
+GO
+
+ALTER TABLE [${ohdsiSchema}].[feas_study_generation_info]
+  ADD CONSTRAINT [FK_feas_study_generation_info_feasibility_study] FOREIGN KEY ([study_id]) REFERENCES [${ohdsiSchema}].[feasibility_study] ([id]);
+GO
+
+DECLARE @sql NVARCHAR(MAX);
+DECLARE @id_val INT;
+SELECT @id_val = coalesce(MAX(id), 1) FROM ${ohdsiSchema}.feasibility_study;
+SET @sql = N'ALTER SEQUENCE ${ohdsiSchema}.feasibility_study_sequence RESTART WITH ' + CAST(@id_val AS NVARCHAR(20)) + ';';
+EXEC sp_executesql @sql;
+GO
+
+CREATE SEQUENCE ${ohdsiSchema}.ir_analysis_sequence;
+GO
+
+ALTER TABLE ${ohdsiSchema}.ir_analysis ADD id_tmp INT;
+GO
+
+UPDATE ${ohdsiSchema}.ir_analysis SET id_tmp = id;
+GO
+
+ALTER TABLE ${ohdsiSchema}.ir_analysis_details DROP CONSTRAINT FK_irad_ira;
+GO
+
+DECLARE @sql NVARCHAR(MAX), @pk NVARCHAR(512);
+SELECT @pk = name FROM sys.key_constraints where [type] = 'PK' AND parent_object_id = OBJECT_ID('${ohdsiSchema}.ir_analysis');
+SET @sql = 'ALTER TABLE ${ohdsiSchema}.ir_analysis DROP CONSTRAINT ' + @pk + ';';
+EXEC sp_executesql @sql;
+GO
+
+ALTER TABLE ${ohdsiSchema}.ir_analysis DROP COLUMN id;
+GO
+
+EXEC sp_rename '${ohdsiSchema}.ir_analysis.id_tmp', 'id', 'COLUMN'
+GO
+
+ALTER TABLE ${ohdsiSchema}.ir_analysis ALTER COLUMN id INT NOT NULL;
+GO
+
+ALTER TABLE ${ohdsiSchema}.ir_analysis ADD CONSTRAINT PK_ir_analysis_id PRIMARY KEY CLUSTERED(id);
+GO
+
+ALTER TABLE ${ohdsiSchema}.ir_analysis_details ADD CONSTRAINT FK_irad_ira
+    FOREIGN KEY (id) REFERENCES ${ohdsiSchema}.ir_analysis(id);
+GO
+
+DECLARE @sql NVARCHAR(MAX);
+DECLARE @id_val INT;
+SELECT @id_val = coalesce(MAX(id), 1) FROM ${ohdsiSchema}.ir_analysis;
+SET @sql = N'ALTER SEQUENCE ${ohdsiSchema}.ir_analysis_sequence RESTART WITH ' + CAST(@id_val AS NVARCHAR(20)) + ';';
+EXEC sp_executesql @sql;
+GO
+
+CREATE SEQUENCE ${ohdsiSchema}.plp_sequence;
+GO
+
+ALTER TABLE ${ohdsiSchema}.plp ADD plp_id_tmp INT;
+GO
+
+UPDATE ${ohdsiSchema}.plp SET plp_id_tmp = plp_id;
+GO
+
+ALTER TABLE ${ohdsiSchema}.plp DROP COLUMN plp_id;
+GO
+
+EXEC sp_rename '${ohdsiSchema}.plp.plp_id_tmp', 'plp_id', 'COLUMN';
+GO
+
+ALTER TABLE ${ohdsiSchema}.plp ALTER COLUMN plp_id INT NOT NULL;
+GO
+
+ALTER TABLE ${ohdsiSchema}.plp ADD CONSTRAINT PK_plp_plp_id PRIMARY KEY CLUSTERED(plp_id);
+GO
+
+DECLARE @sql NVARCHAR(MAX);
+DECLARE @plp_id_val INT;
+SELECT @plp_id_val = coalesce(MAX(plp_id), 1) FROM ${ohdsiSchema}.plp;
+SET @sql = N'ALTER SEQUENCE ${ohdsiSchema}.plp_sequence RESTART WITH ' + CAST(@plp_id_val AS NVARCHAR(20)) + ';';
+GO


### PR DESCRIPTION
Continuation of work from @wivern as part of #324.

Add fix for Flyway migration for PostgreSQL. With this fix applied, the changes look good from my side for PostgreSQL. I've also added a commit to address a regression in another SQL Server flyway script for dropping the password/salt fields for the sec_user table per @chrisknoll's issue raised on: https://github.com/OHDSI/WebAPI/pull/327#pullrequestreview-97933012

Tagging @chen-regen for awareness and help testing on Oracle. 