### PR TITLE
Fixes for Heracles analysis in Netezza

### DIFF
--- a/src/main/resources/resources/cohortanalysis/sql/runHeraclesAnalyses.sql
+++ b/src/main/resources/resources/cohortanalysis/sql/runHeraclesAnalyses.sql
@@ -13687,33 +13687,39 @@ DROP TABLE #raw_period_4023;
   AND 1.0 * abs(ar2.count_value - her1.count_value) / her1.count_value > 1
   AND her1.count_value > 10;
   
-  --WARNING:  monthly change > 100% at concept level
-  INSERT INTO @results_schema.HERACLES_HEEL_results (
-  cohort_definition_id,
-  analysis_id,
-  HERACLES_HEEL_warning
-  )
-  SELECT her1.cohort_definition_id,
+--WARNING:  monthly change > 100% at concept level
+WITH hr AS (
+    SELECT
+      cohort_definition_id,
+      analysis_id,
+      stratum_1,
+      CAST((CASE WHEN stratum_2 = ''
+        THEN NULL
+            ELSE stratum_2 END) AS INT) stratum_2,
+      count_value
+    FROM @results_schema.HERACLES_results
+    WHERE analysis_id IN (
+      402,
+      602,
+      702,
+      802,
+      902,
+      1002
+    )
+)
+SELECT her1.cohort_definition_id,
   her1.analysis_id,
-  'WARNING: ' + cast(her1.analysis_id as VARCHAR) + '-' + aa1.analysis_name + '; ' + cast(COUNT_BIG(DISTINCT her1.stratum_1) AS VARCHAR) + ' concepts have a 100% change in monthly count of events' AS HERACLES_HEEL_warning
+  'WARNING: ' || CAST(her1.analysis_id  AS VARCHAR(1000)) || '-' || aa1.analysis_name || '; ' || CAST(COUNT(DISTINCT her1.stratum_1)  AS VARCHAR(1000)) || 'concepts have a 100% change in monthly count of events' AS HERACLES_HEEL_warning
   FROM @results_schema.HERACLES_analysis aa1
-  INNER JOIN @results_schema.HERACLES_results her1
+  INNER JOIN hr her1
   ON aa1.analysis_id = her1.analysis_id
-  INNER JOIN @results_schema.HERACLES_results ar2
+  INNER JOIN hr ar2
   ON her1.analysis_id = ar2.analysis_id
   and her1.cohort_definition_id = ar2.cohort_definition_id
   AND her1.stratum_1 = ar2.stratum_1
-  AND her1.analysis_id IN (
-  402,
-  602,
-  702,
-  802,
-  902,
-  1002
-  )
   WHERE (
-  CAST(her1.stratum_2 AS INT) + 1 = CAST(ar2.stratum_2 AS INT)
-  OR CAST(her1.stratum_2 AS INT) + 89 = CAST(ar2.stratum_2 AS INT)
+    her1.stratum_2 + 1 = ar2.stratum_2
+    OR her1.stratum_2 + 89 = ar2.stratum_2
   )
   and her1.cohort_definition_id in (@cohort_definition_id)
   AND 1.0 * abs(ar2.count_value - her1.count_value) / her1.count_value > 1

--- a/src/main/resources/resources/cohortanalysis/sql/runHeraclesAnalyses.sql
+++ b/src/main/resources/resources/cohortanalysis/sql/runHeraclesAnalyses.sql
@@ -13714,7 +13714,7 @@ INSERT INTO @results_schema.HERACLES_HEEL_results
 )
 SELECT her1.cohort_definition_id,
   her1.analysis_id,
-  'WARNING: ' + CAST(her1.analysis_id  AS VARCHAR(1000)) + '-' + aa1.analysis_name + '; ' + CAST(COUNT(DISTINCT her1.stratum_1)  AS VARCHAR(1000)) + 'concepts have a 100% change in monthly count of events' AS HERACLES_HEEL_warning
+  'WARNING: ' + CAST(her1.analysis_id  AS VARCHAR(1000)) + '-' + aa1.analysis_name + '; ' + CAST(COUNT_BIG(DISTINCT her1.stratum_1)  AS VARCHAR(1000)) + 'concepts have a 100% change in monthly count of events' AS HERACLES_HEEL_warning
   FROM @results_schema.HERACLES_analysis aa1
   INNER JOIN hr her1
   ON aa1.analysis_id = her1.analysis_id

--- a/src/main/resources/resources/cohortanalysis/sql/runHeraclesAnalyses.sql
+++ b/src/main/resources/resources/cohortanalysis/sql/runHeraclesAnalyses.sql
@@ -13714,7 +13714,7 @@ INSERT INTO @results_schema.HERACLES_HEEL_results
 )
 SELECT her1.cohort_definition_id,
   her1.analysis_id,
-  'WARNING: ' || CAST(her1.analysis_id  AS VARCHAR(1000)) || '-' || aa1.analysis_name || '; ' || CAST(COUNT(DISTINCT her1.stratum_1)  AS VARCHAR(1000)) || 'concepts have a 100% change in monthly count of events' AS HERACLES_HEEL_warning
+  'WARNING: ' + CAST(her1.analysis_id  AS VARCHAR(1000)) + '-' + aa1.analysis_name + '; ' + CAST(COUNT(DISTINCT her1.stratum_1)  AS VARCHAR(1000)) + 'concepts have a 100% change in monthly count of events' AS HERACLES_HEEL_warning
   FROM @results_schema.HERACLES_analysis aa1
   INNER JOIN hr her1
   ON aa1.analysis_id = her1.analysis_id

--- a/src/main/resources/resources/cohortanalysis/sql/runHeraclesAnalyses.sql
+++ b/src/main/resources/resources/cohortanalysis/sql/runHeraclesAnalyses.sql
@@ -13707,6 +13707,11 @@ WITH hr AS (
       1002
     )
 )
+INSERT INTO @results_schema.HERACLES_HEEL_results
+  cohort_definition_id,
+  analysis_id,
+  HERACLES_HEEL_warning
+)
 SELECT her1.cohort_definition_id,
   her1.analysis_id,
   'WARNING: ' || CAST(her1.analysis_id  AS VARCHAR(1000)) || '-' || aa1.analysis_name || '; ' || CAST(COUNT(DISTINCT her1.stratum_1)  AS VARCHAR(1000)) || 'concepts have a 100% change in monthly count of events' AS HERACLES_HEEL_warning


### PR DESCRIPTION
Closes https://github.com/OHDSI/WebAPI/issues/446

For some reason, Netezza processed CASTs first and filtering by ids list then. That's why it tried to CAST('' AS INTEGER) which was causing an exception. Also VARCHARs length was not specified