### PR TITLE
Fixes possibility of duplicates presence in sec_role table

### DIFF
--- a/src/main/resources/db/migration/oracle/V2.4.0.20180516223100__roles-unique.sql
+++ b/src/main/resources/db/migration/oracle/V2.4.0.20180516223100__roles-unique.sql
@@ -1,0 +1,1 @@
+alter table ${ohdsiSchema}.sec_role ADD CONSTRAINT sec_role_name_uq UNIQUE (name);

--- a/src/main/resources/db/migration/postgresql/V2.4.0.20180516223100__roles-unique.sql
+++ b/src/main/resources/db/migration/postgresql/V2.4.0.20180516223100__roles-unique.sql
@@ -1,0 +1,1 @@
+alter table ${ohdsiSchema}.sec_role ADD CONSTRAINT sec_role_name_uq UNIQUE (name);

--- a/src/main/resources/db/migration/sqlserver/V2.4.0.20180516223100__roles-unique.sql
+++ b/src/main/resources/db/migration/sqlserver/V2.4.0.20180516223100__roles-unique.sql
@@ -1,0 +1,1 @@
+alter table ${ohdsiSchema}.sec_role ADD CONSTRAINT sec_role_name_uq UNIQUE (name);


### PR DESCRIPTION
Fixes https://github.com/OHDSI/WebAPI/issues/420

In case of consistent DB (w/o duplicates in sec_role), migration will work OK. Otherwise, it will fail, so manual clean up is required.