### PR TITLE
New cdm results drilldown details

### DIFF
--- a/src/main/resources/resources/cdmresults/sql/report/measurement/drilldown/byOperator.sql
+++ b/src/main/resources/resources/cdmresults/sql/report/measurement/drilldown/byOperator.sql
@@ -1,0 +1,12 @@
+SELECT
+  c1.concept_id   AS observation_concept_id,
+  c1.concept_name AS observation_concept_name,
+  c2.concept_id   AS concept_id,
+  c2.concept_name AS concept_name,
+  ar1.count_value AS count_value
+FROM @results_database_schema.ACHILLES_results ar1
+  LEFT JOIN @vocab_database_schema.concept c1 ON CAST(ar1.stratum_1 AS INT) = c1.concept_id
+  LEFT JOIN @vocab_database_schema.concept c2 ON CAST(ar1.stratum_2 AS INT) = c2.concept_id
+WHERE ar1.analysis_id = 1823
+      AND CAST(ar1.stratum_1 AS INT) = @conceptId
+;

--- a/src/main/resources/resources/cdmresults/sql/report/measurement/drilldown/byValueAsConcept.sql
+++ b/src/main/resources/resources/cdmresults/sql/report/measurement/drilldown/byValueAsConcept.sql
@@ -1,0 +1,12 @@
+SELECT
+  c1.concept_id   AS observation_concept_id,
+  c1.concept_name AS observation_concept_name,
+  c2.concept_id   AS concept_id,
+  c2.concept_name AS concept_name,
+  ar1.count_value AS count_value
+FROM @results_database_schema.ACHILLES_results ar1
+  LEFT JOIN @vocab_database_schema.concept c1 ON CAST(ar1.stratum_1 AS INT) = c1.concept_id
+  LEFT JOIN @vocab_database_schema.concept c2 ON CAST(ar1.stratum_2 AS INT) = c2.concept_id
+WHERE ar1.analysis_id = 1822
+AND CAST(ar1.stratum_1 AS INT) = @conceptId
+;

--- a/src/main/resources/resources/cdmresults/sql/report/observation/drilldown/byQualifier.sql
+++ b/src/main/resources/resources/cdmresults/sql/report/observation/drilldown/byQualifier.sql
@@ -1,0 +1,12 @@
+SELECT
+  c1.concept_id   AS observation_concept_id,
+  c1.concept_name AS observation_concept_name,
+  c2.concept_id   AS concept_id,
+  c2.concept_name AS concept_name,
+  ar1.count_value AS count_value
+FROM @results_database_schema.ACHILLES_results ar1
+  LEFT JOIN @vocab_database_schema.concept c1 ON CAST(ar1.stratum_1 AS INT) = c1.concept_id
+  LEFT JOIN @vocab_database_schema.concept c2 ON CAST(ar1.stratum_2 AS INT) = c2.concept_id
+WHERE ar1.analysis_id = 823
+      AND CAST(ar1.stratum_1 AS INT) = @conceptId
+;

--- a/src/main/resources/resources/cdmresults/sql/report/observation/drilldown/byValueAsConcept.sql
+++ b/src/main/resources/resources/cdmresults/sql/report/observation/drilldown/byValueAsConcept.sql
@@ -1,0 +1,12 @@
+SELECT
+  c1.concept_id   AS observation_concept_id,
+  c1.concept_name AS observation_concept_name,
+  c2.concept_id   AS concept_id,
+  c2.concept_name AS concept_name,
+  ar1.count_value AS count_value
+FROM @results_database_schema.ACHILLES_results ar1
+  LEFT JOIN @vocab_database_schema.concept c1 ON CAST(ar1.stratum_1 AS INT) = c1.concept_id
+  LEFT JOIN @vocab_database_schema.concept c2 ON CAST(ar1.stratum_2 AS INT) = c2.concept_id
+WHERE ar1.analysis_id = 822
+AND CAST(ar1.stratum_1 AS INT) = @conceptId
+;


### PR DESCRIPTION
Adds three new drilldown details to cdmresults, for the following Achilles analyses:
* 822 and 1822, for distribution of `value_as_concept_id` in observation and measurement tables
* 823 for distribution of  `qualifier_concept_id` in observation table
* 1823 for distribution of `operator_concept_id` in measurement table

This data will be used in Atlas/Data Sources for new donut charts. Related PR in Atlas: https://github.com/OHDSI/Atlas/pull/672

For more background see: http://forums.ohdsi.org/t/achilles-proposal-for-new-observation-measurement-value-visualisation/4340