### PR TITLE
Externalize impala JDBC drivers from repository folders.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -110,7 +110,7 @@
 		<executionengine.token>Basic YWRtaW5Ab2R5c3NldXNpbmMuY29tOnBhc3N3b3Jk</executionengine.token>
 		<executionengine.updateStatusCallback>http://localhost:8080/WebAPI/executionservice/callbacks/submission/{id}/status/update/{password}</executionengine.updateStatusCallback>
 		<executionengine.resultCallback>http://localhost:8080/WebAPI/executionservice/callbacks/submission/{id}/result/{password}</executionengine.resultCallback>
-    
+		    
   </properties>
   <build>
     <finalName>WebAPI</finalName>
@@ -720,6 +720,8 @@
       <id>webapi-impala</id>
       <properties>
         <impala.enabled>true</impala.enabled>
+				<!-- Impala JDBC driver path -->
+				<impala.classpath>...path/to/impala/jdbc/drivers...</impala.classpath>
       </properties>
       <dependencies>
         <dependency>
@@ -782,7 +784,7 @@
                   <artifactId>ImpalaJDBC41</artifactId>
                   <version>2.5.41</version>
                   <packaging>jar</packaging>
-                  <file>${basedir}/src/main/extras/impala/ImpalaJDBC41.jar</file>
+                  <file>${impala.classpath}/ImpalaJDBC41.jar</file>
                 </configuration>
               </execution>
               <execution>
@@ -796,7 +798,7 @@
                   <artifactId>hive_metastore</artifactId>
                   <version>1.0.0</version>
                   <packaging>jar</packaging>
-                  <file>${basedir}/src/main/extras/impala/hive_metastore.jar</file>
+                  <file>${impala.classpath}/hive_metastore.jar</file>
                 </configuration>
               </execution>
               <execution>
@@ -810,7 +812,7 @@
                   <artifactId>hive_service</artifactId>
                   <version>1.0.0</version>
                   <packaging>jar</packaging>
-                  <file>${basedir}/src/main/extras/impala/hive_service.jar</file>
+                  <file>${impala.classpath}/hive_service.jar</file>
                 </configuration>
               </execution>
               <execution>
@@ -824,7 +826,7 @@
                   <artifactId>libfb303</artifactId>
                   <version>0.9.0</version>
                   <packaging>jar</packaging>
-                  <file>${basedir}/src/main/extras/impala/libfb303-0.9.0.jar</file>
+                  <file>${impala.classpath}/libfb303-0.9.0.jar</file>
                 </configuration>
               </execution>
               <execution>
@@ -838,7 +840,7 @@
                   <artifactId>libthrift</artifactId>
                   <version>0.9.0</version>
                   <packaging>jar</packaging>
-                  <file>${basedir}/src/main/extras/impala/libthrift-0.9.0.jar</file>
+                  <file>${impala.classpath}/libthrift-0.9.0.jar</file>
                 </configuration>
               </execution>
               <execution>
@@ -852,7 +854,7 @@
                   <artifactId>ql</artifactId>
                   <version>1.0.0</version>
                   <packaging>jar</packaging>
-                  <file>${basedir}/src/main/extras/impala/ql.jar</file>
+                  <file>${impala.classpath}/ql.jar</file>
                 </configuration>
               </execution>
               <execution>
@@ -866,7 +868,7 @@
                   <artifactId>TCLI</artifactId>
                   <version>1.0.0</version>
                   <packaging>jar</packaging>
-                  <file>${basedir}/src/main/extras/impala/TCLIServiceClient.jar</file>
+                  <file>${impala.classpath}/TCLIServiceClient.jar</file>
                 </configuration>
               </execution>
             </executions>

--- a/src/main/extras/impala/README.md
+++ b/src/main/extras/impala/README.md
@@ -1,8 +1,7 @@
 To build WebAPI with Impala support do the following:
 1. Go to the https://www.cloudera.com/downloads/connectors/impala/jdbc/2-5-43.html
-1. Register to clouder if you did not registered earlier or sign in to your Cloudera account
-1. Download the latest Impala JDBC drivers
-1. Unpack archive and copy all jars from directory with name looks like ClouderaImpalaJDBC41 here.
-1. Build WebAPI with webapi-impala profile. 
+2. Register to clouder if you did not registered earlier or sign in to your Cloudera account
+3. Download the latest Impala JDBC drivers
+4. Unpack archive and and set the impala.classpath property in your settings.xml to the unpacked archive location (ie: C://downloads/impalaJDBC) inside the webapi-impala profile.
+5. Build WebAPI with webapi-impala profile. 
    * mvn -Pwebapi-postgresql,webapi-impala clean package
-


### PR DESCRIPTION
This is a proposed alternative to impala_support PR #405.  

In #405, the jdbc drivers need to be copied into a folder under the WebAPI repository.  With this PR, the user instead unpacks their drivers anywhere on their drive (does not have to be under WebAPI repo) and specifies the path to the folder in a settings config property: 'impala.classpath'.

