### PR TITLE
Updated inits of heracles_analysis table to use more performant insert

### DIFF
--- a/src/main/resources/ddl/results/initTables.sql
+++ b/src/main/resources/ddl/results/initTables.sql
@@ -3,6 +3,7 @@
 TRUNCATE TABLE @results_schema.heracles_analysis;
 
 insert into @results_schema.heracles_analysis
+(analysis_id,analysis_name,stratum_1_name,stratum_2_name,stratum_3_name,stratum_4_name,stratum_5_name,analysis_type)
 select    0 as analysis_id,
 CAST('Source name' as VARCHAR(255)) as analysis_name,
 NULL as stratum_1_name,

--- a/src/main/resources/ddl/results/initTables.sql
+++ b/src/main/resources/ddl/results/initTables.sql
@@ -2,190 +2,1669 @@
 
 TRUNCATE TABLE @results_schema.heracles_analysis;
 
-insert into @results_schema.heracles_analysis (ANALYSIS_ID,ANALYSIS_NAME,STRATUM_1_NAME,STRATUM_2_NAME,STRATUM_3_NAME,STRATUM_4_NAME,STRATUM_5_NAME,ANALYSIS_TYPE) values (0,'Source name',null,null,null,null,null,'PERSON');
-insert into @results_schema.heracles_analysis (ANALYSIS_ID,ANALYSIS_NAME,STRATUM_1_NAME,STRATUM_2_NAME,STRATUM_3_NAME,STRATUM_4_NAME,STRATUM_5_NAME,ANALYSIS_TYPE) values (1,'Number of persons',null,null,null,null,null,'PERSON');
-insert into @results_schema.heracles_analysis (ANALYSIS_ID,ANALYSIS_NAME,STRATUM_1_NAME,STRATUM_2_NAME,STRATUM_3_NAME,STRATUM_4_NAME,STRATUM_5_NAME,ANALYSIS_TYPE) values (2,'Number of persons by gender','gender_concept_id',null,null,null,null,'PERSON');
-insert into @results_schema.heracles_analysis (ANALYSIS_ID,ANALYSIS_NAME,STRATUM_1_NAME,STRATUM_2_NAME,STRATUM_3_NAME,STRATUM_4_NAME,STRATUM_5_NAME,ANALYSIS_TYPE) values (3,'Number of persons by year of birth','year_of_birth',null,null,null,null,'PERSON');
-insert into @results_schema.heracles_analysis (ANALYSIS_ID,ANALYSIS_NAME,STRATUM_1_NAME,STRATUM_2_NAME,STRATUM_3_NAME,STRATUM_4_NAME,STRATUM_5_NAME,ANALYSIS_TYPE) values (4,'Number of persons by race','race_concept_id',null,null,null,null,'PERSON');
-insert into @results_schema.heracles_analysis (ANALYSIS_ID,ANALYSIS_NAME,STRATUM_1_NAME,STRATUM_2_NAME,STRATUM_3_NAME,STRATUM_4_NAME,STRATUM_5_NAME,ANALYSIS_TYPE) values (5,'Number of persons by ethnicity','ethnicity_concept_id',null,null,null,null,'PERSON');
-insert into @results_schema.heracles_analysis (ANALYSIS_ID,ANALYSIS_NAME,STRATUM_1_NAME,STRATUM_2_NAME,STRATUM_3_NAME,STRATUM_4_NAME,STRATUM_5_NAME,ANALYSIS_TYPE) values (7,'Number of persons with invalid provider_id',null,null,null,null,null,'PERSON');
-insert into @results_schema.heracles_analysis (ANALYSIS_ID,ANALYSIS_NAME,STRATUM_1_NAME,STRATUM_2_NAME,STRATUM_3_NAME,STRATUM_4_NAME,STRATUM_5_NAME,ANALYSIS_TYPE) values (8,'Number of persons with invalid location_id',null,null,null,null,null,'PERSON');
-insert into @results_schema.heracles_analysis (ANALYSIS_ID,ANALYSIS_NAME,STRATUM_1_NAME,STRATUM_2_NAME,STRATUM_3_NAME,STRATUM_4_NAME,STRATUM_5_NAME,ANALYSIS_TYPE) values (9,'Number of persons with invalid care_site_id',null,null,null,null,null,'PERSON');
-insert into @results_schema.heracles_analysis (ANALYSIS_ID,ANALYSIS_NAME,STRATUM_1_NAME,STRATUM_2_NAME,STRATUM_3_NAME,STRATUM_4_NAME,STRATUM_5_NAME,ANALYSIS_TYPE) values (101,'Number of persons by age, with age at first observation period','age',null,null,null,null,'OBSERVATION');
-insert into @results_schema.heracles_analysis (ANALYSIS_ID,ANALYSIS_NAME,STRATUM_1_NAME,STRATUM_2_NAME,STRATUM_3_NAME,STRATUM_4_NAME,STRATUM_5_NAME,ANALYSIS_TYPE) values (102,'Number of persons by gender by age, with age at first observation period','gender_concept_id','age',null,null,null,'OBSERVATION');
-insert into @results_schema.heracles_analysis (ANALYSIS_ID,ANALYSIS_NAME,STRATUM_1_NAME,STRATUM_2_NAME,STRATUM_3_NAME,STRATUM_4_NAME,STRATUM_5_NAME,ANALYSIS_TYPE) values (103,'Distribution of age at first observation period',null,null,null,null,null,'OBSERVATION');
-insert into @results_schema.heracles_analysis (ANALYSIS_ID,ANALYSIS_NAME,STRATUM_1_NAME,STRATUM_2_NAME,STRATUM_3_NAME,STRATUM_4_NAME,STRATUM_5_NAME,ANALYSIS_TYPE) values (104,'Distribution of age at first observation period by gender','gender_concept_id',null,null,null,null,'OBSERVATION');
-insert into @results_schema.heracles_analysis (ANALYSIS_ID,ANALYSIS_NAME,STRATUM_1_NAME,STRATUM_2_NAME,STRATUM_3_NAME,STRATUM_4_NAME,STRATUM_5_NAME,ANALYSIS_TYPE) values (105,'Length of observation (days) of first observation period',null,null,null,null,null,'OBSERVATION');
-insert into @results_schema.heracles_analysis (ANALYSIS_ID,ANALYSIS_NAME,STRATUM_1_NAME,STRATUM_2_NAME,STRATUM_3_NAME,STRATUM_4_NAME,STRATUM_5_NAME,ANALYSIS_TYPE) values (106,'Length of observation (days) of first observation period by gender','gender_concept_id',null,null,null,null,'OBSERVATION');
-insert into @results_schema.heracles_analysis (ANALYSIS_ID,ANALYSIS_NAME,STRATUM_1_NAME,STRATUM_2_NAME,STRATUM_3_NAME,STRATUM_4_NAME,STRATUM_5_NAME,ANALYSIS_TYPE) values (107,'Length of observation (days) of first observation period by age decile','age decile',null,null,null,null,'OBSERVATION');
-insert into @results_schema.heracles_analysis (ANALYSIS_ID,ANALYSIS_NAME,STRATUM_1_NAME,STRATUM_2_NAME,STRATUM_3_NAME,STRATUM_4_NAME,STRATUM_5_NAME,ANALYSIS_TYPE) values (108,'Number of persons by length of observation period, in 30d increments','Observation period length 30d increments',null,null,null,null,'OBSERVATION');
-insert into @results_schema.heracles_analysis (ANALYSIS_ID,ANALYSIS_NAME,STRATUM_1_NAME,STRATUM_2_NAME,STRATUM_3_NAME,STRATUM_4_NAME,STRATUM_5_NAME,ANALYSIS_TYPE) values (109,'Number of persons with continuous observation in each year','calendar year',null,null,null,null,'OBSERVATION');
-insert into @results_schema.heracles_analysis (ANALYSIS_ID,ANALYSIS_NAME,STRATUM_1_NAME,STRATUM_2_NAME,STRATUM_3_NAME,STRATUM_4_NAME,STRATUM_5_NAME,ANALYSIS_TYPE) values (110,'Number of persons with continuous observation in each month','calendar month',null,null,null,null,'OBSERVATION');
-insert into @results_schema.heracles_analysis (ANALYSIS_ID,ANALYSIS_NAME,STRATUM_1_NAME,STRATUM_2_NAME,STRATUM_3_NAME,STRATUM_4_NAME,STRATUM_5_NAME,ANALYSIS_TYPE) values (111,'Number of persons by observation period start month','calendar month',null,null,null,null,'OBSERVATION');
-insert into @results_schema.heracles_analysis (ANALYSIS_ID,ANALYSIS_NAME,STRATUM_1_NAME,STRATUM_2_NAME,STRATUM_3_NAME,STRATUM_4_NAME,STRATUM_5_NAME,ANALYSIS_TYPE) values (112,'Number of persons by observation period end month','calendar month',null,null,null,null,'OBSERVATION');
-insert into @results_schema.heracles_analysis (ANALYSIS_ID,ANALYSIS_NAME,STRATUM_1_NAME,STRATUM_2_NAME,STRATUM_3_NAME,STRATUM_4_NAME,STRATUM_5_NAME,ANALYSIS_TYPE) values (113,'Number of persons by number of observation periods','number of observation periods',null,null,null,null,'OBSERVATION');
-insert into @results_schema.heracles_analysis (ANALYSIS_ID,ANALYSIS_NAME,STRATUM_1_NAME,STRATUM_2_NAME,STRATUM_3_NAME,STRATUM_4_NAME,STRATUM_5_NAME,ANALYSIS_TYPE) values (114,'Number of persons with observation period before year-of-birth',null,null,null,null,null,'OBSERVATION');
-insert into @results_schema.heracles_analysis (ANALYSIS_ID,ANALYSIS_NAME,STRATUM_1_NAME,STRATUM_2_NAME,STRATUM_3_NAME,STRATUM_4_NAME,STRATUM_5_NAME,ANALYSIS_TYPE) values (115,'Number of persons with observation period end < observation period start',null,null,null,null,null,'OBSERVATION');
-insert into @results_schema.heracles_analysis (ANALYSIS_ID,ANALYSIS_NAME,STRATUM_1_NAME,STRATUM_2_NAME,STRATUM_3_NAME,STRATUM_4_NAME,STRATUM_5_NAME,ANALYSIS_TYPE) values (116,'Number of persons with at least one day of observation in each year by gender and age decile','calendar year','gender_concept_id','age decile',null,null,'OBSERVATION');
-insert into @results_schema.heracles_analysis (ANALYSIS_ID,ANALYSIS_NAME,STRATUM_1_NAME,STRATUM_2_NAME,STRATUM_3_NAME,STRATUM_4_NAME,STRATUM_5_NAME,ANALYSIS_TYPE) values (117,'Number of persons with at least one day of observation in each month','calendar month',null,null,null,null,'OBSERVATION');
-insert into @results_schema.heracles_analysis (ANALYSIS_ID,ANALYSIS_NAME,STRATUM_1_NAME,STRATUM_2_NAME,STRATUM_3_NAME,STRATUM_4_NAME,STRATUM_5_NAME,ANALYSIS_TYPE) values (200,'Number of persons with at least one visit occurrence, by visit_concept_id','visit_concept_id',null,null,null,null,'VISITS');
-insert into @results_schema.heracles_analysis (ANALYSIS_ID,ANALYSIS_NAME,STRATUM_1_NAME,STRATUM_2_NAME,STRATUM_3_NAME,STRATUM_4_NAME,STRATUM_5_NAME,ANALYSIS_TYPE) values (201,'Number of visit occurrence records, by visit_concept_id','visit_concept_id',null,null,null,null,'VISITS');
-insert into @results_schema.heracles_analysis (ANALYSIS_ID,ANALYSIS_NAME,STRATUM_1_NAME,STRATUM_2_NAME,STRATUM_3_NAME,STRATUM_4_NAME,STRATUM_5_NAME,ANALYSIS_TYPE) values (202,'Number of persons by visit occurrence start month, by visit_concept_id','visit_concept_id','calendar month',null,null,null,'VISITS');
-insert into @results_schema.heracles_analysis (ANALYSIS_ID,ANALYSIS_NAME,STRATUM_1_NAME,STRATUM_2_NAME,STRATUM_3_NAME,STRATUM_4_NAME,STRATUM_5_NAME,ANALYSIS_TYPE) values (203,'Number of distinct visit occurrence concepts per person',null,null,null,null,null,'VISITS');
-insert into @results_schema.heracles_analysis (ANALYSIS_ID,ANALYSIS_NAME,STRATUM_1_NAME,STRATUM_2_NAME,STRATUM_3_NAME,STRATUM_4_NAME,STRATUM_5_NAME,ANALYSIS_TYPE) values (204,'Number of persons with at least one visit occurrence, by visit_concept_id by calendar year by gender by age decile','visit_concept_id','calendar year','gender_concept_id','age decile',null,'VISITS');
-insert into @results_schema.heracles_analysis (ANALYSIS_ID,ANALYSIS_NAME,STRATUM_1_NAME,STRATUM_2_NAME,STRATUM_3_NAME,STRATUM_4_NAME,STRATUM_5_NAME,ANALYSIS_TYPE) values (206,'Distribution of age by visit_concept_id','visit_concept_id','gender_concept_id',null,null,null,'VISITS');
-insert into @results_schema.heracles_analysis (ANALYSIS_ID,ANALYSIS_NAME,STRATUM_1_NAME,STRATUM_2_NAME,STRATUM_3_NAME,STRATUM_4_NAME,STRATUM_5_NAME,ANALYSIS_TYPE) values (207,'Number of visit records with invalid person_id',null,null,null,null,null,'VISITS');
-insert into @results_schema.heracles_analysis (ANALYSIS_ID,ANALYSIS_NAME,STRATUM_1_NAME,STRATUM_2_NAME,STRATUM_3_NAME,STRATUM_4_NAME,STRATUM_5_NAME,ANALYSIS_TYPE) values (208,'Number of visit records outside valid observation period',null,null,null,null,null,'VISITS');
-insert into @results_schema.heracles_analysis (ANALYSIS_ID,ANALYSIS_NAME,STRATUM_1_NAME,STRATUM_2_NAME,STRATUM_3_NAME,STRATUM_4_NAME,STRATUM_5_NAME,ANALYSIS_TYPE) values (209,'Number of visit records with end date < start date',null,null,null,null,null,'VISITS');
-insert into @results_schema.heracles_analysis (ANALYSIS_ID,ANALYSIS_NAME,STRATUM_1_NAME,STRATUM_2_NAME,STRATUM_3_NAME,STRATUM_4_NAME,STRATUM_5_NAME,ANALYSIS_TYPE) values (210,'Number of visit records with invalid care_site_id',null,null,null,null,null,'VISITS');
-insert into @results_schema.heracles_analysis (ANALYSIS_ID,ANALYSIS_NAME,STRATUM_1_NAME,STRATUM_2_NAME,STRATUM_3_NAME,STRATUM_4_NAME,STRATUM_5_NAME,ANALYSIS_TYPE) values (211,'Distribution of length of stay by visit_concept_id','visit_concept_id',null,null,null,null,'VISITS');
-insert into @results_schema.heracles_analysis (ANALYSIS_ID,ANALYSIS_NAME,STRATUM_1_NAME,STRATUM_2_NAME,STRATUM_3_NAME,STRATUM_4_NAME,STRATUM_5_NAME,ANALYSIS_TYPE) values (220,'Number of visit occurrence records by visit occurrence start month','calendar month',null,null,null,null,'VISITS');
-insert into @results_schema.heracles_analysis (ANALYSIS_ID,ANALYSIS_NAME,STRATUM_1_NAME,STRATUM_2_NAME,STRATUM_3_NAME,STRATUM_4_NAME,STRATUM_5_NAME,ANALYSIS_TYPE) values (400,'Number of persons with at least one condition occurrence, by condition_concept_id','condition_concept_id',null,null,null,null,'CONDITION');
-insert into @results_schema.heracles_analysis (ANALYSIS_ID,ANALYSIS_NAME,STRATUM_1_NAME,STRATUM_2_NAME,STRATUM_3_NAME,STRATUM_4_NAME,STRATUM_5_NAME,ANALYSIS_TYPE) values (401,'Number of condition occurrence records, by condition_concept_id','condition_concept_id',null,null,null,null,'CONDITION');
-insert into @results_schema.heracles_analysis (ANALYSIS_ID,ANALYSIS_NAME,STRATUM_1_NAME,STRATUM_2_NAME,STRATUM_3_NAME,STRATUM_4_NAME,STRATUM_5_NAME,ANALYSIS_TYPE) values (402,'Number of persons by condition occurrence start month, by condition_concept_id','condition_concept_id','calendar month',null,null,null,'CONDITION');
-insert into @results_schema.heracles_analysis (ANALYSIS_ID,ANALYSIS_NAME,STRATUM_1_NAME,STRATUM_2_NAME,STRATUM_3_NAME,STRATUM_4_NAME,STRATUM_5_NAME,ANALYSIS_TYPE) values (403,'Number of distinct condition occurrence concepts per person',null,null,null,null,null,'CONDITION');
-insert into @results_schema.heracles_analysis (ANALYSIS_ID,ANALYSIS_NAME,STRATUM_1_NAME,STRATUM_2_NAME,STRATUM_3_NAME,STRATUM_4_NAME,STRATUM_5_NAME,ANALYSIS_TYPE) values (404,'Number of persons with at least one condition occurrence, by condition_concept_id by calendar year by gender by age decile','condition_concept_id','calendar year','gender_concept_id','age decile',null,'CONDITION');
-insert into @results_schema.heracles_analysis (ANALYSIS_ID,ANALYSIS_NAME,STRATUM_1_NAME,STRATUM_2_NAME,STRATUM_3_NAME,STRATUM_4_NAME,STRATUM_5_NAME,ANALYSIS_TYPE) values (405,'Number of condition occurrence records, by condition_concept_id by condition_type_concept_id','condition_concept_id','condition_type_concept_id',null,null,null,'CONDITION');
-insert into @results_schema.heracles_analysis (ANALYSIS_ID,ANALYSIS_NAME,STRATUM_1_NAME,STRATUM_2_NAME,STRATUM_3_NAME,STRATUM_4_NAME,STRATUM_5_NAME,ANALYSIS_TYPE) values (406,'Distribution of age by condition_concept_id','condition_concept_id','gender_concept_id',null,null,null,'CONDITION');
-insert into @results_schema.heracles_analysis (ANALYSIS_ID,ANALYSIS_NAME,STRATUM_1_NAME,STRATUM_2_NAME,STRATUM_3_NAME,STRATUM_4_NAME,STRATUM_5_NAME,ANALYSIS_TYPE) values (409,'Number of condition occurrence records with invalid person_id',null,null,null,null,null,'CONDITION');
-insert into @results_schema.heracles_analysis (ANALYSIS_ID,ANALYSIS_NAME,STRATUM_1_NAME,STRATUM_2_NAME,STRATUM_3_NAME,STRATUM_4_NAME,STRATUM_5_NAME,ANALYSIS_TYPE) values (410,'Number of condition occurrence records outside valid observation period',null,null,null,null,null,'CONDITION');
-insert into @results_schema.heracles_analysis (ANALYSIS_ID,ANALYSIS_NAME,STRATUM_1_NAME,STRATUM_2_NAME,STRATUM_3_NAME,STRATUM_4_NAME,STRATUM_5_NAME,ANALYSIS_TYPE) values (411,'Number of condition occurrence records with end date < start date',null,null,null,null,null,'CONDITION');
-insert into @results_schema.heracles_analysis (ANALYSIS_ID,ANALYSIS_NAME,STRATUM_1_NAME,STRATUM_2_NAME,STRATUM_3_NAME,STRATUM_4_NAME,STRATUM_5_NAME,ANALYSIS_TYPE) values (412,'Number of condition occurrence records with invalid provider_id',null,null,null,null,null,'CONDITION');
-insert into @results_schema.heracles_analysis (ANALYSIS_ID,ANALYSIS_NAME,STRATUM_1_NAME,STRATUM_2_NAME,STRATUM_3_NAME,STRATUM_4_NAME,STRATUM_5_NAME,ANALYSIS_TYPE) values (413,'Number of condition occurrence records with invalid visit_id',null,null,null,null,null,'CONDITION');
-insert into @results_schema.heracles_analysis (ANALYSIS_ID,ANALYSIS_NAME,STRATUM_1_NAME,STRATUM_2_NAME,STRATUM_3_NAME,STRATUM_4_NAME,STRATUM_5_NAME,ANALYSIS_TYPE) values (420,'Number of condition occurrence records by condition occurrence start month','calendar month',null,null,null,null,'CONDITION');
-insert into @results_schema.heracles_analysis (ANALYSIS_ID,ANALYSIS_NAME,STRATUM_1_NAME,STRATUM_2_NAME,STRATUM_3_NAME,STRATUM_4_NAME,STRATUM_5_NAME,ANALYSIS_TYPE) values (500,'Number of persons with death, by cause_of_death_concept_id','cause_of_death_concept_id',null,null,null,null,'DEATH');
-insert into @results_schema.heracles_analysis (ANALYSIS_ID,ANALYSIS_NAME,STRATUM_1_NAME,STRATUM_2_NAME,STRATUM_3_NAME,STRATUM_4_NAME,STRATUM_5_NAME,ANALYSIS_TYPE) values (501,'Number of records of death, by cause_of_death_concept_id','cause_of_death_concept_id',null,null,null,null,'DEATH');
-insert into @results_schema.heracles_analysis (ANALYSIS_ID,ANALYSIS_NAME,STRATUM_1_NAME,STRATUM_2_NAME,STRATUM_3_NAME,STRATUM_4_NAME,STRATUM_5_NAME,ANALYSIS_TYPE) values (502,'Number of persons by death month','calendar month',null,null,null,null,'DEATH');
-insert into @results_schema.heracles_analysis (ANALYSIS_ID,ANALYSIS_NAME,STRATUM_1_NAME,STRATUM_2_NAME,STRATUM_3_NAME,STRATUM_4_NAME,STRATUM_5_NAME,ANALYSIS_TYPE) values (504,'Number of persons with a death, by calendar year by gender by age decile','calendar year','gender_concept_id','age decile',null,null,'DEATH');
-insert into @results_schema.heracles_analysis (ANALYSIS_ID,ANALYSIS_NAME,STRATUM_1_NAME,STRATUM_2_NAME,STRATUM_3_NAME,STRATUM_4_NAME,STRATUM_5_NAME,ANALYSIS_TYPE) values (505,'Number of death records, by death_type_concept_id','death_type_concept_id',null,null,null,null,'DEATH');
-insert into @results_schema.heracles_analysis (ANALYSIS_ID,ANALYSIS_NAME,STRATUM_1_NAME,STRATUM_2_NAME,STRATUM_3_NAME,STRATUM_4_NAME,STRATUM_5_NAME,ANALYSIS_TYPE) values (506,'Distribution of age at death by gender','gender_concept_id',null,null,null,null,'DEATH');
-insert into @results_schema.heracles_analysis (ANALYSIS_ID,ANALYSIS_NAME,STRATUM_1_NAME,STRATUM_2_NAME,STRATUM_3_NAME,STRATUM_4_NAME,STRATUM_5_NAME,ANALYSIS_TYPE) values (509,'Number of death records with invalid person_id',null,null,null,null,null,'DEATH');
-insert into @results_schema.heracles_analysis (ANALYSIS_ID,ANALYSIS_NAME,STRATUM_1_NAME,STRATUM_2_NAME,STRATUM_3_NAME,STRATUM_4_NAME,STRATUM_5_NAME,ANALYSIS_TYPE) values (510,'Number of death records outside valid observation period',null,null,null,null,null,'DEATH');
-insert into @results_schema.heracles_analysis (ANALYSIS_ID,ANALYSIS_NAME,STRATUM_1_NAME,STRATUM_2_NAME,STRATUM_3_NAME,STRATUM_4_NAME,STRATUM_5_NAME,ANALYSIS_TYPE) values (511,'Distribution of time from death to last condition',null,null,null,null,null,'DEATH');
-insert into @results_schema.heracles_analysis (ANALYSIS_ID,ANALYSIS_NAME,STRATUM_1_NAME,STRATUM_2_NAME,STRATUM_3_NAME,STRATUM_4_NAME,STRATUM_5_NAME,ANALYSIS_TYPE) values (512,'Distribution of time from death to last drug',null,null,null,null,null,'DEATH');
-insert into @results_schema.heracles_analysis (ANALYSIS_ID,ANALYSIS_NAME,STRATUM_1_NAME,STRATUM_2_NAME,STRATUM_3_NAME,STRATUM_4_NAME,STRATUM_5_NAME,ANALYSIS_TYPE) values (513,'Distribution of time from death to last visit',null,null,null,null,null,'DEATH');
-insert into @results_schema.heracles_analysis (ANALYSIS_ID,ANALYSIS_NAME,STRATUM_1_NAME,STRATUM_2_NAME,STRATUM_3_NAME,STRATUM_4_NAME,STRATUM_5_NAME,ANALYSIS_TYPE) values (514,'Distribution of time from death to last procedure',null,null,null,null,null,'DEATH');
-insert into @results_schema.heracles_analysis (ANALYSIS_ID,ANALYSIS_NAME,STRATUM_1_NAME,STRATUM_2_NAME,STRATUM_3_NAME,STRATUM_4_NAME,STRATUM_5_NAME,ANALYSIS_TYPE) values (515,'Distribution of time from death to last observation',null,null,null,null,null,'DEATH');
-insert into @results_schema.heracles_analysis (ANALYSIS_ID,ANALYSIS_NAME,STRATUM_1_NAME,STRATUM_2_NAME,STRATUM_3_NAME,STRATUM_4_NAME,STRATUM_5_NAME,ANALYSIS_TYPE) values (600,'Number of persons with at least one procedure occurrence, by procedure_concept_id','procedure_concept_id',null,null,null,null,'PROCEDURE');
-insert into @results_schema.heracles_analysis (ANALYSIS_ID,ANALYSIS_NAME,STRATUM_1_NAME,STRATUM_2_NAME,STRATUM_3_NAME,STRATUM_4_NAME,STRATUM_5_NAME,ANALYSIS_TYPE) values (601,'Number of procedure occurrence records, by procedure_concept_id','procedure_concept_id',null,null,null,null,'PROCEDURE');
-insert into @results_schema.heracles_analysis (ANALYSIS_ID,ANALYSIS_NAME,STRATUM_1_NAME,STRATUM_2_NAME,STRATUM_3_NAME,STRATUM_4_NAME,STRATUM_5_NAME,ANALYSIS_TYPE) values (602,'Number of persons by procedure occurrence start month, by procedure_concept_id','procedure_concept_id','calendar month',null,null,null,'PROCEDURE');
-insert into @results_schema.heracles_analysis (ANALYSIS_ID,ANALYSIS_NAME,STRATUM_1_NAME,STRATUM_2_NAME,STRATUM_3_NAME,STRATUM_4_NAME,STRATUM_5_NAME,ANALYSIS_TYPE) values (603,'Number of distinct procedure occurrence concepts per person',null,null,null,null,null,'PROCEDURE');
-insert into @results_schema.heracles_analysis (ANALYSIS_ID,ANALYSIS_NAME,STRATUM_1_NAME,STRATUM_2_NAME,STRATUM_3_NAME,STRATUM_4_NAME,STRATUM_5_NAME,ANALYSIS_TYPE) values (604,'Number of persons with at least one procedure occurrence, by procedure_concept_id by calendar year by gender by age decile','procedure_concept_id','calendar year','gender_concept_id','age decile',null,'PROCEDURE');
-insert into @results_schema.heracles_analysis (ANALYSIS_ID,ANALYSIS_NAME,STRATUM_1_NAME,STRATUM_2_NAME,STRATUM_3_NAME,STRATUM_4_NAME,STRATUM_5_NAME,ANALYSIS_TYPE) values (605,'Number of procedure occurrence records, by procedure_concept_id by procedure_type_concept_id','procedure_concept_id','procedure_type_concept_id',null,null,null,'PROCEDURE');
-insert into @results_schema.heracles_analysis (ANALYSIS_ID,ANALYSIS_NAME,STRATUM_1_NAME,STRATUM_2_NAME,STRATUM_3_NAME,STRATUM_4_NAME,STRATUM_5_NAME,ANALYSIS_TYPE) values (606,'Distribution of age by procedure_concept_id','procedure_concept_id','gender_concept_id',null,null,null,'PROCEDURE');
-insert into @results_schema.heracles_analysis (ANALYSIS_ID,ANALYSIS_NAME,STRATUM_1_NAME,STRATUM_2_NAME,STRATUM_3_NAME,STRATUM_4_NAME,STRATUM_5_NAME,ANALYSIS_TYPE) values (609,'Number of procedure occurrence records with invalid person_id',null,null,null,null,null,'PROCEDURE');
-insert into @results_schema.heracles_analysis (ANALYSIS_ID,ANALYSIS_NAME,STRATUM_1_NAME,STRATUM_2_NAME,STRATUM_3_NAME,STRATUM_4_NAME,STRATUM_5_NAME,ANALYSIS_TYPE) values (610,'Number of procedure occurrence records outside valid observation period',null,null,null,null,null,'PROCEDURE');
-insert into @results_schema.heracles_analysis (ANALYSIS_ID,ANALYSIS_NAME,STRATUM_1_NAME,STRATUM_2_NAME,STRATUM_3_NAME,STRATUM_4_NAME,STRATUM_5_NAME,ANALYSIS_TYPE) values (612,'Number of procedure occurrence records with invalid provider_id',null,null,null,null,null,'PROCEDURE');
-insert into @results_schema.heracles_analysis (ANALYSIS_ID,ANALYSIS_NAME,STRATUM_1_NAME,STRATUM_2_NAME,STRATUM_3_NAME,STRATUM_4_NAME,STRATUM_5_NAME,ANALYSIS_TYPE) values (613,'Number of procedure occurrence records with invalid visit_id',null,null,null,null,null,'PROCEDURE');
-insert into @results_schema.heracles_analysis (ANALYSIS_ID,ANALYSIS_NAME,STRATUM_1_NAME,STRATUM_2_NAME,STRATUM_3_NAME,STRATUM_4_NAME,STRATUM_5_NAME,ANALYSIS_TYPE) values (620,'Number of procedure occurrence records  by procedure occurrence start month','calendar month',null,null,null,null,'PROCEDURE');
-insert into @results_schema.heracles_analysis (ANALYSIS_ID,ANALYSIS_NAME,STRATUM_1_NAME,STRATUM_2_NAME,STRATUM_3_NAME,STRATUM_4_NAME,STRATUM_5_NAME,ANALYSIS_TYPE) values (700,'Number of persons with at least one drug exposure, by drug_concept_id','drug_concept_id',null,null,null,null,'DRUG');
-insert into @results_schema.heracles_analysis (ANALYSIS_ID,ANALYSIS_NAME,STRATUM_1_NAME,STRATUM_2_NAME,STRATUM_3_NAME,STRATUM_4_NAME,STRATUM_5_NAME,ANALYSIS_TYPE) values (701,'Number of drug exposure records, by drug_concept_id','drug_concept_id',null,null,null,null,'DRUG');
-insert into @results_schema.heracles_analysis (ANALYSIS_ID,ANALYSIS_NAME,STRATUM_1_NAME,STRATUM_2_NAME,STRATUM_3_NAME,STRATUM_4_NAME,STRATUM_5_NAME,ANALYSIS_TYPE) values (702,'Number of persons by drug exposure start month, by drug_concept_id','drug_concept_id','calendar month',null,null,null,'DRUG');
-insert into @results_schema.heracles_analysis (ANALYSIS_ID,ANALYSIS_NAME,STRATUM_1_NAME,STRATUM_2_NAME,STRATUM_3_NAME,STRATUM_4_NAME,STRATUM_5_NAME,ANALYSIS_TYPE) values (703,'Number of distinct drug exposure concepts per person',null,null,null,null,null,'DRUG');
-insert into @results_schema.heracles_analysis (ANALYSIS_ID,ANALYSIS_NAME,STRATUM_1_NAME,STRATUM_2_NAME,STRATUM_3_NAME,STRATUM_4_NAME,STRATUM_5_NAME,ANALYSIS_TYPE) values (704,'Number of persons with at least one drug exposure, by drug_concept_id by calendar year by gender by age decile','drug_concept_id','calendar year','gender_concept_id','age decile',null,'DRUG');
-insert into @results_schema.heracles_analysis (ANALYSIS_ID,ANALYSIS_NAME,STRATUM_1_NAME,STRATUM_2_NAME,STRATUM_3_NAME,STRATUM_4_NAME,STRATUM_5_NAME,ANALYSIS_TYPE) values (705,'Number of drug exposure records, by drug_concept_id by drug_type_concept_id','drug_concept_id','drug_type_concept_id',null,null,null,'DRUG');
-insert into @results_schema.heracles_analysis (ANALYSIS_ID,ANALYSIS_NAME,STRATUM_1_NAME,STRATUM_2_NAME,STRATUM_3_NAME,STRATUM_4_NAME,STRATUM_5_NAME,ANALYSIS_TYPE) values (706,'Distribution of age by drug_concept_id','drug_concept_id','gender_concept_id',null,null,null,'DRUG');
-insert into @results_schema.heracles_analysis (ANALYSIS_ID,ANALYSIS_NAME,STRATUM_1_NAME,STRATUM_2_NAME,STRATUM_3_NAME,STRATUM_4_NAME,STRATUM_5_NAME,ANALYSIS_TYPE) values (709,'Number of drug exposure records with invalid person_id',null,null,null,null,null,'DRUG');
-insert into @results_schema.heracles_analysis (ANALYSIS_ID,ANALYSIS_NAME,STRATUM_1_NAME,STRATUM_2_NAME,STRATUM_3_NAME,STRATUM_4_NAME,STRATUM_5_NAME,ANALYSIS_TYPE) values (710,'Number of drug exposure records outside valid observation period',null,null,null,null,null,'DRUG');
-insert into @results_schema.heracles_analysis (ANALYSIS_ID,ANALYSIS_NAME,STRATUM_1_NAME,STRATUM_2_NAME,STRATUM_3_NAME,STRATUM_4_NAME,STRATUM_5_NAME,ANALYSIS_TYPE) values (711,'Number of drug exposure records with end date < start date',null,null,null,null,null,'DRUG');
-insert into @results_schema.heracles_analysis (ANALYSIS_ID,ANALYSIS_NAME,STRATUM_1_NAME,STRATUM_2_NAME,STRATUM_3_NAME,STRATUM_4_NAME,STRATUM_5_NAME,ANALYSIS_TYPE) values (712,'Number of drug exposure records with invalid provider_id',null,null,null,null,null,'DRUG');
-insert into @results_schema.heracles_analysis (ANALYSIS_ID,ANALYSIS_NAME,STRATUM_1_NAME,STRATUM_2_NAME,STRATUM_3_NAME,STRATUM_4_NAME,STRATUM_5_NAME,ANALYSIS_TYPE) values (713,'Number of drug exposure records with invalid visit_id',null,null,null,null,null,'DRUG');
-insert into @results_schema.heracles_analysis (ANALYSIS_ID,ANALYSIS_NAME,STRATUM_1_NAME,STRATUM_2_NAME,STRATUM_3_NAME,STRATUM_4_NAME,STRATUM_5_NAME,ANALYSIS_TYPE) values (715,'Distribution of days_supply by drug_concept_id','drug_concept_id',null,null,null,null,'DRUG');
-insert into @results_schema.heracles_analysis (ANALYSIS_ID,ANALYSIS_NAME,STRATUM_1_NAME,STRATUM_2_NAME,STRATUM_3_NAME,STRATUM_4_NAME,STRATUM_5_NAME,ANALYSIS_TYPE) values (716,'Distribution of refills by drug_concept_id','drug_concept_id',null,null,null,null,'DRUG');
-insert into @results_schema.heracles_analysis (ANALYSIS_ID,ANALYSIS_NAME,STRATUM_1_NAME,STRATUM_2_NAME,STRATUM_3_NAME,STRATUM_4_NAME,STRATUM_5_NAME,ANALYSIS_TYPE) values (717,'Distribution of quantity by drug_concept_id','drug_concept_id',null,null,null,null,'DRUG');
-insert into @results_schema.heracles_analysis (ANALYSIS_ID,ANALYSIS_NAME,STRATUM_1_NAME,STRATUM_2_NAME,STRATUM_3_NAME,STRATUM_4_NAME,STRATUM_5_NAME,ANALYSIS_TYPE) values (720,'Number of drug exposure records  by drug exposure start month','calendar month',null,null,null,null,'DRUG');
-insert into @results_schema.heracles_analysis (ANALYSIS_ID,ANALYSIS_NAME,STRATUM_1_NAME,STRATUM_2_NAME,STRATUM_3_NAME,STRATUM_4_NAME,STRATUM_5_NAME,ANALYSIS_TYPE) values (800,'Number of persons with at least one observation occurrence, by observation_concept_id','observation_concept_id',null,null,null,null,'OBSERVATION');
-insert into @results_schema.heracles_analysis (ANALYSIS_ID,ANALYSIS_NAME,STRATUM_1_NAME,STRATUM_2_NAME,STRATUM_3_NAME,STRATUM_4_NAME,STRATUM_5_NAME,ANALYSIS_TYPE) values (801,'Number of observation occurrence records, by observation_concept_id','observation_concept_id',null,null,null,null,'OBSERVATION');
-insert into @results_schema.heracles_analysis (ANALYSIS_ID,ANALYSIS_NAME,STRATUM_1_NAME,STRATUM_2_NAME,STRATUM_3_NAME,STRATUM_4_NAME,STRATUM_5_NAME,ANALYSIS_TYPE) values (802,'Number of persons by observation occurrence start month, by observation_concept_id','observation_concept_id','calendar month',null,null,null,'OBSERVATION');
-insert into @results_schema.heracles_analysis (ANALYSIS_ID,ANALYSIS_NAME,STRATUM_1_NAME,STRATUM_2_NAME,STRATUM_3_NAME,STRATUM_4_NAME,STRATUM_5_NAME,ANALYSIS_TYPE) values (803,'Number of distinct observation occurrence concepts per person',null,null,null,null,null,'OBSERVATION');
-insert into @results_schema.heracles_analysis (ANALYSIS_ID,ANALYSIS_NAME,STRATUM_1_NAME,STRATUM_2_NAME,STRATUM_3_NAME,STRATUM_4_NAME,STRATUM_5_NAME,ANALYSIS_TYPE) values (804,'Number of persons with at least one observation occurrence, by observation_concept_id by calendar year by gender by age decile','observation_concept_id','calendar year','gender_concept_id','age decile',null,'OBSERVATION');
-insert into @results_schema.heracles_analysis (ANALYSIS_ID,ANALYSIS_NAME,STRATUM_1_NAME,STRATUM_2_NAME,STRATUM_3_NAME,STRATUM_4_NAME,STRATUM_5_NAME,ANALYSIS_TYPE) values (805,'Number of observation occurrence records, by observation_concept_id by observation_type_concept_id','observation_concept_id','observation_type_concept_id',null,null,null,'OBSERVATION');
-insert into @results_schema.heracles_analysis (ANALYSIS_ID,ANALYSIS_NAME,STRATUM_1_NAME,STRATUM_2_NAME,STRATUM_3_NAME,STRATUM_4_NAME,STRATUM_5_NAME,ANALYSIS_TYPE) values (806,'Distribution of age by observation_concept_id','observation_concept_id','gender_concept_id',null,null,null,'OBSERVATION');
-insert into @results_schema.heracles_analysis (ANALYSIS_ID,ANALYSIS_NAME,STRATUM_1_NAME,STRATUM_2_NAME,STRATUM_3_NAME,STRATUM_4_NAME,STRATUM_5_NAME,ANALYSIS_TYPE) values (807,'Number of observation occurrence records, by observation_concept_id and unit_concept_id','observation_concept_id','unit_concept_id',null,null,null,'OBSERVATION');
-insert into @results_schema.heracles_analysis (ANALYSIS_ID,ANALYSIS_NAME,STRATUM_1_NAME,STRATUM_2_NAME,STRATUM_3_NAME,STRATUM_4_NAME,STRATUM_5_NAME,ANALYSIS_TYPE) values (809,'Number of observation records with invalid person_id',null,null,null,null,null,'OBSERVATION');
-insert into @results_schema.heracles_analysis (ANALYSIS_ID,ANALYSIS_NAME,STRATUM_1_NAME,STRATUM_2_NAME,STRATUM_3_NAME,STRATUM_4_NAME,STRATUM_5_NAME,ANALYSIS_TYPE) values (810,'Number of observation records outside valid observation period',null,null,null,null,null,'OBSERVATION');
-insert into @results_schema.heracles_analysis (ANALYSIS_ID,ANALYSIS_NAME,STRATUM_1_NAME,STRATUM_2_NAME,STRATUM_3_NAME,STRATUM_4_NAME,STRATUM_5_NAME,ANALYSIS_TYPE) values (812,'Number of observation records with invalid provider_id',null,null,null,null,null,'OBSERVATION');
-insert into @results_schema.heracles_analysis (ANALYSIS_ID,ANALYSIS_NAME,STRATUM_1_NAME,STRATUM_2_NAME,STRATUM_3_NAME,STRATUM_4_NAME,STRATUM_5_NAME,ANALYSIS_TYPE) values (813,'Number of observation records with invalid visit_id',null,null,null,null,null,'OBSERVATION');
-insert into @results_schema.heracles_analysis (ANALYSIS_ID,ANALYSIS_NAME,STRATUM_1_NAME,STRATUM_2_NAME,STRATUM_3_NAME,STRATUM_4_NAME,STRATUM_5_NAME,ANALYSIS_TYPE) values (814,'Number of observation records with no value (numeric, string, or concept)',null,null,null,null,null,'OBSERVATION');
-insert into @results_schema.heracles_analysis (ANALYSIS_ID,ANALYSIS_NAME,STRATUM_1_NAME,STRATUM_2_NAME,STRATUM_3_NAME,STRATUM_4_NAME,STRATUM_5_NAME,ANALYSIS_TYPE) values (815,'Distribution of numeric values, by observation_concept_id and unit_concept_id',null,null,null,null,null,'OBSERVATION');
-insert into @results_schema.heracles_analysis (ANALYSIS_ID,ANALYSIS_NAME,STRATUM_1_NAME,STRATUM_2_NAME,STRATUM_3_NAME,STRATUM_4_NAME,STRATUM_5_NAME,ANALYSIS_TYPE) values (816,'Distribution of low range, by observation_concept_id and unit_concept_id',null,null,null,null,null,'OBSERVATION');
-insert into @results_schema.heracles_analysis (ANALYSIS_ID,ANALYSIS_NAME,STRATUM_1_NAME,STRATUM_2_NAME,STRATUM_3_NAME,STRATUM_4_NAME,STRATUM_5_NAME,ANALYSIS_TYPE) values (817,'Distribution of high range, by observation_concept_id and unit_concept_id',null,null,null,null,null,'OBSERVATION');
-insert into @results_schema.heracles_analysis (ANALYSIS_ID,ANALYSIS_NAME,STRATUM_1_NAME,STRATUM_2_NAME,STRATUM_3_NAME,STRATUM_4_NAME,STRATUM_5_NAME,ANALYSIS_TYPE) values (818,'Number of observation records below/within/above normal range, by observation_concept_id and unit_concept_id',null,null,null,null,null,'OBSERVATION');
-insert into @results_schema.heracles_analysis (ANALYSIS_ID,ANALYSIS_NAME,STRATUM_1_NAME,STRATUM_2_NAME,STRATUM_3_NAME,STRATUM_4_NAME,STRATUM_5_NAME,ANALYSIS_TYPE) values (820,'Number of observation records  by observation start month','calendar month',null,null,null,null,'OBSERVATION');
-insert into @results_schema.heracles_analysis (ANALYSIS_ID,ANALYSIS_NAME,STRATUM_1_NAME,STRATUM_2_NAME,STRATUM_3_NAME,STRATUM_4_NAME,STRATUM_5_NAME,ANALYSIS_TYPE) values (900,'Number of persons with at least one drug era, by drug_concept_id','drug_concept_id',null,null,null,null,'DRUG_ERA');
-insert into @results_schema.heracles_analysis (ANALYSIS_ID,ANALYSIS_NAME,STRATUM_1_NAME,STRATUM_2_NAME,STRATUM_3_NAME,STRATUM_4_NAME,STRATUM_5_NAME,ANALYSIS_TYPE) values (901,'Number of drug era records, by drug_concept_id','drug_concept_id',null,null,null,null,'DRUG_ERA');
-insert into @results_schema.heracles_analysis (ANALYSIS_ID,ANALYSIS_NAME,STRATUM_1_NAME,STRATUM_2_NAME,STRATUM_3_NAME,STRATUM_4_NAME,STRATUM_5_NAME,ANALYSIS_TYPE) values (902,'Number of persons by drug era start month, by drug_concept_id','drug_concept_id','calendar month',null,null,null,'DRUG_ERA');
-insert into @results_schema.heracles_analysis (ANALYSIS_ID,ANALYSIS_NAME,STRATUM_1_NAME,STRATUM_2_NAME,STRATUM_3_NAME,STRATUM_4_NAME,STRATUM_5_NAME,ANALYSIS_TYPE) values (903,'Number of distinct drug era concepts per person',null,null,null,null,null,'DRUG_ERA');
-insert into @results_schema.heracles_analysis (ANALYSIS_ID,ANALYSIS_NAME,STRATUM_1_NAME,STRATUM_2_NAME,STRATUM_3_NAME,STRATUM_4_NAME,STRATUM_5_NAME,ANALYSIS_TYPE) values (904,'Number of persons with at least one drug era, by drug_concept_id by calendar year by gender by age decile','drug_concept_id','calendar year','gender_concept_id','age decile',null,'DRUG_ERA');
-insert into @results_schema.heracles_analysis (ANALYSIS_ID,ANALYSIS_NAME,STRATUM_1_NAME,STRATUM_2_NAME,STRATUM_3_NAME,STRATUM_4_NAME,STRATUM_5_NAME,ANALYSIS_TYPE) values (906,'Distribution of age by drug_concept_id','drug_concept_id','gender_concept_id',null,null,null,'DRUG_ERA');
-insert into @results_schema.heracles_analysis (ANALYSIS_ID,ANALYSIS_NAME,STRATUM_1_NAME,STRATUM_2_NAME,STRATUM_3_NAME,STRATUM_4_NAME,STRATUM_5_NAME,ANALYSIS_TYPE) values (907,'Distribution of drug era length, by drug_concept_id','drug_concept_id',null,null,null,null,'DRUG_ERA');
-insert into @results_schema.heracles_analysis (ANALYSIS_ID,ANALYSIS_NAME,STRATUM_1_NAME,STRATUM_2_NAME,STRATUM_3_NAME,STRATUM_4_NAME,STRATUM_5_NAME,ANALYSIS_TYPE) values (908,'Number of drug eras without valid person',null,null,null,null,null,'DRUG_ERA');
-insert into @results_schema.heracles_analysis (ANALYSIS_ID,ANALYSIS_NAME,STRATUM_1_NAME,STRATUM_2_NAME,STRATUM_3_NAME,STRATUM_4_NAME,STRATUM_5_NAME,ANALYSIS_TYPE) values (909,'Number of drug eras outside valid observation period',null,null,null,null,null,'DRUG_ERA');
-insert into @results_schema.heracles_analysis (ANALYSIS_ID,ANALYSIS_NAME,STRATUM_1_NAME,STRATUM_2_NAME,STRATUM_3_NAME,STRATUM_4_NAME,STRATUM_5_NAME,ANALYSIS_TYPE) values (910,'Number of drug eras with end date < start date',null,null,null,null,null,'DRUG_ERA');
-insert into @results_schema.heracles_analysis (ANALYSIS_ID,ANALYSIS_NAME,STRATUM_1_NAME,STRATUM_2_NAME,STRATUM_3_NAME,STRATUM_4_NAME,STRATUM_5_NAME,ANALYSIS_TYPE) values (920,'Number of drug era records  by drug era start month','calendar month',null,null,null,null,'DRUG_ERA');
-insert into @results_schema.heracles_analysis (ANALYSIS_ID,ANALYSIS_NAME,STRATUM_1_NAME,STRATUM_2_NAME,STRATUM_3_NAME,STRATUM_4_NAME,STRATUM_5_NAME,ANALYSIS_TYPE) values (1000,'Number of persons with at least one condition era, by condition_concept_id','condition_concept_id',null,null,null,null,'CONDITION_ERA');
-insert into @results_schema.heracles_analysis (ANALYSIS_ID,ANALYSIS_NAME,STRATUM_1_NAME,STRATUM_2_NAME,STRATUM_3_NAME,STRATUM_4_NAME,STRATUM_5_NAME,ANALYSIS_TYPE) values (1001,'Number of condition era records, by condition_concept_id','condition_concept_id',null,null,null,null,'CONDITION_ERA');
-insert into @results_schema.heracles_analysis (ANALYSIS_ID,ANALYSIS_NAME,STRATUM_1_NAME,STRATUM_2_NAME,STRATUM_3_NAME,STRATUM_4_NAME,STRATUM_5_NAME,ANALYSIS_TYPE) values (1002,'Number of persons by condition era start month, by condition_concept_id','condition_concept_id','calendar month',null,null,null,'CONDITION_ERA');
-insert into @results_schema.heracles_analysis (ANALYSIS_ID,ANALYSIS_NAME,STRATUM_1_NAME,STRATUM_2_NAME,STRATUM_3_NAME,STRATUM_4_NAME,STRATUM_5_NAME,ANALYSIS_TYPE) values (1003,'Number of distinct condition era concepts per person',null,null,null,null,null,'CONDITION_ERA');
-insert into @results_schema.heracles_analysis (ANALYSIS_ID,ANALYSIS_NAME,STRATUM_1_NAME,STRATUM_2_NAME,STRATUM_3_NAME,STRATUM_4_NAME,STRATUM_5_NAME,ANALYSIS_TYPE) values (1004,'Number of persons with at least one condition era, by condition_concept_id by calendar year by gender by age decile','condition_concept_id','calendar year','gender_concept_id','age decile',null,'CONDITION_ERA');
-insert into @results_schema.heracles_analysis (ANALYSIS_ID,ANALYSIS_NAME,STRATUM_1_NAME,STRATUM_2_NAME,STRATUM_3_NAME,STRATUM_4_NAME,STRATUM_5_NAME,ANALYSIS_TYPE) values (1006,'Distribution of age by condition_concept_id','condition_concept_id','gender_concept_id',null,null,null,'CONDITION_ERA');
-insert into @results_schema.heracles_analysis (ANALYSIS_ID,ANALYSIS_NAME,STRATUM_1_NAME,STRATUM_2_NAME,STRATUM_3_NAME,STRATUM_4_NAME,STRATUM_5_NAME,ANALYSIS_TYPE) values (1007,'Distribution of condition era length, by condition_concept_id','condition_concept_id',null,null,null,null,'CONDITION_ERA');
-insert into @results_schema.heracles_analysis (ANALYSIS_ID,ANALYSIS_NAME,STRATUM_1_NAME,STRATUM_2_NAME,STRATUM_3_NAME,STRATUM_4_NAME,STRATUM_5_NAME,ANALYSIS_TYPE) values (1008,'Number of condition eras without valid person',null,null,null,null,null,'CONDITION_ERA');
-insert into @results_schema.heracles_analysis (ANALYSIS_ID,ANALYSIS_NAME,STRATUM_1_NAME,STRATUM_2_NAME,STRATUM_3_NAME,STRATUM_4_NAME,STRATUM_5_NAME,ANALYSIS_TYPE) values (1009,'Number of condition eras outside valid observation period',null,null,null,null,null,'CONDITION_ERA');
-insert into @results_schema.heracles_analysis (ANALYSIS_ID,ANALYSIS_NAME,STRATUM_1_NAME,STRATUM_2_NAME,STRATUM_3_NAME,STRATUM_4_NAME,STRATUM_5_NAME,ANALYSIS_TYPE) values (1010,'Number of condition eras with end date < start date',null,null,null,null,null,'CONDITION_ERA');
-insert into @results_schema.heracles_analysis (ANALYSIS_ID,ANALYSIS_NAME,STRATUM_1_NAME,STRATUM_2_NAME,STRATUM_3_NAME,STRATUM_4_NAME,STRATUM_5_NAME,ANALYSIS_TYPE) values (1020,'Number of condition era records by condition era start month','calendar month',null,null,null,null,'CONDITION_ERA');
-insert into @results_schema.heracles_analysis (ANALYSIS_ID,ANALYSIS_NAME,STRATUM_1_NAME,STRATUM_2_NAME,STRATUM_3_NAME,STRATUM_4_NAME,STRATUM_5_NAME,ANALYSIS_TYPE) values (1100,'Number of persons by location 3-digit zip','3-digit zip',null,null,null,null,'LOCATION');
-insert into @results_schema.heracles_analysis (ANALYSIS_ID,ANALYSIS_NAME,STRATUM_1_NAME,STRATUM_2_NAME,STRATUM_3_NAME,STRATUM_4_NAME,STRATUM_5_NAME,ANALYSIS_TYPE) values (1101,'Number of persons by location state','state',null,null,null,null,'LOCATION');
-insert into @results_schema.heracles_analysis (ANALYSIS_ID,ANALYSIS_NAME,STRATUM_1_NAME,STRATUM_2_NAME,STRATUM_3_NAME,STRATUM_4_NAME,STRATUM_5_NAME,ANALYSIS_TYPE) values (1200,'Number of persons by place of service','place_of_service_concept_id',null,null,null,null,'CARE_SITE');
-insert into @results_schema.heracles_analysis (ANALYSIS_ID,ANALYSIS_NAME,STRATUM_1_NAME,STRATUM_2_NAME,STRATUM_3_NAME,STRATUM_4_NAME,STRATUM_5_NAME,ANALYSIS_TYPE) values (1201,'Number of visits by place of service','place_of_service_concept_id',null,null,null,null,'CARE_SITE');
-insert into @results_schema.heracles_analysis (ANALYSIS_ID,ANALYSIS_NAME,STRATUM_1_NAME,STRATUM_2_NAME,STRATUM_3_NAME,STRATUM_4_NAME,STRATUM_5_NAME,ANALYSIS_TYPE) values (1700,'Number of records by cohort_definition_id','cohort_definition_id',null,null,null,null,'COHORT');
-insert into @results_schema.heracles_analysis (ANALYSIS_ID,ANALYSIS_NAME,STRATUM_1_NAME,STRATUM_2_NAME,STRATUM_3_NAME,STRATUM_4_NAME,STRATUM_5_NAME,ANALYSIS_TYPE) values (1701,'Number of records with cohort end date < cohort start date',null,null,null,null,null,'COHORT');
-insert into @results_schema.heracles_analysis (ANALYSIS_ID,ANALYSIS_NAME,STRATUM_1_NAME,STRATUM_2_NAME,STRATUM_3_NAME,STRATUM_4_NAME,STRATUM_5_NAME,ANALYSIS_TYPE) values (1800,'Number of persons by age, with age at cohort start','age',null,null,null,null,'COHORT_SPECIFIC_ANALYSES');
-insert into @results_schema.heracles_analysis (ANALYSIS_ID,ANALYSIS_NAME,STRATUM_1_NAME,STRATUM_2_NAME,STRATUM_3_NAME,STRATUM_4_NAME,STRATUM_5_NAME,ANALYSIS_TYPE) values (1801,'Distribution of age at cohort start',null,null,null,null,null,'COHORT_SPECIFIC_ANALYSES');
-insert into @results_schema.heracles_analysis (ANALYSIS_ID,ANALYSIS_NAME,STRATUM_1_NAME,STRATUM_2_NAME,STRATUM_3_NAME,STRATUM_4_NAME,STRATUM_5_NAME,ANALYSIS_TYPE) values (1802,'Distribution of age at cohort start by gender','gender_concept_id',null,null,null,null,'COHORT_SPECIFIC_ANALYSES');
-insert into @results_schema.heracles_analysis (ANALYSIS_ID,ANALYSIS_NAME,STRATUM_1_NAME,STRATUM_2_NAME,STRATUM_3_NAME,STRATUM_4_NAME,STRATUM_5_NAME,ANALYSIS_TYPE) values (1803,'Distribution of age at cohort start by cohort start year','calendar year',null,null,null,null,'COHORT_SPECIFIC_ANALYSES');
-insert into @results_schema.heracles_analysis (ANALYSIS_ID,ANALYSIS_NAME,STRATUM_1_NAME,STRATUM_2_NAME,STRATUM_3_NAME,STRATUM_4_NAME,STRATUM_5_NAME,ANALYSIS_TYPE) values (1804,'Number of persons by duration from cohort start to cohort end, in 30d increments','Cohort period length 30d increments',null,null,null,null,'COHORT_SPECIFIC_ANALYSES');
-insert into @results_schema.heracles_analysis (ANALYSIS_ID,ANALYSIS_NAME,STRATUM_1_NAME,STRATUM_2_NAME,STRATUM_3_NAME,STRATUM_4_NAME,STRATUM_5_NAME,ANALYSIS_TYPE) values (1805,'Number of persons by duration from observation start to cohort start, in 30d increments','Baseline period length 30d increments',null,null,null,null,'COHORT_SPECIFIC_ANALYSES');
-insert into @results_schema.heracles_analysis (ANALYSIS_ID,ANALYSIS_NAME,STRATUM_1_NAME,STRATUM_2_NAME,STRATUM_3_NAME,STRATUM_4_NAME,STRATUM_5_NAME,ANALYSIS_TYPE) values (1806,'Number of persons by duration from cohort start to observation end, in 30d increments','Follow-up period length 30d increments',null,null,null,null,'COHORT_SPECIFIC_ANALYSES');
-insert into @results_schema.heracles_analysis (ANALYSIS_ID,ANALYSIS_NAME,STRATUM_1_NAME,STRATUM_2_NAME,STRATUM_3_NAME,STRATUM_4_NAME,STRATUM_5_NAME,ANALYSIS_TYPE) values (1807,'Number of persons by duration from cohort end to observation end, in 30d increments','Post-cohort period length 30d increments',null,null,null,null,'COHORT_SPECIFIC_ANALYSES');
-insert into @results_schema.heracles_analysis (ANALYSIS_ID,ANALYSIS_NAME,STRATUM_1_NAME,STRATUM_2_NAME,STRATUM_3_NAME,STRATUM_4_NAME,STRATUM_5_NAME,ANALYSIS_TYPE) values (1808,'Distribution of duration (days) from cohort start to cohort end',null,null,null,null,null,'COHORT_SPECIFIC_ANALYSES');
-insert into @results_schema.heracles_analysis (ANALYSIS_ID,ANALYSIS_NAME,STRATUM_1_NAME,STRATUM_2_NAME,STRATUM_3_NAME,STRATUM_4_NAME,STRATUM_5_NAME,ANALYSIS_TYPE) values (1809,'Distribution of duration (days) from cohort start to cohort end, by gender','gender_concept_id',null,null,null,null,'COHORT_SPECIFIC_ANALYSES');
-insert into @results_schema.heracles_analysis (ANALYSIS_ID,ANALYSIS_NAME,STRATUM_1_NAME,STRATUM_2_NAME,STRATUM_3_NAME,STRATUM_4_NAME,STRATUM_5_NAME,ANALYSIS_TYPE) values (1810,'Distribution of duration (days) from cohort start to cohort end, by age decile','age decile',null,null,null,null,'COHORT_SPECIFIC_ANALYSES');
-insert into @results_schema.heracles_analysis (ANALYSIS_ID,ANALYSIS_NAME,STRATUM_1_NAME,STRATUM_2_NAME,STRATUM_3_NAME,STRATUM_4_NAME,STRATUM_5_NAME,ANALYSIS_TYPE) values (1811,'Distribution of duration (days) from observation start to cohort start',null,null,null,null,null,'COHORT_SPECIFIC_ANALYSES');
-insert into @results_schema.heracles_analysis (ANALYSIS_ID,ANALYSIS_NAME,STRATUM_1_NAME,STRATUM_2_NAME,STRATUM_3_NAME,STRATUM_4_NAME,STRATUM_5_NAME,ANALYSIS_TYPE) values (1812,'Distribution of duration (days) from cohort start to observation end',null,null,null,null,null,'COHORT_SPECIFIC_ANALYSES');
-insert into @results_schema.heracles_analysis (ANALYSIS_ID,ANALYSIS_NAME,STRATUM_1_NAME,STRATUM_2_NAME,STRATUM_3_NAME,STRATUM_4_NAME,STRATUM_5_NAME,ANALYSIS_TYPE) values (1813,'Distribution of duration (days) from cohort end to observation end',null,null,null,null,null,'COHORT_SPECIFIC_ANALYSES');
-insert into @results_schema.heracles_analysis (ANALYSIS_ID,ANALYSIS_NAME,STRATUM_1_NAME,STRATUM_2_NAME,STRATUM_3_NAME,STRATUM_4_NAME,STRATUM_5_NAME,ANALYSIS_TYPE) values (1814,'Number of persons by cohort start year by gender by age decile','calendar year','gender_concept_id','age decile',null,null,'COHORT_SPECIFIC_ANALYSES');
-insert into @results_schema.heracles_analysis (ANALYSIS_ID,ANALYSIS_NAME,STRATUM_1_NAME,STRATUM_2_NAME,STRATUM_3_NAME,STRATUM_4_NAME,STRATUM_5_NAME,ANALYSIS_TYPE) values (1815,'Number of persons by cohort start month','calendar month',null,null,null,null,'COHORT_SPECIFIC_ANALYSES');
-insert into @results_schema.heracles_analysis (ANALYSIS_ID,ANALYSIS_NAME,STRATUM_1_NAME,STRATUM_2_NAME,STRATUM_3_NAME,STRATUM_4_NAME,STRATUM_5_NAME,ANALYSIS_TYPE) values (1816,'Number of persons by number of cohort periods','number of cohort periods',null,null,null,null,'COHORT_SPECIFIC_ANALYSES');
-insert into @results_schema.heracles_analysis (ANALYSIS_ID,ANALYSIS_NAME,STRATUM_1_NAME,STRATUM_2_NAME,STRATUM_3_NAME,STRATUM_4_NAME,STRATUM_5_NAME,ANALYSIS_TYPE) values (1820,'Number of persons by duration from cohort start to first occurrence of condition occurrence, by condition_concept_id','condition_concept_id','time-to-event 30d increments',null,null,null,'COHORT_SPECIFIC_ANALYSES');
-insert into @results_schema.heracles_analysis (ANALYSIS_ID,ANALYSIS_NAME,STRATUM_1_NAME,STRATUM_2_NAME,STRATUM_3_NAME,STRATUM_4_NAME,STRATUM_5_NAME,ANALYSIS_TYPE) values (1821,'Number of events by duration from cohort start to all occurrences of condition occurrence, by condition_concept_id','condition_concept_id','time-to-event 30d increments',null,null,null,'COHORT_SPECIFIC_ANALYSES');
-insert into @results_schema.heracles_analysis (ANALYSIS_ID,ANALYSIS_NAME,STRATUM_1_NAME,STRATUM_2_NAME,STRATUM_3_NAME,STRATUM_4_NAME,STRATUM_5_NAME,ANALYSIS_TYPE) values (1830,'Number of persons by duration from cohort start to first occurrence of procedure occurrence, by procedure_concept_id','procedure_concept_id','time-to-event 30d increments',null,null,null,'COHORT_SPECIFIC_ANALYSES');
-insert into @results_schema.heracles_analysis (ANALYSIS_ID,ANALYSIS_NAME,STRATUM_1_NAME,STRATUM_2_NAME,STRATUM_3_NAME,STRATUM_4_NAME,STRATUM_5_NAME,ANALYSIS_TYPE) values (1831,'Number of events by duration from cohort start to all occurrences of procedure occurrence, by procedure_concept_id','procedure_concept_id','time-to-event 30d increments',null,null,null,'COHORT_SPECIFIC_ANALYSES');
-insert into @results_schema.heracles_analysis (ANALYSIS_ID,ANALYSIS_NAME,STRATUM_1_NAME,STRATUM_2_NAME,STRATUM_3_NAME,STRATUM_4_NAME,STRATUM_5_NAME,ANALYSIS_TYPE) values (1840,'Number of persons by duration from cohort start to first occurrence of drug exposure, by drug_concept_id','drug_concept_id','time-to-event 30d increments',null,null,null,'COHORT_SPECIFIC_ANALYSES');
-insert into @results_schema.heracles_analysis (ANALYSIS_ID,ANALYSIS_NAME,STRATUM_1_NAME,STRATUM_2_NAME,STRATUM_3_NAME,STRATUM_4_NAME,STRATUM_5_NAME,ANALYSIS_TYPE) values (1841,'Number of events by duration from cohort start to all occurrences of drug exposure, by drug_concept_id','drug_concept_id','time-to-event 30d increments',null,null,null,'COHORT_SPECIFIC_ANALYSES');
-insert into @results_schema.heracles_analysis (ANALYSIS_ID,ANALYSIS_NAME,STRATUM_1_NAME,STRATUM_2_NAME,STRATUM_3_NAME,STRATUM_4_NAME,STRATUM_5_NAME,ANALYSIS_TYPE) values (1850,'Number of persons by duration from cohort start to first occurrence of observation, by observation_concept_id','observation_concept_id','time-to-event 30d increments',null,null,null,'COHORT_SPECIFIC_ANALYSES');
-insert into @results_schema.heracles_analysis (ANALYSIS_ID,ANALYSIS_NAME,STRATUM_1_NAME,STRATUM_2_NAME,STRATUM_3_NAME,STRATUM_4_NAME,STRATUM_5_NAME,ANALYSIS_TYPE) values (1851,'Number of events by duration from cohort start to all occurrences of observation, by observation_concept_id','observation_concept_id','time-to-event 30d increments',null,null,null,'COHORT_SPECIFIC_ANALYSES');
-insert into @results_schema.heracles_analysis (ANALYSIS_ID,ANALYSIS_NAME,STRATUM_1_NAME,STRATUM_2_NAME,STRATUM_3_NAME,STRATUM_4_NAME,STRATUM_5_NAME,ANALYSIS_TYPE) values (1860,'Number of persons by duration from cohort start to first occurrence of condition era, by condition_concept_id','condition_concept_id','time-to-event 30d increments',null,null,null,'COHORT_SPECIFIC_ANALYSES');
-insert into @results_schema.heracles_analysis (ANALYSIS_ID,ANALYSIS_NAME,STRATUM_1_NAME,STRATUM_2_NAME,STRATUM_3_NAME,STRATUM_4_NAME,STRATUM_5_NAME,ANALYSIS_TYPE) values (1861,'Number of events by duration from cohort start to all occurrences of condition era, by condition_concept_id','condition_concept_id','time-to-event 30d increments',null,null,null,'COHORT_SPECIFIC_ANALYSES');
-insert into @results_schema.heracles_analysis (ANALYSIS_ID,ANALYSIS_NAME,STRATUM_1_NAME,STRATUM_2_NAME,STRATUM_3_NAME,STRATUM_4_NAME,STRATUM_5_NAME,ANALYSIS_TYPE) values (1870,'Number of persons by duration from cohort start to first occurrence of drug era, by drug_concept_id','drug_concept_id','time-to-event 30d increments',null,null,null,'COHORT_SPECIFIC_ANALYSES');
-insert into @results_schema.heracles_analysis (ANALYSIS_ID,ANALYSIS_NAME,STRATUM_1_NAME,STRATUM_2_NAME,STRATUM_3_NAME,STRATUM_4_NAME,STRATUM_5_NAME,ANALYSIS_TYPE) values (1871,'Number of events by duration from cohort start to all occurrences of drug era, by drug_concept_id','drug_concept_id','time-to-event 30d increments',null,null,null,'COHORT_SPECIFIC_ANALYSES');
-
-insert into @results_schema.heracles_analysis (ANALYSIS_ID,ANALYSIS_NAME,STRATUM_1_NAME,STRATUM_2_NAME,STRATUM_3_NAME,STRATUM_4_NAME,STRATUM_5_NAME,ANALYSIS_TYPE) values (1300,'Number of persons with at least one measurement occurrence, by measurement_concept_id','measurement_concept_id',null,null,null,null,'MEASUREMENT');
-insert into @results_schema.heracles_analysis (ANALYSIS_ID,ANALYSIS_NAME,STRATUM_1_NAME,STRATUM_2_NAME,STRATUM_3_NAME,STRATUM_4_NAME,STRATUM_5_NAME,ANALYSIS_TYPE) values (1301,'Number of measurement occurrence records, by measurement_concept_id','measurement_concept_id',null,null,null,null,'MEASUREMENT');
-insert into @results_schema.heracles_analysis (ANALYSIS_ID,ANALYSIS_NAME,STRATUM_1_NAME,STRATUM_2_NAME,STRATUM_3_NAME,STRATUM_4_NAME,STRATUM_5_NAME,ANALYSIS_TYPE) values (1302,'Number of persons by measurement occurrence start month, by measurement_concept_id','measurement_concept_id','calendar month',null,null,null,'MEASUREMENT');
-insert into @results_schema.heracles_analysis (ANALYSIS_ID,ANALYSIS_NAME,STRATUM_1_NAME,STRATUM_2_NAME,STRATUM_3_NAME,STRATUM_4_NAME,STRATUM_5_NAME,ANALYSIS_TYPE) values (1303,'Number of distinct measurement occurrence concepts per person',null,null,null,null,null,'MEASUREMENT');
-insert into @results_schema.heracles_analysis (ANALYSIS_ID,ANALYSIS_NAME,STRATUM_1_NAME,STRATUM_2_NAME,STRATUM_3_NAME,STRATUM_4_NAME,STRATUM_5_NAME,ANALYSIS_TYPE) values (1304,'Number of persons with at least one measurement occurrence, by measurement_concept_id by calendar year by gender by age decile','measurement_concept_id','calendar year','gender_concept_id','age decile',null,'MEASUREMENT');
-insert into @results_schema.heracles_analysis (ANALYSIS_ID,ANALYSIS_NAME,STRATUM_1_NAME,STRATUM_2_NAME,STRATUM_3_NAME,STRATUM_4_NAME,STRATUM_5_NAME,ANALYSIS_TYPE) values (1305,'Number of measurement occurrence records, by measurement_concept_id by measurement_type_concept_id','measurement_concept_id','measurement_type_concept_id',null,null,null,'MEASUREMENT');
-insert into @results_schema.heracles_analysis (ANALYSIS_ID,ANALYSIS_NAME,STRATUM_1_NAME,STRATUM_2_NAME,STRATUM_3_NAME,STRATUM_4_NAME,STRATUM_5_NAME,ANALYSIS_TYPE) values (1306,'Distribution of age by measurement_concept_id','measurement_concept_id','gender_concept_id',null,null,null,'MEASUREMENT');
-insert into @results_schema.heracles_analysis (ANALYSIS_ID,ANALYSIS_NAME,STRATUM_1_NAME,STRATUM_2_NAME,STRATUM_3_NAME,STRATUM_4_NAME,STRATUM_5_NAME,ANALYSIS_TYPE) values (1307,'Number of measurement occurrence records, by measurement_concept_id and unit_concept_id','measurement_concept_id','unit_concept_id',null,null,null,'MEASUREMENT');
-insert into @results_schema.heracles_analysis (ANALYSIS_ID,ANALYSIS_NAME,STRATUM_1_NAME,STRATUM_2_NAME,STRATUM_3_NAME,STRATUM_4_NAME,STRATUM_5_NAME,ANALYSIS_TYPE) values (1309,'Number of measurement records with invalid person_id',null,null,null,null,null,'MEASUREMENT');
-insert into @results_schema.heracles_analysis (ANALYSIS_ID,ANALYSIS_NAME,STRATUM_1_NAME,STRATUM_2_NAME,STRATUM_3_NAME,STRATUM_4_NAME,STRATUM_5_NAME,ANALYSIS_TYPE) values (1310,'Number of measurement records outside valid measurement period',null,null,null,null,null,'MEASUREMENT');
-insert into @results_schema.heracles_analysis (ANALYSIS_ID,ANALYSIS_NAME,STRATUM_1_NAME,STRATUM_2_NAME,STRATUM_3_NAME,STRATUM_4_NAME,STRATUM_5_NAME,ANALYSIS_TYPE) values (1312,'Number of measurement records with invalid provider_id',null,null,null,null,null,'MEASUREMENT');
-insert into @results_schema.heracles_analysis (ANALYSIS_ID,ANALYSIS_NAME,STRATUM_1_NAME,STRATUM_2_NAME,STRATUM_3_NAME,STRATUM_4_NAME,STRATUM_5_NAME,ANALYSIS_TYPE) values (1313,'Number of measurement records with invalid visit_id',null,null,null,null,null,'MEASUREMENT');
-insert into @results_schema.heracles_analysis (ANALYSIS_ID,ANALYSIS_NAME,STRATUM_1_NAME,STRATUM_2_NAME,STRATUM_3_NAME,STRATUM_4_NAME,STRATUM_5_NAME,ANALYSIS_TYPE) values (1314,'Number of measurement records with no value (numeric, string, or concept)',null,null,null,null,null,'MEASUREMENT');
-insert into @results_schema.heracles_analysis (ANALYSIS_ID,ANALYSIS_NAME,STRATUM_1_NAME,STRATUM_2_NAME,STRATUM_3_NAME,STRATUM_4_NAME,STRATUM_5_NAME,ANALYSIS_TYPE) values (1315,'Distribution of numeric values, by measurement_concept_id and unit_concept_id',null,null,null,null,null,'MEASUREMENT');
-insert into @results_schema.heracles_analysis (ANALYSIS_ID,ANALYSIS_NAME,STRATUM_1_NAME,STRATUM_2_NAME,STRATUM_3_NAME,STRATUM_4_NAME,STRATUM_5_NAME,ANALYSIS_TYPE) values (1316,'Distribution of low range, by measurement_concept_id and unit_concept_id',null,null,null,null,null,'MEASUREMENT');
-insert into @results_schema.heracles_analysis (ANALYSIS_ID,ANALYSIS_NAME,STRATUM_1_NAME,STRATUM_2_NAME,STRATUM_3_NAME,STRATUM_4_NAME,STRATUM_5_NAME,ANALYSIS_TYPE) values (1317,'Distribution of high range, by measurement_concept_id and unit_concept_id',null,null,null,null,null,'MEASUREMENT');
-insert into @results_schema.heracles_analysis (ANALYSIS_ID,ANALYSIS_NAME,STRATUM_1_NAME,STRATUM_2_NAME,STRATUM_3_NAME,STRATUM_4_NAME,STRATUM_5_NAME,ANALYSIS_TYPE) values (1318,'Number of measurement records below/within/above normal range, by measurement_concept_id and unit_concept_id',null,null,null,null,null,'MEASUREMENT');
-insert into @results_schema.heracles_analysis (ANALYSIS_ID,ANALYSIS_NAME,STRATUM_1_NAME,STRATUM_2_NAME,STRATUM_3_NAME,STRATUM_4_NAME,STRATUM_5_NAME,ANALYSIS_TYPE) values (1320,'Number of measurement records  by measurement start month','calendar month',null,null,null,null,'MEASUREMENT');
-
+insert into @results_schema.heracles_analysis
+select    0 as analysis_id,
+CAST('Source name' as VARCHAR(255)) as analysis_name,
+NULL as stratum_1_name,
+NULL as stratum_2_name,
+NULL as stratum_3_name,
+NULL as stratum_4_name,
+NULL as stratum_5_name,
+CAST('PERSON' as VARCHAR(255)) as analysis_type
+union all
+select    1 as analysis_id,
+CAST('Number of persons' as VARCHAR(255)) as analysis_name,
+NULL as stratum_1_name,
+NULL as stratum_2_name,
+NULL as stratum_3_name,
+NULL as stratum_4_name,
+NULL as stratum_5_name,
+CAST('PERSON' as VARCHAR(255)) as analysis_type
+union all
+select    2 as analysis_id,
+CAST('Number of persons by gender' as VARCHAR(255)) as analysis_name,
+CAST('gender_concept_id' as VARCHAR(255)) as stratum_1_name,
+NULL as stratum_2_name,
+NULL as stratum_3_name,
+NULL as stratum_4_name,
+NULL as stratum_5_name,
+CAST('PERSON' as VARCHAR(255)) as analysis_type
+union all
+select    3 as analysis_id,
+CAST('Number of persons by year of birth' as VARCHAR(255)) as analysis_name,
+CAST('year_of_birth' as VARCHAR(255)) as stratum_1_name,
+NULL as stratum_2_name,
+NULL as stratum_3_name,
+NULL as stratum_4_name,
+NULL as stratum_5_name,
+CAST('PERSON' as VARCHAR(255)) as analysis_type
+union all
+select    4 as analysis_id,
+CAST('Number of persons by race' as VARCHAR(255)) as analysis_name,
+CAST('race_concept_id' as VARCHAR(255)) as stratum_1_name,
+NULL as stratum_2_name,
+NULL as stratum_3_name,
+NULL as stratum_4_name,
+NULL as stratum_5_name,
+CAST('PERSON' as VARCHAR(255)) as analysis_type
+union all
+select    5 as analysis_id,
+CAST('Number of persons by ethnicity' as VARCHAR(255)) as analysis_name,
+CAST('ethnicity_concept_id' as VARCHAR(255)) as stratum_1_name,
+NULL as stratum_2_name,
+NULL as stratum_3_name,
+NULL as stratum_4_name,
+NULL as stratum_5_name,
+CAST('PERSON' as VARCHAR(255)) as analysis_type
+union all
+select    7 as analysis_id,
+CAST('Number of persons with invalid provider_id' as VARCHAR(255)) as analysis_name,
+NULL as stratum_1_name,
+NULL as stratum_2_name,
+NULL as stratum_3_name,
+NULL as stratum_4_name,
+NULL as stratum_5_name,
+CAST('PERSON' as VARCHAR(255)) as analysis_type
+union all
+select    8 as analysis_id,
+CAST('Number of persons with invalid location_id' as VARCHAR(255)) as analysis_name,
+NULL as stratum_1_name,
+NULL as stratum_2_name,
+NULL as stratum_3_name,
+NULL as stratum_4_name,
+NULL as stratum_5_name,
+CAST('PERSON' as VARCHAR(255)) as analysis_type
+union all
+select    9 as analysis_id,
+CAST('Number of persons with invalid care_site_id' as VARCHAR(255)) as analysis_name,
+NULL as stratum_1_name,
+NULL as stratum_2_name,
+NULL as stratum_3_name,
+NULL as stratum_4_name,
+NULL as stratum_5_name,
+CAST('PERSON' as VARCHAR(255)) as analysis_type
+union all
+select  101 as analysis_id,
+CAST('Number of persons by age, with age at first observation period' as VARCHAR(255)) as analysis_name,
+CAST('age' as VARCHAR(255)) as stratum_1_name,
+NULL as stratum_2_name,
+NULL as stratum_3_name,
+NULL as stratum_4_name,
+NULL as stratum_5_name,
+CAST('OBSERVATION' as VARCHAR(255)) as analysis_type
+union all
+select  102 as analysis_id,
+CAST('Number of persons by gender by age, with age at first observation period' as VARCHAR(255)) as analysis_name,
+CAST('gender_concept_id' as VARCHAR(255)) as stratum_1_name,
+CAST('age' as VARCHAR(255)) as stratum_2_name,
+NULL as stratum_3_name,
+NULL as stratum_4_name,
+NULL as stratum_5_name,
+CAST('OBSERVATION' as VARCHAR(255)) as analysis_type
+union all
+select  103 as analysis_id,
+CAST('Distribution of age at first observation period' as VARCHAR(255)) as analysis_name,
+NULL as stratum_1_name,
+NULL as stratum_2_name,
+NULL as stratum_3_name,
+NULL as stratum_4_name,
+NULL as stratum_5_name,
+CAST('OBSERVATION' as VARCHAR(255)) as analysis_type
+union all
+select  104 as analysis_id,
+CAST('Distribution of age at first observation period by gender' as VARCHAR(255)) as analysis_name,
+CAST('gender_concept_id' as VARCHAR(255)) as stratum_1_name,
+NULL as stratum_2_name,
+NULL as stratum_3_name,
+NULL as stratum_4_name,
+NULL as stratum_5_name,
+CAST('OBSERVATION' as VARCHAR(255)) as analysis_type
+union all
+select  105 as analysis_id,
+CAST('Length of observation (days) of first observation period' as VARCHAR(255)) as analysis_name,
+NULL as stratum_1_name,
+NULL as stratum_2_name,
+NULL as stratum_3_name,
+NULL as stratum_4_name,
+NULL as stratum_5_name,
+CAST('OBSERVATION' as VARCHAR(255)) as analysis_type
+union all
+select  106 as analysis_id,
+CAST('Length of observation (days) of first observation period by gender' as VARCHAR(255)) as analysis_name,
+CAST('gender_concept_id' as VARCHAR(255)) as stratum_1_name,
+NULL as stratum_2_name,
+NULL as stratum_3_name,
+NULL as stratum_4_name,
+NULL as stratum_5_name,
+CAST('OBSERVATION' as VARCHAR(255)) as analysis_type
+union all
+select  107 as analysis_id,
+CAST('Length of observation (days) of first observation period by age decile' as VARCHAR(255)) as analysis_name,
+CAST('age decile' as VARCHAR(255)) as stratum_1_name,
+NULL as stratum_2_name,
+NULL as stratum_3_name,
+NULL as stratum_4_name,
+NULL as stratum_5_name,
+CAST('OBSERVATION' as VARCHAR(255)) as analysis_type
+union all
+select  108 as analysis_id,
+CAST('Number of persons by length of observation period, in 30d increments' as VARCHAR(255)) as analysis_name,
+CAST('Observation period length 30d increments' as VARCHAR(255)) as stratum_1_name,
+NULL as stratum_2_name,
+NULL as stratum_3_name,
+NULL as stratum_4_name,
+NULL as stratum_5_name,
+CAST('OBSERVATION' as VARCHAR(255)) as analysis_type
+union all
+select  109 as analysis_id,
+CAST('Number of persons with continuous observation in each year' as VARCHAR(255)) as analysis_name,
+CAST('calendar year' as VARCHAR(255)) as stratum_1_name,
+NULL as stratum_2_name,
+NULL as stratum_3_name,
+NULL as stratum_4_name,
+NULL as stratum_5_name,
+CAST('OBSERVATION' as VARCHAR(255)) as analysis_type
+union all
+select  110 as analysis_id,
+CAST('Number of persons with continuous observation in each month' as VARCHAR(255)) as analysis_name,
+CAST('calendar month' as VARCHAR(255)) as stratum_1_name,
+NULL as stratum_2_name,
+NULL as stratum_3_name,
+NULL as stratum_4_name,
+NULL as stratum_5_name,
+CAST('OBSERVATION' as VARCHAR(255)) as analysis_type
+union all
+select  111 as analysis_id,
+CAST('Number of persons by observation period start month' as VARCHAR(255)) as analysis_name,
+CAST('calendar month' as VARCHAR(255)) as stratum_1_name,
+NULL as stratum_2_name,
+NULL as stratum_3_name,
+NULL as stratum_4_name,
+NULL as stratum_5_name,
+CAST('OBSERVATION' as VARCHAR(255)) as analysis_type
+union all
+select  112 as analysis_id,
+CAST('Number of persons by observation period end month' as VARCHAR(255)) as analysis_name,
+CAST('calendar month' as VARCHAR(255)) as stratum_1_name,
+NULL as stratum_2_name,
+NULL as stratum_3_name,
+NULL as stratum_4_name,
+NULL as stratum_5_name,
+CAST('OBSERVATION' as VARCHAR(255)) as analysis_type
+union all
+select  113 as analysis_id,
+CAST('Number of persons by number of observation periods' as VARCHAR(255)) as analysis_name,
+CAST('number of observation periods' as VARCHAR(255)) as stratum_1_name,
+NULL as stratum_2_name,
+NULL as stratum_3_name,
+NULL as stratum_4_name,
+NULL as stratum_5_name,
+CAST('OBSERVATION' as VARCHAR(255)) as analysis_type
+union all
+select  114 as analysis_id,
+CAST('Number of persons with observation period before year-of-birth' as VARCHAR(255)) as analysis_name,
+NULL as stratum_1_name,
+NULL as stratum_2_name,
+NULL as stratum_3_name,
+NULL as stratum_4_name,
+NULL as stratum_5_name,
+CAST('OBSERVATION' as VARCHAR(255)) as analysis_type
+union all
+select  115 as analysis_id,
+CAST('Number of persons with observation period end < observation period start' as VARCHAR(255)) as analysis_name,
+NULL as stratum_1_name,
+NULL as stratum_2_name,
+NULL as stratum_3_name,
+NULL as stratum_4_name,
+NULL as stratum_5_name,
+CAST('OBSERVATION' as VARCHAR(255)) as analysis_type
+union all
+select  116 as analysis_id,
+CAST('Number of persons with at least one day of observation in each year by gender and age decile' as VARCHAR(255)) as analysis_name,
+CAST('calendar year' as VARCHAR(255)) as stratum_1_name,
+CAST('gender_concept_id' as VARCHAR(255)) as stratum_2_name,
+CAST('age decile' as VARCHAR(255)) as stratum_3_name,
+NULL as stratum_4_name,
+NULL as stratum_5_name,
+CAST('OBSERVATION' as VARCHAR(255)) as analysis_type
+union all
+select  117 as analysis_id,
+CAST('Number of persons with at least one day of observation in each month' as VARCHAR(255)) as analysis_name,
+CAST('calendar month' as VARCHAR(255)) as stratum_1_name,
+NULL as stratum_2_name,
+NULL as stratum_3_name,
+NULL as stratum_4_name,
+NULL as stratum_5_name,
+CAST('OBSERVATION' as VARCHAR(255)) as analysis_type
+union all
+select  200 as analysis_id,
+CAST('Number of persons with at least one visit occurrence, by visit_concept_id' as VARCHAR(255)) as analysis_name,
+CAST('visit_concept_id' as VARCHAR(255)) as stratum_1_name,
+NULL as stratum_2_name,
+NULL as stratum_3_name,
+NULL as stratum_4_name,
+NULL as stratum_5_name,
+CAST('VISITS' as VARCHAR(255)) as analysis_type
+union all
+select  201 as analysis_id,
+CAST('Number of visit occurrence records, by visit_concept_id' as VARCHAR(255)) as analysis_name,
+CAST('visit_concept_id' as VARCHAR(255)) as stratum_1_name,
+NULL as stratum_2_name,
+NULL as stratum_3_name,
+NULL as stratum_4_name,
+NULL as stratum_5_name,
+CAST('VISITS' as VARCHAR(255)) as analysis_type
+union all
+select  202 as analysis_id,
+CAST('Number of persons by visit occurrence start month, by visit_concept_id' as VARCHAR(255)) as analysis_name,
+CAST('visit_concept_id' as VARCHAR(255)) as stratum_1_name,
+CAST('calendar month' as VARCHAR(255)) as stratum_2_name,
+NULL as stratum_3_name,
+NULL as stratum_4_name,
+NULL as stratum_5_name,
+CAST('VISITS' as VARCHAR(255)) as analysis_type
+union all
+select  203 as analysis_id,
+CAST('Number of distinct visit occurrence concepts per person' as VARCHAR(255)) as analysis_name,
+NULL as stratum_1_name,
+NULL as stratum_2_name,
+NULL as stratum_3_name,
+NULL as stratum_4_name,
+NULL as stratum_5_name,
+CAST('VISITS' as VARCHAR(255)) as analysis_type
+union all
+select  204 as analysis_id,
+CAST('Number of persons with at least one visit occurrence, by visit_concept_id by calendar year by gender by age decile' as VARCHAR(255)) as analysis_name,
+CAST('visit_concept_id' as VARCHAR(255)) as stratum_1_name,
+CAST('calendar year' as VARCHAR(255)) as stratum_2_name,
+CAST('gender_concept_id' as VARCHAR(255)) as stratum_3_name,
+CAST('age decile' as VARCHAR(255)) as stratum_4_name,
+NULL as stratum_5_name,
+CAST('VISITS' as VARCHAR(255)) as analysis_type
+union all
+select  206 as analysis_id,
+CAST('Distribution of age by visit_concept_id' as VARCHAR(255)) as analysis_name,
+CAST('visit_concept_id' as VARCHAR(255)) as stratum_1_name,
+CAST('gender_concept_id' as VARCHAR(255)) as stratum_2_name,
+NULL as stratum_3_name,
+NULL as stratum_4_name,
+NULL as stratum_5_name,
+CAST('VISITS' as VARCHAR(255)) as analysis_type
+union all
+select  207 as analysis_id,
+CAST('Number of visit records with invalid person_id' as VARCHAR(255)) as analysis_name,
+NULL as stratum_1_name,
+NULL as stratum_2_name,
+NULL as stratum_3_name,
+NULL as stratum_4_name,
+NULL as stratum_5_name,
+CAST('VISITS' as VARCHAR(255)) as analysis_type
+union all
+select  208 as analysis_id,
+CAST('Number of visit records outside valid observation period' as VARCHAR(255)) as analysis_name,
+NULL as stratum_1_name,
+NULL as stratum_2_name,
+NULL as stratum_3_name,
+NULL as stratum_4_name,
+NULL as stratum_5_name,
+CAST('VISITS' as VARCHAR(255)) as analysis_type
+union all
+select  209 as analysis_id,
+CAST('Number of visit records with end date < start date' as VARCHAR(255)) as analysis_name,
+NULL as stratum_1_name,
+NULL as stratum_2_name,
+NULL as stratum_3_name,
+NULL as stratum_4_name,
+NULL as stratum_5_name,
+CAST('VISITS' as VARCHAR(255)) as analysis_type
+union all
+select  210 as analysis_id,
+CAST('Number of visit records with invalid care_site_id' as VARCHAR(255)) as analysis_name,
+NULL as stratum_1_name,
+NULL as stratum_2_name,
+NULL as stratum_3_name,
+NULL as stratum_4_name,
+NULL as stratum_5_name,
+CAST('VISITS' as VARCHAR(255)) as analysis_type
+union all
+select  211 as analysis_id,
+CAST('Distribution of length of stay by visit_concept_id' as VARCHAR(255)) as analysis_name,
+CAST('visit_concept_id' as VARCHAR(255)) as stratum_1_name,
+NULL as stratum_2_name,
+NULL as stratum_3_name,
+NULL as stratum_4_name,
+NULL as stratum_5_name,
+CAST('VISITS' as VARCHAR(255)) as analysis_type
+union all
+select  220 as analysis_id,
+CAST('Number of visit occurrence records by visit occurrence start month' as VARCHAR(255)) as analysis_name,
+CAST('calendar month' as VARCHAR(255)) as stratum_1_name,
+NULL as stratum_2_name,
+NULL as stratum_3_name,
+NULL as stratum_4_name,
+NULL as stratum_5_name,
+CAST('VISITS' as VARCHAR(255)) as analysis_type
+union all
+select  400 as analysis_id,
+CAST('Number of persons with at least one condition occurrence, by condition_concept_id' as VARCHAR(255)) as analysis_name,
+CAST('condition_concept_id' as VARCHAR(255)) as stratum_1_name,
+NULL as stratum_2_name,
+NULL as stratum_3_name,
+NULL as stratum_4_name,
+NULL as stratum_5_name,
+CAST('CONDITION' as VARCHAR(255)) as analysis_type
+union all
+select  401 as analysis_id,
+CAST('Number of condition occurrence records, by condition_concept_id' as VARCHAR(255)) as analysis_name,
+CAST('condition_concept_id' as VARCHAR(255)) as stratum_1_name,
+NULL as stratum_2_name,
+NULL as stratum_3_name,
+NULL as stratum_4_name,
+NULL as stratum_5_name,
+CAST('CONDITION' as VARCHAR(255)) as analysis_type
+union all
+select  402 as analysis_id,
+CAST('Number of persons by condition occurrence start month, by condition_concept_id' as VARCHAR(255)) as analysis_name,
+CAST('condition_concept_id' as VARCHAR(255)) as stratum_1_name,
+CAST('calendar month' as VARCHAR(255)) as stratum_2_name,
+NULL as stratum_3_name,
+NULL as stratum_4_name,
+NULL as stratum_5_name,
+CAST('CONDITION' as VARCHAR(255)) as analysis_type
+union all
+select  403 as analysis_id,
+CAST('Number of distinct condition occurrence concepts per person' as VARCHAR(255)) as analysis_name,
+NULL as stratum_1_name,
+NULL as stratum_2_name,
+NULL as stratum_3_name,
+NULL as stratum_4_name,
+NULL as stratum_5_name,
+CAST('CONDITION' as VARCHAR(255)) as analysis_type
+union all
+select  404 as analysis_id,
+CAST('Number of persons with at least one condition occurrence, by condition_concept_id by calendar year by gender by age decile' as VARCHAR(255)) as analysis_name,
+CAST('condition_concept_id' as VARCHAR(255)) as stratum_1_name,
+CAST('calendar year' as VARCHAR(255)) as stratum_2_name,
+CAST('gender_concept_id' as VARCHAR(255)) as stratum_3_name,
+CAST('age decile' as VARCHAR(255)) as stratum_4_name,
+NULL as stratum_5_name,
+CAST('CONDITION' as VARCHAR(255)) as analysis_type
+union all
+select  405 as analysis_id,
+CAST('Number of condition occurrence records, by condition_concept_id by condition_type_concept_id' as VARCHAR(255)) as analysis_name,
+CAST('condition_concept_id' as VARCHAR(255)) as stratum_1_name,
+CAST('condition_type_concept_id' as VARCHAR(255)) as stratum_2_name,
+NULL as stratum_3_name,
+NULL as stratum_4_name,
+NULL as stratum_5_name,
+CAST('CONDITION' as VARCHAR(255)) as analysis_type
+union all
+select  406 as analysis_id,
+CAST('Distribution of age by condition_concept_id' as VARCHAR(255)) as analysis_name,
+CAST('condition_concept_id' as VARCHAR(255)) as stratum_1_name,
+CAST('gender_concept_id' as VARCHAR(255)) as stratum_2_name,
+NULL as stratum_3_name,
+NULL as stratum_4_name,
+NULL as stratum_5_name,
+CAST('CONDITION' as VARCHAR(255)) as analysis_type
+union all
+select  409 as analysis_id,
+CAST('Number of condition occurrence records with invalid person_id' as VARCHAR(255)) as analysis_name,
+NULL as stratum_1_name,
+NULL as stratum_2_name,
+NULL as stratum_3_name,
+NULL as stratum_4_name,
+NULL as stratum_5_name,
+CAST('CONDITION' as VARCHAR(255)) as analysis_type
+union all
+select  410 as analysis_id,
+CAST('Number of condition occurrence records outside valid observation period' as VARCHAR(255)) as analysis_name,
+NULL as stratum_1_name,
+NULL as stratum_2_name,
+NULL as stratum_3_name,
+NULL as stratum_4_name,
+NULL as stratum_5_name,
+CAST('CONDITION' as VARCHAR(255)) as analysis_type
+union all
+select  411 as analysis_id,
+CAST('Number of condition occurrence records with end date < start date' as VARCHAR(255)) as analysis_name,
+NULL as stratum_1_name,
+NULL as stratum_2_name,
+NULL as stratum_3_name,
+NULL as stratum_4_name,
+NULL as stratum_5_name,
+CAST('CONDITION' as VARCHAR(255)) as analysis_type
+union all
+select  412 as analysis_id,
+CAST('Number of condition occurrence records with invalid provider_id' as VARCHAR(255)) as analysis_name,
+NULL as stratum_1_name,
+NULL as stratum_2_name,
+NULL as stratum_3_name,
+NULL as stratum_4_name,
+NULL as stratum_5_name,
+CAST('CONDITION' as VARCHAR(255)) as analysis_type
+union all
+select  413 as analysis_id,
+CAST('Number of condition occurrence records with invalid visit_id' as VARCHAR(255)) as analysis_name,
+NULL as stratum_1_name,
+NULL as stratum_2_name,
+NULL as stratum_3_name,
+NULL as stratum_4_name,
+NULL as stratum_5_name,
+CAST('CONDITION' as VARCHAR(255)) as analysis_type
+union all
+select  420 as analysis_id,
+CAST('Number of condition occurrence records by condition occurrence start month' as VARCHAR(255)) as analysis_name,
+CAST('calendar month' as VARCHAR(255)) as stratum_1_name,
+NULL as stratum_2_name,
+NULL as stratum_3_name,
+NULL as stratum_4_name,
+NULL as stratum_5_name,
+CAST('CONDITION' as VARCHAR(255)) as analysis_type
+union all
+select  500 as analysis_id,
+CAST('Number of persons with death, by cause_of_death_concept_id' as VARCHAR(255)) as analysis_name,
+CAST('cause_of_death_concept_id' as VARCHAR(255)) as stratum_1_name,
+NULL as stratum_2_name,
+NULL as stratum_3_name,
+NULL as stratum_4_name,
+NULL as stratum_5_name,
+CAST('DEATH' as VARCHAR(255)) as analysis_type
+union all
+select  501 as analysis_id,
+CAST('Number of records of death, by cause_of_death_concept_id' as VARCHAR(255)) as analysis_name,
+CAST('cause_of_death_concept_id' as VARCHAR(255)) as stratum_1_name,
+NULL as stratum_2_name,
+NULL as stratum_3_name,
+NULL as stratum_4_name,
+NULL as stratum_5_name,
+CAST('DEATH' as VARCHAR(255)) as analysis_type
+union all
+select  502 as analysis_id,
+CAST('Number of persons by death month' as VARCHAR(255)) as analysis_name,
+CAST('calendar month' as VARCHAR(255)) as stratum_1_name,
+NULL as stratum_2_name,
+NULL as stratum_3_name,
+NULL as stratum_4_name,
+NULL as stratum_5_name,
+CAST('DEATH' as VARCHAR(255)) as analysis_type
+union all
+select  504 as analysis_id,
+CAST('Number of persons with a death, by calendar year by gender by age decile' as VARCHAR(255)) as analysis_name,
+CAST('calendar year' as VARCHAR(255)) as stratum_1_name,
+CAST('gender_concept_id' as VARCHAR(255)) as stratum_2_name,
+CAST('age decile' as VARCHAR(255)) as stratum_3_name,
+NULL as stratum_4_name,
+NULL as stratum_5_name,
+CAST('DEATH' as VARCHAR(255)) as analysis_type
+union all
+select  505 as analysis_id,
+CAST('Number of death records, by death_type_concept_id' as VARCHAR(255)) as analysis_name,
+CAST('death_type_concept_id' as VARCHAR(255)) as stratum_1_name,
+NULL as stratum_2_name,
+NULL as stratum_3_name,
+NULL as stratum_4_name,
+NULL as stratum_5_name,
+CAST('DEATH' as VARCHAR(255)) as analysis_type
+union all
+select  506 as analysis_id,
+CAST('Distribution of age at death by gender' as VARCHAR(255)) as analysis_name,
+CAST('gender_concept_id' as VARCHAR(255)) as stratum_1_name,
+NULL as stratum_2_name,
+NULL as stratum_3_name,
+NULL as stratum_4_name,
+NULL as stratum_5_name,
+CAST('DEATH' as VARCHAR(255)) as analysis_type
+union all
+select  509 as analysis_id,
+CAST('Number of death records with invalid person_id' as VARCHAR(255)) as analysis_name,
+NULL as stratum_1_name,
+NULL as stratum_2_name,
+NULL as stratum_3_name,
+NULL as stratum_4_name,
+NULL as stratum_5_name,
+CAST('DEATH' as VARCHAR(255)) as analysis_type
+union all
+select  510 as analysis_id,
+CAST('Number of death records outside valid observation period' as VARCHAR(255)) as analysis_name,
+NULL as stratum_1_name,
+NULL as stratum_2_name,
+NULL as stratum_3_name,
+NULL as stratum_4_name,
+NULL as stratum_5_name,
+CAST('DEATH' as VARCHAR(255)) as analysis_type
+union all
+select  511 as analysis_id,
+CAST('Distribution of time from death to last condition' as VARCHAR(255)) as analysis_name,
+NULL as stratum_1_name,
+NULL as stratum_2_name,
+NULL as stratum_3_name,
+NULL as stratum_4_name,
+NULL as stratum_5_name,
+CAST('DEATH' as VARCHAR(255)) as analysis_type
+union all
+select  512 as analysis_id,
+CAST('Distribution of time from death to last drug' as VARCHAR(255)) as analysis_name,
+NULL as stratum_1_name,
+NULL as stratum_2_name,
+NULL as stratum_3_name,
+NULL as stratum_4_name,
+NULL as stratum_5_name,
+CAST('DEATH' as VARCHAR(255)) as analysis_type
+union all
+select  513 as analysis_id,
+CAST('Distribution of time from death to last visit' as VARCHAR(255)) as analysis_name,
+NULL as stratum_1_name,
+NULL as stratum_2_name,
+NULL as stratum_3_name,
+NULL as stratum_4_name,
+NULL as stratum_5_name,
+CAST('DEATH' as VARCHAR(255)) as analysis_type
+union all
+select  514 as analysis_id,
+CAST('Distribution of time from death to last procedure' as VARCHAR(255)) as analysis_name,
+NULL as stratum_1_name,
+NULL as stratum_2_name,
+NULL as stratum_3_name,
+NULL as stratum_4_name,
+NULL as stratum_5_name,
+CAST('DEATH' as VARCHAR(255)) as analysis_type
+union all
+select  515 as analysis_id,
+CAST('Distribution of time from death to last observation' as VARCHAR(255)) as analysis_name,
+NULL as stratum_1_name,
+NULL as stratum_2_name,
+NULL as stratum_3_name,
+NULL as stratum_4_name,
+NULL as stratum_5_name,
+CAST('DEATH' as VARCHAR(255)) as analysis_type
+union all
+select  600 as analysis_id,
+CAST('Number of persons with at least one procedure occurrence, by procedure_concept_id' as VARCHAR(255)) as analysis_name,
+CAST('procedure_concept_id' as VARCHAR(255)) as stratum_1_name,
+NULL as stratum_2_name,
+NULL as stratum_3_name,
+NULL as stratum_4_name,
+NULL as stratum_5_name,
+CAST('PROCEDURE' as VARCHAR(255)) as analysis_type
+union all
+select  601 as analysis_id,
+CAST('Number of procedure occurrence records, by procedure_concept_id' as VARCHAR(255)) as analysis_name,
+CAST('procedure_concept_id' as VARCHAR(255)) as stratum_1_name,
+NULL as stratum_2_name,
+NULL as stratum_3_name,
+NULL as stratum_4_name,
+NULL as stratum_5_name,
+CAST('PROCEDURE' as VARCHAR(255)) as analysis_type
+union all
+select  602 as analysis_id,
+CAST('Number of persons by procedure occurrence start month, by procedure_concept_id' as VARCHAR(255)) as analysis_name,
+CAST('procedure_concept_id' as VARCHAR(255)) as stratum_1_name,
+CAST('calendar month' as VARCHAR(255)) as stratum_2_name,
+NULL as stratum_3_name,
+NULL as stratum_4_name,
+NULL as stratum_5_name,
+CAST('PROCEDURE' as VARCHAR(255)) as analysis_type
+union all
+select  603 as analysis_id,
+CAST('Number of distinct procedure occurrence concepts per person' as VARCHAR(255)) as analysis_name,
+NULL as stratum_1_name,
+NULL as stratum_2_name,
+NULL as stratum_3_name,
+NULL as stratum_4_name,
+NULL as stratum_5_name,
+CAST('PROCEDURE' as VARCHAR(255)) as analysis_type
+union all
+select  604 as analysis_id,
+CAST('Number of persons with at least one procedure occurrence, by procedure_concept_id by calendar year by gender by age decile' as VARCHAR(255)) as analysis_name,
+CAST('procedure_concept_id' as VARCHAR(255)) as stratum_1_name,
+CAST('calendar year' as VARCHAR(255)) as stratum_2_name,
+CAST('gender_concept_id' as VARCHAR(255)) as stratum_3_name,
+CAST('age decile' as VARCHAR(255)) as stratum_4_name,
+NULL as stratum_5_name,
+CAST('PROCEDURE' as VARCHAR(255)) as analysis_type
+union all
+select  605 as analysis_id,
+CAST('Number of procedure occurrence records, by procedure_concept_id by procedure_type_concept_id' as VARCHAR(255)) as analysis_name,
+CAST('procedure_concept_id' as VARCHAR(255)) as stratum_1_name,
+CAST('procedure_type_concept_id' as VARCHAR(255)) as stratum_2_name,
+NULL as stratum_3_name,
+NULL as stratum_4_name,
+NULL as stratum_5_name,
+CAST('PROCEDURE' as VARCHAR(255)) as analysis_type
+union all
+select  606 as analysis_id,
+CAST('Distribution of age by procedure_concept_id' as VARCHAR(255)) as analysis_name,
+CAST('procedure_concept_id' as VARCHAR(255)) as stratum_1_name,
+CAST('gender_concept_id' as VARCHAR(255)) as stratum_2_name,
+NULL as stratum_3_name,
+NULL as stratum_4_name,
+NULL as stratum_5_name,
+CAST('PROCEDURE' as VARCHAR(255)) as analysis_type
+union all
+select  609 as analysis_id,
+CAST('Number of procedure occurrence records with invalid person_id' as VARCHAR(255)) as analysis_name,
+NULL as stratum_1_name,
+NULL as stratum_2_name,
+NULL as stratum_3_name,
+NULL as stratum_4_name,
+NULL as stratum_5_name,
+CAST('PROCEDURE' as VARCHAR(255)) as analysis_type
+union all
+select  610 as analysis_id,
+CAST('Number of procedure occurrence records outside valid observation period' as VARCHAR(255)) as analysis_name,
+NULL as stratum_1_name,
+NULL as stratum_2_name,
+NULL as stratum_3_name,
+NULL as stratum_4_name,
+NULL as stratum_5_name,
+CAST('PROCEDURE' as VARCHAR(255)) as analysis_type
+union all
+select  612 as analysis_id,
+CAST('Number of procedure occurrence records with invalid provider_id' as VARCHAR(255)) as analysis_name,
+NULL as stratum_1_name,
+NULL as stratum_2_name,
+NULL as stratum_3_name,
+NULL as stratum_4_name,
+NULL as stratum_5_name,
+CAST('PROCEDURE' as VARCHAR(255)) as analysis_type
+union all
+select  613 as analysis_id,
+CAST('Number of procedure occurrence records with invalid visit_id' as VARCHAR(255)) as analysis_name,
+NULL as stratum_1_name,
+NULL as stratum_2_name,
+NULL as stratum_3_name,
+NULL as stratum_4_name,
+NULL as stratum_5_name,
+CAST('PROCEDURE' as VARCHAR(255)) as analysis_type
+union all
+select  620 as analysis_id,
+CAST('Number of procedure occurrence records  by procedure occurrence start month' as VARCHAR(255)) as analysis_name,
+CAST('calendar month' as VARCHAR(255)) as stratum_1_name,
+NULL as stratum_2_name,
+NULL as stratum_3_name,
+NULL as stratum_4_name,
+NULL as stratum_5_name,
+CAST('PROCEDURE' as VARCHAR(255)) as analysis_type
+union all
+select  700 as analysis_id,
+CAST('Number of persons with at least one drug exposure, by drug_concept_id' as VARCHAR(255)) as analysis_name,
+CAST('drug_concept_id' as VARCHAR(255)) as stratum_1_name,
+NULL as stratum_2_name,
+NULL as stratum_3_name,
+NULL as stratum_4_name,
+NULL as stratum_5_name,
+CAST('DRUG' as VARCHAR(255)) as analysis_type
+union all
+select  701 as analysis_id,
+CAST('Number of drug exposure records, by drug_concept_id' as VARCHAR(255)) as analysis_name,
+CAST('drug_concept_id' as VARCHAR(255)) as stratum_1_name,
+NULL as stratum_2_name,
+NULL as stratum_3_name,
+NULL as stratum_4_name,
+NULL as stratum_5_name,
+CAST('DRUG' as VARCHAR(255)) as analysis_type
+union all
+select  702 as analysis_id,
+CAST('Number of persons by drug exposure start month, by drug_concept_id' as VARCHAR(255)) as analysis_name,
+CAST('drug_concept_id' as VARCHAR(255)) as stratum_1_name,
+CAST('calendar month' as VARCHAR(255)) as stratum_2_name,
+NULL as stratum_3_name,
+NULL as stratum_4_name,
+NULL as stratum_5_name,
+CAST('DRUG' as VARCHAR(255)) as analysis_type
+union all
+select  703 as analysis_id,
+CAST('Number of distinct drug exposure concepts per person' as VARCHAR(255)) as analysis_name,
+NULL as stratum_1_name,
+NULL as stratum_2_name,
+NULL as stratum_3_name,
+NULL as stratum_4_name,
+NULL as stratum_5_name,
+CAST('DRUG' as VARCHAR(255)) as analysis_type
+union all
+select  704 as analysis_id,
+CAST('Number of persons with at least one drug exposure, by drug_concept_id by calendar year by gender by age decile' as VARCHAR(255)) as analysis_name,
+CAST('drug_concept_id' as VARCHAR(255)) as stratum_1_name,
+CAST('calendar year' as VARCHAR(255)) as stratum_2_name,
+CAST('gender_concept_id' as VARCHAR(255)) as stratum_3_name,
+CAST('age decile' as VARCHAR(255)) as stratum_4_name,
+NULL as stratum_5_name,
+CAST('DRUG' as VARCHAR(255)) as analysis_type
+union all
+select  705 as analysis_id,
+CAST('Number of drug exposure records, by drug_concept_id by drug_type_concept_id' as VARCHAR(255)) as analysis_name,
+CAST('drug_concept_id' as VARCHAR(255)) as stratum_1_name,
+CAST('drug_type_concept_id' as VARCHAR(255)) as stratum_2_name,
+NULL as stratum_3_name,
+NULL as stratum_4_name,
+NULL as stratum_5_name,
+CAST('DRUG' as VARCHAR(255)) as analysis_type
+union all
+select  706 as analysis_id,
+CAST('Distribution of age by drug_concept_id' as VARCHAR(255)) as analysis_name,
+CAST('drug_concept_id' as VARCHAR(255)) as stratum_1_name,
+CAST('gender_concept_id' as VARCHAR(255)) as stratum_2_name,
+NULL as stratum_3_name,
+NULL as stratum_4_name,
+NULL as stratum_5_name,
+CAST('DRUG' as VARCHAR(255)) as analysis_type
+union all
+select  709 as analysis_id,
+CAST('Number of drug exposure records with invalid person_id' as VARCHAR(255)) as analysis_name,
+NULL as stratum_1_name,
+NULL as stratum_2_name,
+NULL as stratum_3_name,
+NULL as stratum_4_name,
+NULL as stratum_5_name,
+CAST('DRUG' as VARCHAR(255)) as analysis_type
+union all
+select  710 as analysis_id,
+CAST('Number of drug exposure records outside valid observation period' as VARCHAR(255)) as analysis_name,
+NULL as stratum_1_name,
+NULL as stratum_2_name,
+NULL as stratum_3_name,
+NULL as stratum_4_name,
+NULL as stratum_5_name,
+CAST('DRUG' as VARCHAR(255)) as analysis_type
+union all
+select  711 as analysis_id,
+CAST('Number of drug exposure records with end date < start date' as VARCHAR(255)) as analysis_name,
+NULL as stratum_1_name,
+NULL as stratum_2_name,
+NULL as stratum_3_name,
+NULL as stratum_4_name,
+NULL as stratum_5_name,
+CAST('DRUG' as VARCHAR(255)) as analysis_type
+union all
+select  712 as analysis_id,
+CAST('Number of drug exposure records with invalid provider_id' as VARCHAR(255)) as analysis_name,
+NULL as stratum_1_name,
+NULL as stratum_2_name,
+NULL as stratum_3_name,
+NULL as stratum_4_name,
+NULL as stratum_5_name,
+CAST('DRUG' as VARCHAR(255)) as analysis_type
+union all
+select  713 as analysis_id,
+CAST('Number of drug exposure records with invalid visit_id' as VARCHAR(255)) as analysis_name,
+NULL as stratum_1_name,
+NULL as stratum_2_name,
+NULL as stratum_3_name,
+NULL as stratum_4_name,
+NULL as stratum_5_name,
+CAST('DRUG' as VARCHAR(255)) as analysis_type
+union all
+select  715 as analysis_id,
+CAST('Distribution of days_supply by drug_concept_id' as VARCHAR(255)) as analysis_name,
+CAST('drug_concept_id' as VARCHAR(255)) as stratum_1_name,
+NULL as stratum_2_name,
+NULL as stratum_3_name,
+NULL as stratum_4_name,
+NULL as stratum_5_name,
+CAST('DRUG' as VARCHAR(255)) as analysis_type
+union all
+select  716 as analysis_id,
+CAST('Distribution of refills by drug_concept_id' as VARCHAR(255)) as analysis_name,
+CAST('drug_concept_id' as VARCHAR(255)) as stratum_1_name,
+NULL as stratum_2_name,
+NULL as stratum_3_name,
+NULL as stratum_4_name,
+NULL as stratum_5_name,
+CAST('DRUG' as VARCHAR(255)) as analysis_type
+union all
+select  717 as analysis_id,
+CAST('Distribution of quantity by drug_concept_id' as VARCHAR(255)) as analysis_name,
+CAST('drug_concept_id' as VARCHAR(255)) as stratum_1_name,
+NULL as stratum_2_name,
+NULL as stratum_3_name,
+NULL as stratum_4_name,
+NULL as stratum_5_name,
+CAST('DRUG' as VARCHAR(255)) as analysis_type
+union all
+select  720 as analysis_id,
+CAST('Number of drug exposure records  by drug exposure start month' as VARCHAR(255)) as analysis_name,
+CAST('calendar month' as VARCHAR(255)) as stratum_1_name,
+NULL as stratum_2_name,
+NULL as stratum_3_name,
+NULL as stratum_4_name,
+NULL as stratum_5_name,
+CAST('DRUG' as VARCHAR(255)) as analysis_type
+union all
+select  800 as analysis_id,
+CAST('Number of persons with at least one observation occurrence, by observation_concept_id' as VARCHAR(255)) as analysis_name,
+CAST('observation_concept_id' as VARCHAR(255)) as stratum_1_name,
+NULL as stratum_2_name,
+NULL as stratum_3_name,
+NULL as stratum_4_name,
+NULL as stratum_5_name,
+CAST('OBSERVATION' as VARCHAR(255)) as analysis_type
+union all
+select  801 as analysis_id,
+CAST('Number of observation occurrence records, by observation_concept_id' as VARCHAR(255)) as analysis_name,
+CAST('observation_concept_id' as VARCHAR(255)) as stratum_1_name,
+NULL as stratum_2_name,
+NULL as stratum_3_name,
+NULL as stratum_4_name,
+NULL as stratum_5_name,
+CAST('OBSERVATION' as VARCHAR(255)) as analysis_type
+union all
+select  802 as analysis_id,
+CAST('Number of persons by observation occurrence start month, by observation_concept_id' as VARCHAR(255)) as analysis_name,
+CAST('observation_concept_id' as VARCHAR(255)) as stratum_1_name,
+CAST('calendar month' as VARCHAR(255)) as stratum_2_name,
+NULL as stratum_3_name,
+NULL as stratum_4_name,
+NULL as stratum_5_name,
+CAST('OBSERVATION' as VARCHAR(255)) as analysis_type
+union all
+select  803 as analysis_id,
+CAST('Number of distinct observation occurrence concepts per person' as VARCHAR(255)) as analysis_name,
+NULL as stratum_1_name,
+NULL as stratum_2_name,
+NULL as stratum_3_name,
+NULL as stratum_4_name,
+NULL as stratum_5_name,
+CAST('OBSERVATION' as VARCHAR(255)) as analysis_type
+union all
+select  804 as analysis_id,
+CAST('Number of persons with at least one observation occurrence, by observation_concept_id by calendar year by gender by age decile' as VARCHAR(255)) as analysis_name,
+CAST('observation_concept_id' as VARCHAR(255)) as stratum_1_name,
+CAST('calendar year' as VARCHAR(255)) as stratum_2_name,
+CAST('gender_concept_id' as VARCHAR(255)) as stratum_3_name,
+CAST('age decile' as VARCHAR(255)) as stratum_4_name,
+NULL as stratum_5_name,
+CAST('OBSERVATION' as VARCHAR(255)) as analysis_type
+union all
+select  805 as analysis_id,
+CAST('Number of observation occurrence records, by observation_concept_id by observation_type_concept_id' as VARCHAR(255)) as analysis_name,
+CAST('observation_concept_id' as VARCHAR(255)) as stratum_1_name,
+CAST('observation_type_concept_id' as VARCHAR(255)) as stratum_2_name,
+NULL as stratum_3_name,
+NULL as stratum_4_name,
+NULL as stratum_5_name,
+CAST('OBSERVATION' as VARCHAR(255)) as analysis_type
+union all
+select  806 as analysis_id,
+CAST('Distribution of age by observation_concept_id' as VARCHAR(255)) as analysis_name,
+CAST('observation_concept_id' as VARCHAR(255)) as stratum_1_name,
+CAST('gender_concept_id' as VARCHAR(255)) as stratum_2_name,
+NULL as stratum_3_name,
+NULL as stratum_4_name,
+NULL as stratum_5_name,
+CAST('OBSERVATION' as VARCHAR(255)) as analysis_type
+union all
+select  807 as analysis_id,
+CAST('Number of observation occurrence records, by observation_concept_id and unit_concept_id' as VARCHAR(255)) as analysis_name,
+CAST('observation_concept_id' as VARCHAR(255)) as stratum_1_name,
+CAST('unit_concept_id' as VARCHAR(255)) as stratum_2_name,
+NULL as stratum_3_name,
+NULL as stratum_4_name,
+NULL as stratum_5_name,
+CAST('OBSERVATION' as VARCHAR(255)) as analysis_type
+union all
+select  809 as analysis_id,
+CAST('Number of observation records with invalid person_id' as VARCHAR(255)) as analysis_name,
+NULL as stratum_1_name,
+NULL as stratum_2_name,
+NULL as stratum_3_name,
+NULL as stratum_4_name,
+NULL as stratum_5_name,
+CAST('OBSERVATION' as VARCHAR(255)) as analysis_type
+union all
+select  810 as analysis_id,
+CAST('Number of observation records outside valid observation period' as VARCHAR(255)) as analysis_name,
+NULL as stratum_1_name,
+NULL as stratum_2_name,
+NULL as stratum_3_name,
+NULL as stratum_4_name,
+NULL as stratum_5_name,
+CAST('OBSERVATION' as VARCHAR(255)) as analysis_type
+union all
+select  812 as analysis_id,
+CAST('Number of observation records with invalid provider_id' as VARCHAR(255)) as analysis_name,
+NULL as stratum_1_name,
+NULL as stratum_2_name,
+NULL as stratum_3_name,
+NULL as stratum_4_name,
+NULL as stratum_5_name,
+CAST('OBSERVATION' as VARCHAR(255)) as analysis_type
+union all
+select  813 as analysis_id,
+CAST('Number of observation records with invalid visit_id' as VARCHAR(255)) as analysis_name,
+NULL as stratum_1_name,
+NULL as stratum_2_name,
+NULL as stratum_3_name,
+NULL as stratum_4_name,
+NULL as stratum_5_name,
+CAST('OBSERVATION' as VARCHAR(255)) as analysis_type
+union all
+select  814 as analysis_id,
+CAST('Number of observation records with no value (numeric, string, or concept)' as VARCHAR(255)) as analysis_name,
+NULL as stratum_1_name,
+NULL as stratum_2_name,
+NULL as stratum_3_name,
+NULL as stratum_4_name,
+NULL as stratum_5_name,
+CAST('OBSERVATION' as VARCHAR(255)) as analysis_type
+union all
+select  815 as analysis_id,
+CAST('Distribution of numeric values, by observation_concept_id and unit_concept_id' as VARCHAR(255)) as analysis_name,
+NULL as stratum_1_name,
+NULL as stratum_2_name,
+NULL as stratum_3_name,
+NULL as stratum_4_name,
+NULL as stratum_5_name,
+CAST('OBSERVATION' as VARCHAR(255)) as analysis_type
+union all
+select  816 as analysis_id,
+CAST('Distribution of low range, by observation_concept_id and unit_concept_id' as VARCHAR(255)) as analysis_name,
+NULL as stratum_1_name,
+NULL as stratum_2_name,
+NULL as stratum_3_name,
+NULL as stratum_4_name,
+NULL as stratum_5_name,
+CAST('OBSERVATION' as VARCHAR(255)) as analysis_type
+union all
+select  817 as analysis_id,
+CAST('Distribution of high range, by observation_concept_id and unit_concept_id' as VARCHAR(255)) as analysis_name,
+NULL as stratum_1_name,
+NULL as stratum_2_name,
+NULL as stratum_3_name,
+NULL as stratum_4_name,
+NULL as stratum_5_name,
+CAST('OBSERVATION' as VARCHAR(255)) as analysis_type
+union all
+select  818 as analysis_id,
+CAST('Number of observation records below/within/above normal range, by observation_concept_id and unit_concept_id' as VARCHAR(255)) as analysis_name,
+NULL as stratum_1_name,
+NULL as stratum_2_name,
+NULL as stratum_3_name,
+NULL as stratum_4_name,
+NULL as stratum_5_name,
+CAST('OBSERVATION' as VARCHAR(255)) as analysis_type
+union all
+select  820 as analysis_id,
+CAST('Number of observation records  by observation start month' as VARCHAR(255)) as analysis_name,
+CAST('calendar month' as VARCHAR(255)) as stratum_1_name,
+NULL as stratum_2_name,
+NULL as stratum_3_name,
+NULL as stratum_4_name,
+NULL as stratum_5_name,
+CAST('OBSERVATION' as VARCHAR(255)) as analysis_type
+union all
+select  900 as analysis_id,
+CAST('Number of persons with at least one drug era, by drug_concept_id' as VARCHAR(255)) as analysis_name,
+CAST('drug_concept_id' as VARCHAR(255)) as stratum_1_name,
+NULL as stratum_2_name,
+NULL as stratum_3_name,
+NULL as stratum_4_name,
+NULL as stratum_5_name,
+CAST('DRUG_ERA' as VARCHAR(255)) as analysis_type
+union all
+select  901 as analysis_id,
+CAST('Number of drug era records, by drug_concept_id' as VARCHAR(255)) as analysis_name,
+CAST('drug_concept_id' as VARCHAR(255)) as stratum_1_name,
+NULL as stratum_2_name,
+NULL as stratum_3_name,
+NULL as stratum_4_name,
+NULL as stratum_5_name,
+CAST('DRUG_ERA' as VARCHAR(255)) as analysis_type
+union all
+select  902 as analysis_id,
+CAST('Number of persons by drug era start month, by drug_concept_id' as VARCHAR(255)) as analysis_name,
+CAST('drug_concept_id' as VARCHAR(255)) as stratum_1_name,
+CAST('calendar month' as VARCHAR(255)) as stratum_2_name,
+NULL as stratum_3_name,
+NULL as stratum_4_name,
+NULL as stratum_5_name,
+CAST('DRUG_ERA' as VARCHAR(255)) as analysis_type
+union all
+select  903 as analysis_id,
+CAST('Number of distinct drug era concepts per person' as VARCHAR(255)) as analysis_name,
+NULL as stratum_1_name,
+NULL as stratum_2_name,
+NULL as stratum_3_name,
+NULL as stratum_4_name,
+NULL as stratum_5_name,
+CAST('DRUG_ERA' as VARCHAR(255)) as analysis_type
+union all
+select  904 as analysis_id,
+CAST('Number of persons with at least one drug era, by drug_concept_id by calendar year by gender by age decile' as VARCHAR(255)) as analysis_name,
+CAST('drug_concept_id' as VARCHAR(255)) as stratum_1_name,
+CAST('calendar year' as VARCHAR(255)) as stratum_2_name,
+CAST('gender_concept_id' as VARCHAR(255)) as stratum_3_name,
+CAST('age decile' as VARCHAR(255)) as stratum_4_name,
+NULL as stratum_5_name,
+CAST('DRUG_ERA' as VARCHAR(255)) as analysis_type
+union all
+select  906 as analysis_id,
+CAST('Distribution of age by drug_concept_id' as VARCHAR(255)) as analysis_name,
+CAST('drug_concept_id' as VARCHAR(255)) as stratum_1_name,
+CAST('gender_concept_id' as VARCHAR(255)) as stratum_2_name,
+NULL as stratum_3_name,
+NULL as stratum_4_name,
+NULL as stratum_5_name,
+CAST('DRUG_ERA' as VARCHAR(255)) as analysis_type
+union all
+select  907 as analysis_id,
+CAST('Distribution of drug era length, by drug_concept_id' as VARCHAR(255)) as analysis_name,
+CAST('drug_concept_id' as VARCHAR(255)) as stratum_1_name,
+NULL as stratum_2_name,
+NULL as stratum_3_name,
+NULL as stratum_4_name,
+NULL as stratum_5_name,
+CAST('DRUG_ERA' as VARCHAR(255)) as analysis_type
+union all
+select  908 as analysis_id,
+CAST('Number of drug eras without valid person' as VARCHAR(255)) as analysis_name,
+NULL as stratum_1_name,
+NULL as stratum_2_name,
+NULL as stratum_3_name,
+NULL as stratum_4_name,
+NULL as stratum_5_name,
+CAST('DRUG_ERA' as VARCHAR(255)) as analysis_type
+union all
+select  909 as analysis_id,
+CAST('Number of drug eras outside valid observation period' as VARCHAR(255)) as analysis_name,
+NULL as stratum_1_name,
+NULL as stratum_2_name,
+NULL as stratum_3_name,
+NULL as stratum_4_name,
+NULL as stratum_5_name,
+CAST('DRUG_ERA' as VARCHAR(255)) as analysis_type
+union all
+select  910 as analysis_id,
+CAST('Number of drug eras with end date < start date' as VARCHAR(255)) as analysis_name,
+NULL as stratum_1_name,
+NULL as stratum_2_name,
+NULL as stratum_3_name,
+NULL as stratum_4_name,
+NULL as stratum_5_name,
+CAST('DRUG_ERA' as VARCHAR(255)) as analysis_type
+union all
+select  920 as analysis_id,
+CAST('Number of drug era records  by drug era start month' as VARCHAR(255)) as analysis_name,
+CAST('calendar month' as VARCHAR(255)) as stratum_1_name,
+NULL as stratum_2_name,
+NULL as stratum_3_name,
+NULL as stratum_4_name,
+NULL as stratum_5_name,
+CAST('DRUG_ERA' as VARCHAR(255)) as analysis_type
+union all
+select 1000 as analysis_id,
+CAST('Number of persons with at least one condition era, by condition_concept_id' as VARCHAR(255)) as analysis_name,
+CAST('condition_concept_id' as VARCHAR(255)) as stratum_1_name,
+NULL as stratum_2_name,
+NULL as stratum_3_name,
+NULL as stratum_4_name,
+NULL as stratum_5_name,
+CAST('CONDITION_ERA' as VARCHAR(255)) as analysis_type
+union all
+select 1001 as analysis_id,
+CAST('Number of condition era records, by condition_concept_id' as VARCHAR(255)) as analysis_name,
+CAST('condition_concept_id' as VARCHAR(255)) as stratum_1_name,
+NULL as stratum_2_name,
+NULL as stratum_3_name,
+NULL as stratum_4_name,
+NULL as stratum_5_name,
+CAST('CONDITION_ERA' as VARCHAR(255)) as analysis_type
+union all
+select 1002 as analysis_id,
+CAST('Number of persons by condition era start month, by condition_concept_id' as VARCHAR(255)) as analysis_name,
+CAST('condition_concept_id' as VARCHAR(255)) as stratum_1_name,
+CAST('calendar month' as VARCHAR(255)) as stratum_2_name,
+NULL as stratum_3_name,
+NULL as stratum_4_name,
+NULL as stratum_5_name,
+CAST('CONDITION_ERA' as VARCHAR(255)) as analysis_type
+union all
+select 1003 as analysis_id,
+CAST('Number of distinct condition era concepts per person' as VARCHAR(255)) as analysis_name,
+NULL as stratum_1_name,
+NULL as stratum_2_name,
+NULL as stratum_3_name,
+NULL as stratum_4_name,
+NULL as stratum_5_name,
+CAST('CONDITION_ERA' as VARCHAR(255)) as analysis_type
+union all
+select 1004 as analysis_id,
+CAST('Number of persons with at least one condition era, by condition_concept_id by calendar year by gender by age decile' as VARCHAR(255)) as analysis_name,
+CAST('condition_concept_id' as VARCHAR(255)) as stratum_1_name,
+CAST('calendar year' as VARCHAR(255)) as stratum_2_name,
+CAST('gender_concept_id' as VARCHAR(255)) as stratum_3_name,
+CAST('age decile' as VARCHAR(255)) as stratum_4_name,
+NULL as stratum_5_name,
+CAST('CONDITION_ERA' as VARCHAR(255)) as analysis_type
+union all
+select 1006 as analysis_id,
+CAST('Distribution of age by condition_concept_id' as VARCHAR(255)) as analysis_name,
+CAST('condition_concept_id' as VARCHAR(255)) as stratum_1_name,
+CAST('gender_concept_id' as VARCHAR(255)) as stratum_2_name,
+NULL as stratum_3_name,
+NULL as stratum_4_name,
+NULL as stratum_5_name,
+CAST('CONDITION_ERA' as VARCHAR(255)) as analysis_type
+union all
+select 1007 as analysis_id,
+CAST('Distribution of condition era length, by condition_concept_id' as VARCHAR(255)) as analysis_name,
+CAST('condition_concept_id' as VARCHAR(255)) as stratum_1_name,
+NULL as stratum_2_name,
+NULL as stratum_3_name,
+NULL as stratum_4_name,
+NULL as stratum_5_name,
+CAST('CONDITION_ERA' as VARCHAR(255)) as analysis_type
+union all
+select 1008 as analysis_id,
+CAST('Number of condition eras without valid person' as VARCHAR(255)) as analysis_name,
+NULL as stratum_1_name,
+NULL as stratum_2_name,
+NULL as stratum_3_name,
+NULL as stratum_4_name,
+NULL as stratum_5_name,
+CAST('CONDITION_ERA' as VARCHAR(255)) as analysis_type
+union all
+select 1009 as analysis_id,
+CAST('Number of condition eras outside valid observation period' as VARCHAR(255)) as analysis_name,
+NULL as stratum_1_name,
+NULL as stratum_2_name,
+NULL as stratum_3_name,
+NULL as stratum_4_name,
+NULL as stratum_5_name,
+CAST('CONDITION_ERA' as VARCHAR(255)) as analysis_type
+union all
+select 1010 as analysis_id,
+CAST('Number of condition eras with end date < start date' as VARCHAR(255)) as analysis_name,
+NULL as stratum_1_name,
+NULL as stratum_2_name,
+NULL as stratum_3_name,
+NULL as stratum_4_name,
+NULL as stratum_5_name,
+CAST('CONDITION_ERA' as VARCHAR(255)) as analysis_type
+union all
+select 1020 as analysis_id,
+CAST('Number of condition era records by condition era start month' as VARCHAR(255)) as analysis_name,
+CAST('calendar month' as VARCHAR(255)) as stratum_1_name,
+NULL as stratum_2_name,
+NULL as stratum_3_name,
+NULL as stratum_4_name,
+NULL as stratum_5_name,
+CAST('CONDITION_ERA' as VARCHAR(255)) as analysis_type
+union all
+select 1100 as analysis_id,
+CAST('Number of persons by location 3-digit zip' as VARCHAR(255)) as analysis_name,
+CAST('3-digit zip' as VARCHAR(255)) as stratum_1_name,
+NULL as stratum_2_name,
+NULL as stratum_3_name,
+NULL as stratum_4_name,
+NULL as stratum_5_name,
+CAST('LOCATION' as VARCHAR(255)) as analysis_type
+union all
+select 1101 as analysis_id,
+CAST('Number of persons by location state' as VARCHAR(255)) as analysis_name,
+CAST('state' as VARCHAR(255)) as stratum_1_name,
+NULL as stratum_2_name,
+NULL as stratum_3_name,
+NULL as stratum_4_name,
+NULL as stratum_5_name,
+CAST('LOCATION' as VARCHAR(255)) as analysis_type
+union all
+select 1200 as analysis_id,
+CAST('Number of persons by place of service' as VARCHAR(255)) as analysis_name,
+CAST('place_of_service_concept_id' as VARCHAR(255)) as stratum_1_name,
+NULL as stratum_2_name,
+NULL as stratum_3_name,
+NULL as stratum_4_name,
+NULL as stratum_5_name,
+CAST('CARE_SITE' as VARCHAR(255)) as analysis_type
+union all
+select 1201 as analysis_id,
+CAST('Number of visits by place of service' as VARCHAR(255)) as analysis_name,
+CAST('place_of_service_concept_id' as VARCHAR(255)) as stratum_1_name,
+NULL as stratum_2_name,
+NULL as stratum_3_name,
+NULL as stratum_4_name,
+NULL as stratum_5_name,
+CAST('CARE_SITE' as VARCHAR(255)) as analysis_type
+union all
+select 1300 as analysis_id,
+CAST('Number of persons with at least one measurement occurrence, by measurement_concept_id' as VARCHAR(255)) as analysis_name,
+CAST('measurement_concept_id' as VARCHAR(255)) as stratum_1_name,
+NULL as stratum_2_name,
+NULL as stratum_3_name,
+NULL as stratum_4_name,
+NULL as stratum_5_name,
+CAST('MEASUREMENT' as VARCHAR(255)) as analysis_type
+union all
+select 1301 as analysis_id,
+CAST('Number of measurement occurrence records, by measurement_concept_id' as VARCHAR(255)) as analysis_name,
+CAST('measurement_concept_id' as VARCHAR(255)) as stratum_1_name,
+NULL as stratum_2_name,
+NULL as stratum_3_name,
+NULL as stratum_4_name,
+NULL as stratum_5_name,
+CAST('MEASUREMENT' as VARCHAR(255)) as analysis_type
+union all
+select 1302 as analysis_id,
+CAST('Number of persons by measurement occurrence start month, by measurement_concept_id' as VARCHAR(255)) as analysis_name,
+CAST('measurement_concept_id' as VARCHAR(255)) as stratum_1_name,
+CAST('calendar month' as VARCHAR(255)) as stratum_2_name,
+NULL as stratum_3_name,
+NULL as stratum_4_name,
+NULL as stratum_5_name,
+CAST('MEASUREMENT' as VARCHAR(255)) as analysis_type
+union all
+select 1303 as analysis_id,
+CAST('Number of distinct measurement occurrence concepts per person' as VARCHAR(255)) as analysis_name,
+NULL as stratum_1_name,
+NULL as stratum_2_name,
+NULL as stratum_3_name,
+NULL as stratum_4_name,
+NULL as stratum_5_name,
+CAST('MEASUREMENT' as VARCHAR(255)) as analysis_type
+union all
+select 1304 as analysis_id,
+CAST('Number of persons with at least one measurement occurrence, by measurement_concept_id by calendar year by gender by age decile' as VARCHAR(255)) as analysis_name,
+CAST('measurement_concept_id' as VARCHAR(255)) as stratum_1_name,
+CAST('calendar year' as VARCHAR(255)) as stratum_2_name,
+CAST('gender_concept_id' as VARCHAR(255)) as stratum_3_name,
+CAST('age decile' as VARCHAR(255)) as stratum_4_name,
+NULL as stratum_5_name,
+CAST('MEASUREMENT' as VARCHAR(255)) as analysis_type
+union all
+select 1305 as analysis_id,
+CAST('Number of measurement occurrence records, by measurement_concept_id by measurement_type_concept_id' as VARCHAR(255)) as analysis_name,
+CAST('measurement_concept_id' as VARCHAR(255)) as stratum_1_name,
+CAST('measurement_type_concept_id' as VARCHAR(255)) as stratum_2_name,
+NULL as stratum_3_name,
+NULL as stratum_4_name,
+NULL as stratum_5_name,
+CAST('MEASUREMENT' as VARCHAR(255)) as analysis_type
+union all
+select 1306 as analysis_id,
+CAST('Distribution of age by measurement_concept_id' as VARCHAR(255)) as analysis_name,
+CAST('measurement_concept_id' as VARCHAR(255)) as stratum_1_name,
+CAST('gender_concept_id' as VARCHAR(255)) as stratum_2_name,
+NULL as stratum_3_name,
+NULL as stratum_4_name,
+NULL as stratum_5_name,
+CAST('MEASUREMENT' as VARCHAR(255)) as analysis_type
+union all
+select 1307 as analysis_id,
+CAST('Number of measurement occurrence records, by measurement_concept_id and unit_concept_id' as VARCHAR(255)) as analysis_name,
+CAST('measurement_concept_id' as VARCHAR(255)) as stratum_1_name,
+CAST('unit_concept_id' as VARCHAR(255)) as stratum_2_name,
+NULL as stratum_3_name,
+NULL as stratum_4_name,
+NULL as stratum_5_name,
+CAST('MEASUREMENT' as VARCHAR(255)) as analysis_type
+union all
+select 1309 as analysis_id,
+CAST('Number of measurement records with invalid person_id' as VARCHAR(255)) as analysis_name,
+NULL as stratum_1_name,
+NULL as stratum_2_name,
+NULL as stratum_3_name,
+NULL as stratum_4_name,
+NULL as stratum_5_name,
+CAST('MEASUREMENT' as VARCHAR(255)) as analysis_type
+union all
+select 1310 as analysis_id,
+CAST('Number of measurement records outside valid measurement period' as VARCHAR(255)) as analysis_name,
+NULL as stratum_1_name,
+NULL as stratum_2_name,
+NULL as stratum_3_name,
+NULL as stratum_4_name,
+NULL as stratum_5_name,
+CAST('MEASUREMENT' as VARCHAR(255)) as analysis_type
+union all
+select 1312 as analysis_id,
+CAST('Number of measurement records with invalid provider_id' as VARCHAR(255)) as analysis_name,
+NULL as stratum_1_name,
+NULL as stratum_2_name,
+NULL as stratum_3_name,
+NULL as stratum_4_name,
+NULL as stratum_5_name,
+CAST('MEASUREMENT' as VARCHAR(255)) as analysis_type
+union all
+select 1313 as analysis_id,
+CAST('Number of measurement records with invalid visit_id' as VARCHAR(255)) as analysis_name,
+NULL as stratum_1_name,
+NULL as stratum_2_name,
+NULL as stratum_3_name,
+NULL as stratum_4_name,
+NULL as stratum_5_name,
+CAST('MEASUREMENT' as VARCHAR(255)) as analysis_type
+union all
+select 1314 as analysis_id,
+CAST('Number of measurement records with no value (numeric, string, or concept)' as VARCHAR(255)) as analysis_name,
+NULL as stratum_1_name,
+NULL as stratum_2_name,
+NULL as stratum_3_name,
+NULL as stratum_4_name,
+NULL as stratum_5_name,
+CAST('MEASUREMENT' as VARCHAR(255)) as analysis_type
+union all
+select 1315 as analysis_id,
+CAST('Distribution of numeric values, by measurement_concept_id and unit_concept_id' as VARCHAR(255)) as analysis_name,
+NULL as stratum_1_name,
+NULL as stratum_2_name,
+NULL as stratum_3_name,
+NULL as stratum_4_name,
+NULL as stratum_5_name,
+CAST('MEASUREMENT' as VARCHAR(255)) as analysis_type
+union all
+select 1316 as analysis_id,
+CAST('Distribution of low range, by measurement_concept_id and unit_concept_id' as VARCHAR(255)) as analysis_name,
+NULL as stratum_1_name,
+NULL as stratum_2_name,
+NULL as stratum_3_name,
+NULL as stratum_4_name,
+NULL as stratum_5_name,
+CAST('MEASUREMENT' as VARCHAR(255)) as analysis_type
+union all
+select 1317 as analysis_id,
+CAST('Distribution of high range, by measurement_concept_id and unit_concept_id' as VARCHAR(255)) as analysis_name,
+NULL as stratum_1_name,
+NULL as stratum_2_name,
+NULL as stratum_3_name,
+NULL as stratum_4_name,
+NULL as stratum_5_name,
+CAST('MEASUREMENT' as VARCHAR(255)) as analysis_type
+union all
+select 1318 as analysis_id,
+CAST('Number of measurement records below/within/above normal range, by measurement_concept_id and unit_concept_id' as VARCHAR(255)) as analysis_name,
+NULL as stratum_1_name,
+NULL as stratum_2_name,
+NULL as stratum_3_name,
+NULL as stratum_4_name,
+NULL as stratum_5_name,
+CAST('MEASUREMENT' as VARCHAR(255)) as analysis_type
+union all
+select 1320 as analysis_id,
+CAST('Number of measurement records  by measurement start month' as VARCHAR(255)) as analysis_name,
+CAST('calendar month' as VARCHAR(255)) as stratum_1_name,
+NULL as stratum_2_name,
+NULL as stratum_3_name,
+NULL as stratum_4_name,
+NULL as stratum_5_name,
+CAST('MEASUREMENT' as VARCHAR(255)) as analysis_type
+union all
+select 1700 as analysis_id,
+CAST('Number of records by cohort_definition_id' as VARCHAR(255)) as analysis_name,
+CAST('cohort_definition_id' as VARCHAR(255)) as stratum_1_name,
+NULL as stratum_2_name,
+NULL as stratum_3_name,
+NULL as stratum_4_name,
+NULL as stratum_5_name,
+CAST('COHORT' as VARCHAR(255)) as analysis_type
+union all
+select 1701 as analysis_id,
+CAST('Number of records with cohort end date < cohort start date' as VARCHAR(255)) as analysis_name,
+NULL as stratum_1_name,
+NULL as stratum_2_name,
+NULL as stratum_3_name,
+NULL as stratum_4_name,
+NULL as stratum_5_name,
+CAST('COHORT' as VARCHAR(255)) as analysis_type
+union all
+select 1800 as analysis_id,
+CAST('Number of persons by age, with age at cohort start' as VARCHAR(255)) as analysis_name,
+CAST('age' as VARCHAR(255)) as stratum_1_name,
+NULL as stratum_2_name,
+NULL as stratum_3_name,
+NULL as stratum_4_name,
+NULL as stratum_5_name,
+CAST('COHORT_SPECIFIC_ANALYSES' as VARCHAR(255)) as analysis_type
+union all
+select 1801 as analysis_id,
+CAST('Distribution of age at cohort start' as VARCHAR(255)) as analysis_name,
+NULL as stratum_1_name,
+NULL as stratum_2_name,
+NULL as stratum_3_name,
+NULL as stratum_4_name,
+NULL as stratum_5_name,
+CAST('COHORT_SPECIFIC_ANALYSES' as VARCHAR(255)) as analysis_type
+union all
+select 1802 as analysis_id,
+CAST('Distribution of age at cohort start by gender' as VARCHAR(255)) as analysis_name,
+CAST('gender_concept_id' as VARCHAR(255)) as stratum_1_name,
+NULL as stratum_2_name,
+NULL as stratum_3_name,
+NULL as stratum_4_name,
+NULL as stratum_5_name,
+CAST('COHORT_SPECIFIC_ANALYSES' as VARCHAR(255)) as analysis_type
+union all
+select 1803 as analysis_id,
+CAST('Distribution of age at cohort start by cohort start year' as VARCHAR(255)) as analysis_name,
+CAST('calendar year' as VARCHAR(255)) as stratum_1_name,
+NULL as stratum_2_name,
+NULL as stratum_3_name,
+NULL as stratum_4_name,
+NULL as stratum_5_name,
+CAST('COHORT_SPECIFIC_ANALYSES' as VARCHAR(255)) as analysis_type
+union all
+select 1804 as analysis_id,
+CAST('Number of persons by duration from cohort start to cohort end, in 30d increments' as VARCHAR(255)) as analysis_name,
+CAST('Cohort period length 30d increments' as VARCHAR(255)) as stratum_1_name,
+NULL as stratum_2_name,
+NULL as stratum_3_name,
+NULL as stratum_4_name,
+NULL as stratum_5_name,
+CAST('COHORT_SPECIFIC_ANALYSES' as VARCHAR(255)) as analysis_type
+union all
+select 1805 as analysis_id,
+CAST('Number of persons by duration from observation start to cohort start, in 30d increments' as VARCHAR(255)) as analysis_name,
+CAST('Baseline period length 30d increments' as VARCHAR(255)) as stratum_1_name,
+NULL as stratum_2_name,
+NULL as stratum_3_name,
+NULL as stratum_4_name,
+NULL as stratum_5_name,
+CAST('COHORT_SPECIFIC_ANALYSES' as VARCHAR(255)) as analysis_type
+union all
+select 1806 as analysis_id,
+CAST('Number of persons by duration from cohort start to observation end, in 30d increments' as VARCHAR(255)) as analysis_name,
+CAST('Follow-up period length 30d increments' as VARCHAR(255)) as stratum_1_name,
+NULL as stratum_2_name,
+NULL as stratum_3_name,
+NULL as stratum_4_name,
+NULL as stratum_5_name,
+CAST('COHORT_SPECIFIC_ANALYSES' as VARCHAR(255)) as analysis_type
+union all
+select 1807 as analysis_id,
+CAST('Number of persons by duration from cohort end to observation end, in 30d increments' as VARCHAR(255)) as analysis_name,
+CAST('Post-cohort period length 30d increments' as VARCHAR(255)) as stratum_1_name,
+NULL as stratum_2_name,
+NULL as stratum_3_name,
+NULL as stratum_4_name,
+NULL as stratum_5_name,
+CAST('COHORT_SPECIFIC_ANALYSES' as VARCHAR(255)) as analysis_type
+union all
+select 1808 as analysis_id,
+CAST('Distribution of duration (days) from cohort start to cohort end' as VARCHAR(255)) as analysis_name,
+NULL as stratum_1_name,
+NULL as stratum_2_name,
+NULL as stratum_3_name,
+NULL as stratum_4_name,
+NULL as stratum_5_name,
+CAST('COHORT_SPECIFIC_ANALYSES' as VARCHAR(255)) as analysis_type
+union all
+select 1809 as analysis_id,
+CAST('Distribution of duration (days) from cohort start to cohort end, by gender' as VARCHAR(255)) as analysis_name,
+CAST('gender_concept_id' as VARCHAR(255)) as stratum_1_name,
+NULL as stratum_2_name,
+NULL as stratum_3_name,
+NULL as stratum_4_name,
+NULL as stratum_5_name,
+CAST('COHORT_SPECIFIC_ANALYSES' as VARCHAR(255)) as analysis_type
+union all
+select 1810 as analysis_id,
+CAST('Distribution of duration (days) from cohort start to cohort end, by age decile' as VARCHAR(255)) as analysis_name,
+CAST('age decile' as VARCHAR(255)) as stratum_1_name,
+NULL as stratum_2_name,
+NULL as stratum_3_name,
+NULL as stratum_4_name,
+NULL as stratum_5_name,
+CAST('COHORT_SPECIFIC_ANALYSES' as VARCHAR(255)) as analysis_type
+union all
+select 1811 as analysis_id,
+CAST('Distribution of duration (days) from observation start to cohort start' as VARCHAR(255)) as analysis_name,
+NULL as stratum_1_name,
+NULL as stratum_2_name,
+NULL as stratum_3_name,
+NULL as stratum_4_name,
+NULL as stratum_5_name,
+CAST('COHORT_SPECIFIC_ANALYSES' as VARCHAR(255)) as analysis_type
+union all
+select 1812 as analysis_id,
+CAST('Distribution of duration (days) from cohort start to observation end' as VARCHAR(255)) as analysis_name,
+NULL as stratum_1_name,
+NULL as stratum_2_name,
+NULL as stratum_3_name,
+NULL as stratum_4_name,
+NULL as stratum_5_name,
+CAST('COHORT_SPECIFIC_ANALYSES' as VARCHAR(255)) as analysis_type
+union all
+select 1813 as analysis_id,
+CAST('Distribution of duration (days) from cohort end to observation end' as VARCHAR(255)) as analysis_name,
+NULL as stratum_1_name,
+NULL as stratum_2_name,
+NULL as stratum_3_name,
+NULL as stratum_4_name,
+NULL as stratum_5_name,
+CAST('COHORT_SPECIFIC_ANALYSES' as VARCHAR(255)) as analysis_type
+union all
+select 1814 as analysis_id,
+CAST('Number of persons by cohort start year by gender by age decile' as VARCHAR(255)) as analysis_name,
+CAST('calendar year' as VARCHAR(255)) as stratum_1_name,
+CAST('gender_concept_id' as VARCHAR(255)) as stratum_2_name,
+CAST('age decile' as VARCHAR(255)) as stratum_3_name,
+NULL as stratum_4_name,
+NULL as stratum_5_name,
+CAST('COHORT_SPECIFIC_ANALYSES' as VARCHAR(255)) as analysis_type
+union all
+select 1815 as analysis_id,
+CAST('Number of persons by cohort start month' as VARCHAR(255)) as analysis_name,
+CAST('calendar month' as VARCHAR(255)) as stratum_1_name,
+NULL as stratum_2_name,
+NULL as stratum_3_name,
+NULL as stratum_4_name,
+NULL as stratum_5_name,
+CAST('COHORT_SPECIFIC_ANALYSES' as VARCHAR(255)) as analysis_type
+union all
+select 1816 as analysis_id,
+CAST('Number of persons by number of cohort periods' as VARCHAR(255)) as analysis_name,
+CAST('number of cohort periods' as VARCHAR(255)) as stratum_1_name,
+NULL as stratum_2_name,
+NULL as stratum_3_name,
+NULL as stratum_4_name,
+NULL as stratum_5_name,
+CAST('COHORT_SPECIFIC_ANALYSES' as VARCHAR(255)) as analysis_type
+union all
+select 1820 as analysis_id,
+CAST('Number of persons by duration from cohort start to first occurrence of condition occurrence, by condition_concept_id' as VARCHAR(255)) as analysis_name,
+CAST('condition_concept_id' as VARCHAR(255)) as stratum_1_name,
+CAST('time-to-event 30d increments' as VARCHAR(255)) as stratum_2_name,
+NULL as stratum_3_name,
+NULL as stratum_4_name,
+NULL as stratum_5_name,
+CAST('COHORT_SPECIFIC_ANALYSES' as VARCHAR(255)) as analysis_type
+union all
+select 1821 as analysis_id,
+CAST('Number of events by duration from cohort start to all occurrences of condition occurrence, by condition_concept_id' as VARCHAR(255)) as analysis_name,
+CAST('condition_concept_id' as VARCHAR(255)) as stratum_1_name,
+CAST('time-to-event 30d increments' as VARCHAR(255)) as stratum_2_name,
+NULL as stratum_3_name,
+NULL as stratum_4_name,
+NULL as stratum_5_name,
+CAST('COHORT_SPECIFIC_ANALYSES' as VARCHAR(255)) as analysis_type
+union all
+select 1830 as analysis_id,
+CAST('Number of persons by duration from cohort start to first occurrence of procedure occurrence, by procedure_concept_id' as VARCHAR(255)) as analysis_name,
+CAST('procedure_concept_id' as VARCHAR(255)) as stratum_1_name,
+CAST('time-to-event 30d increments' as VARCHAR(255)) as stratum_2_name,
+NULL as stratum_3_name,
+NULL as stratum_4_name,
+NULL as stratum_5_name,
+CAST('COHORT_SPECIFIC_ANALYSES' as VARCHAR(255)) as analysis_type
+union all
+select 1831 as analysis_id,
+CAST('Number of events by duration from cohort start to all occurrences of procedure occurrence, by procedure_concept_id' as VARCHAR(255)) as analysis_name,
+CAST('procedure_concept_id' as VARCHAR(255)) as stratum_1_name,
+CAST('time-to-event 30d increments' as VARCHAR(255)) as stratum_2_name,
+NULL as stratum_3_name,
+NULL as stratum_4_name,
+NULL as stratum_5_name,
+CAST('COHORT_SPECIFIC_ANALYSES' as VARCHAR(255)) as analysis_type
+union all
+select 1840 as analysis_id,
+CAST('Number of persons by duration from cohort start to first occurrence of drug exposure, by drug_concept_id' as VARCHAR(255)) as analysis_name,
+CAST('drug_concept_id' as VARCHAR(255)) as stratum_1_name,
+CAST('time-to-event 30d increments' as VARCHAR(255)) as stratum_2_name,
+NULL as stratum_3_name,
+NULL as stratum_4_name,
+NULL as stratum_5_name,
+CAST('COHORT_SPECIFIC_ANALYSES' as VARCHAR(255)) as analysis_type
+union all
+select 1841 as analysis_id,
+CAST('Number of events by duration from cohort start to all occurrences of drug exposure, by drug_concept_id' as VARCHAR(255)) as analysis_name,
+CAST('drug_concept_id' as VARCHAR(255)) as stratum_1_name,
+CAST('time-to-event 30d increments' as VARCHAR(255)) as stratum_2_name,
+NULL as stratum_3_name,
+NULL as stratum_4_name,
+NULL as stratum_5_name,
+CAST('COHORT_SPECIFIC_ANALYSES' as VARCHAR(255)) as analysis_type
+union all
+select 1850 as analysis_id,
+CAST('Number of persons by duration from cohort start to first occurrence of observation, by observation_concept_id' as VARCHAR(255)) as analysis_name,
+CAST('observation_concept_id' as VARCHAR(255)) as stratum_1_name,
+CAST('time-to-event 30d increments' as VARCHAR(255)) as stratum_2_name,
+NULL as stratum_3_name,
+NULL as stratum_4_name,
+NULL as stratum_5_name,
+CAST('COHORT_SPECIFIC_ANALYSES' as VARCHAR(255)) as analysis_type
+union all
+select 1851 as analysis_id,
+CAST('Number of events by duration from cohort start to all occurrences of observation, by observation_concept_id' as VARCHAR(255)) as analysis_name,
+CAST('observation_concept_id' as VARCHAR(255)) as stratum_1_name,
+CAST('time-to-event 30d increments' as VARCHAR(255)) as stratum_2_name,
+NULL as stratum_3_name,
+NULL as stratum_4_name,
+NULL as stratum_5_name,
+CAST('COHORT_SPECIFIC_ANALYSES' as VARCHAR(255)) as analysis_type
+union all
+select 1860 as analysis_id,
+CAST('Number of persons by duration from cohort start to first occurrence of condition era, by condition_concept_id' as VARCHAR(255)) as analysis_name,
+CAST('condition_concept_id' as VARCHAR(255)) as stratum_1_name,
+CAST('time-to-event 30d increments' as VARCHAR(255)) as stratum_2_name,
+NULL as stratum_3_name,
+NULL as stratum_4_name,
+NULL as stratum_5_name,
+CAST('COHORT_SPECIFIC_ANALYSES' as VARCHAR(255)) as analysis_type
+union all
+select 1861 as analysis_id,
+CAST('Number of events by duration from cohort start to all occurrences of condition era, by condition_concept_id' as VARCHAR(255)) as analysis_name,
+CAST('condition_concept_id' as VARCHAR(255)) as stratum_1_name,
+CAST('time-to-event 30d increments' as VARCHAR(255)) as stratum_2_name,
+NULL as stratum_3_name,
+NULL as stratum_4_name,
+NULL as stratum_5_name,
+CAST('COHORT_SPECIFIC_ANALYSES' as VARCHAR(255)) as analysis_type
+union all
+select 1870 as analysis_id,
+CAST('Number of persons by duration from cohort start to first occurrence of drug era, by drug_concept_id' as VARCHAR(255)) as analysis_name,
+CAST('drug_concept_id' as VARCHAR(255)) as stratum_1_name,
+CAST('time-to-event 30d increments' as VARCHAR(255)) as stratum_2_name,
+NULL as stratum_3_name,
+NULL as stratum_4_name,
+NULL as stratum_5_name,
+CAST('COHORT_SPECIFIC_ANALYSES' as VARCHAR(255)) as analysis_type
+union all
+select 1871 as analysis_id,
+CAST('Number of events by duration from cohort start to all occurrences of drug era, by drug_concept_id' as VARCHAR(255)) as analysis_name,
+CAST('drug_concept_id' as VARCHAR(255)) as stratum_1_name,
+CAST('time-to-event 30d increments' as VARCHAR(255)) as stratum_2_name,
+NULL as stratum_3_name,
+NULL as stratum_4_name,
+NULL as stratum_5_name,
+CAST('COHORT_SPECIFIC_ANALYSES' as VARCHAR(255)) as analysis_type
+;

--- a/src/main/resources/ddl/results/init_heracles_analysis.sql
+++ b/src/main/resources/ddl/results/init_heracles_analysis.sql
@@ -3,6 +3,7 @@
 TRUNCATE TABLE @results_schema.heracles_analysis;
 
 insert into @results_schema.heracles_analysis
+(analysis_id,analysis_name,stratum_1_name,stratum_2_name,stratum_3_name,stratum_4_name,stratum_5_name,analysis_type)
 select    0 as analysis_id,
 CAST('Source name' as VARCHAR(255)) as analysis_name,
 NULL as stratum_1_name,

--- a/src/main/resources/ddl/results/init_heracles_analysis.sql
+++ b/src/main/resources/ddl/results/init_heracles_analysis.sql
@@ -2,199 +2,1669 @@
 
 TRUNCATE TABLE @results_schema.heracles_analysis;
 
-insert into @results_schema.heracles_analysis (ANALYSIS_ID,ANALYSIS_NAME,STRATUM_1_NAME,STRATUM_2_NAME,STRATUM_3_NAME,STRATUM_4_NAME,STRATUM_5_NAME,ANALYSIS_TYPE) values (0,CAST('Source name' AS VARCHAR(255)),null,null,null,null,null,CAST('PERSON' AS VARCHAR(255)));
-insert into @results_schema.heracles_analysis (ANALYSIS_ID,ANALYSIS_NAME,STRATUM_1_NAME,STRATUM_2_NAME,STRATUM_3_NAME,STRATUM_4_NAME,STRATUM_5_NAME,ANALYSIS_TYPE) values (1,CAST('Number of persons' AS VARCHAR(255)),null,null,null,null,null,CAST('PERSON' AS VARCHAR(255)));
-insert into @results_schema.heracles_analysis (ANALYSIS_ID,ANALYSIS_NAME,STRATUM_1_NAME,STRATUM_2_NAME,STRATUM_3_NAME,STRATUM_4_NAME,STRATUM_5_NAME,ANALYSIS_TYPE) values (2,CAST('Number of persons by gender' AS VARCHAR(255)),CAST('gender_concept_id' AS VARCHAR(255)),null,null,null,null,CAST('PERSON' AS VARCHAR(255)));
-insert into @results_schema.heracles_analysis (ANALYSIS_ID,ANALYSIS_NAME,STRATUM_1_NAME,STRATUM_2_NAME,STRATUM_3_NAME,STRATUM_4_NAME,STRATUM_5_NAME,ANALYSIS_TYPE) values (3,CAST('Number of persons by year of birth' AS VARCHAR(255)),CAST('year_of_birth' AS VARCHAR(255)),null,null,null,null,CAST('PERSON' AS VARCHAR(255)));
-insert into @results_schema.heracles_analysis (ANALYSIS_ID,ANALYSIS_NAME,STRATUM_1_NAME,STRATUM_2_NAME,STRATUM_3_NAME,STRATUM_4_NAME,STRATUM_5_NAME,ANALYSIS_TYPE) values (4,CAST('Number of persons by race' AS VARCHAR(255)),CAST('race_concept_id' AS VARCHAR(255)),null,null,null,null,CAST('PERSON' AS VARCHAR(255)));
-insert into @results_schema.heracles_analysis (ANALYSIS_ID,ANALYSIS_NAME,STRATUM_1_NAME,STRATUM_2_NAME,STRATUM_3_NAME,STRATUM_4_NAME,STRATUM_5_NAME,ANALYSIS_TYPE) values (5,CAST('Number of persons by ethnicity' AS VARCHAR(255)),CAST('ethnicity_concept_id' AS VARCHAR(255)),null,null,null,null,CAST('PERSON' AS VARCHAR(255)));
-insert into @results_schema.heracles_analysis (ANALYSIS_ID,ANALYSIS_NAME,STRATUM_1_NAME,STRATUM_2_NAME,STRATUM_3_NAME,STRATUM_4_NAME,STRATUM_5_NAME,ANALYSIS_TYPE) values (7,CAST('Number of persons with invalid provider_id' AS VARCHAR(255)),null,null,null,null,null,CAST('PERSON' AS VARCHAR(255)));
-insert into @results_schema.heracles_analysis (ANALYSIS_ID,ANALYSIS_NAME,STRATUM_1_NAME,STRATUM_2_NAME,STRATUM_3_NAME,STRATUM_4_NAME,STRATUM_5_NAME,ANALYSIS_TYPE) values (8,CAST('Number of persons with invalid location_id' AS VARCHAR(255)),null,null,null,null,null,CAST('PERSON' AS VARCHAR(255)));
-insert into @results_schema.heracles_analysis (ANALYSIS_ID,ANALYSIS_NAME,STRATUM_1_NAME,STRATUM_2_NAME,STRATUM_3_NAME,STRATUM_4_NAME,STRATUM_5_NAME,ANALYSIS_TYPE) values (9,CAST('Number of persons with invalid care_site_id' AS VARCHAR(255)),null,null,null,null,null,CAST('PERSON' AS VARCHAR(255)));
-insert into @results_schema.heracles_analysis (ANALYSIS_ID,ANALYSIS_NAME,STRATUM_1_NAME,STRATUM_2_NAME,STRATUM_3_NAME,STRATUM_4_NAME,STRATUM_5_NAME,ANALYSIS_TYPE) values (101,CAST('Number of persons by age, with age at first observation period' AS VARCHAR(255)),CAST('age' AS VARCHAR(255)),null,null,null,null,CAST('OBSERVATION' AS VARCHAR(255)));
-insert into @results_schema.heracles_analysis (ANALYSIS_ID,ANALYSIS_NAME,STRATUM_1_NAME,STRATUM_2_NAME,STRATUM_3_NAME,STRATUM_4_NAME,STRATUM_5_NAME,ANALYSIS_TYPE) values (102,CAST('Number of persons by gender by age, with age at first observation period' AS VARCHAR(255)),CAST('gender_concept_id' AS VARCHAR(255)),CAST('age' AS VARCHAR(255)),null,null,null,CAST('OBSERVATION' AS VARCHAR(255)));
-insert into @results_schema.heracles_analysis (ANALYSIS_ID,ANALYSIS_NAME,STRATUM_1_NAME,STRATUM_2_NAME,STRATUM_3_NAME,STRATUM_4_NAME,STRATUM_5_NAME,ANALYSIS_TYPE) values (103,CAST('Distribution of age at first observation period' AS VARCHAR(255)),null,null,null,null,null,CAST('OBSERVATION' AS VARCHAR(255)));
-insert into @results_schema.heracles_analysis (ANALYSIS_ID,ANALYSIS_NAME,STRATUM_1_NAME,STRATUM_2_NAME,STRATUM_3_NAME,STRATUM_4_NAME,STRATUM_5_NAME,ANALYSIS_TYPE) values (104,CAST('Distribution of age at first observation period by gender' AS VARCHAR(255)),CAST('gender_concept_id' AS VARCHAR(255)),null,null,null,null,CAST('OBSERVATION' AS VARCHAR(255)));
-insert into @results_schema.heracles_analysis (ANALYSIS_ID,ANALYSIS_NAME,STRATUM_1_NAME,STRATUM_2_NAME,STRATUM_3_NAME,STRATUM_4_NAME,STRATUM_5_NAME,ANALYSIS_TYPE) values (105,CAST('Length of observation (days) of first observation period' AS VARCHAR(255)),null,null,null,null,null,CAST('OBSERVATION' AS VARCHAR(255)));
-insert into @results_schema.heracles_analysis (ANALYSIS_ID,ANALYSIS_NAME,STRATUM_1_NAME,STRATUM_2_NAME,STRATUM_3_NAME,STRATUM_4_NAME,STRATUM_5_NAME,ANALYSIS_TYPE) values (106,CAST('Length of observation (days) of first observation period by gender' AS VARCHAR(255)),CAST('gender_concept_id' AS VARCHAR(255)),null,null,null,null,CAST('OBSERVATION' AS VARCHAR(255)));
-insert into @results_schema.heracles_analysis (ANALYSIS_ID,ANALYSIS_NAME,STRATUM_1_NAME,STRATUM_2_NAME,STRATUM_3_NAME,STRATUM_4_NAME,STRATUM_5_NAME,ANALYSIS_TYPE) values (107,CAST('Length of observation (days) of first observation period by age decile' AS VARCHAR(255)),CAST('age decile' AS VARCHAR(255)),null,null,null,null,CAST('OBSERVATION' AS VARCHAR(255)));
-insert into @results_schema.heracles_analysis (ANALYSIS_ID,ANALYSIS_NAME,STRATUM_1_NAME,STRATUM_2_NAME,STRATUM_3_NAME,STRATUM_4_NAME,STRATUM_5_NAME,ANALYSIS_TYPE) values (108,CAST('Number of persons by length of observation period, in 30d increments' AS VARCHAR(255)),CAST('Observation period length 30d increments' AS VARCHAR(255)),null,null,null,null,CAST('OBSERVATION' AS VARCHAR(255)));
-insert into @results_schema.heracles_analysis (ANALYSIS_ID,ANALYSIS_NAME,STRATUM_1_NAME,STRATUM_2_NAME,STRATUM_3_NAME,STRATUM_4_NAME,STRATUM_5_NAME,ANALYSIS_TYPE) values (109,CAST('Number of persons with continuous observation in each year' AS VARCHAR(255)),CAST('calendar year' AS VARCHAR(255)),null,null,null,null,CAST('OBSERVATION' AS VARCHAR(255)));
-insert into @results_schema.heracles_analysis (ANALYSIS_ID,ANALYSIS_NAME,STRATUM_1_NAME,STRATUM_2_NAME,STRATUM_3_NAME,STRATUM_4_NAME,STRATUM_5_NAME,ANALYSIS_TYPE) values (110,CAST('Number of persons with continuous observation in each month' AS VARCHAR(255)),CAST('calendar month' AS VARCHAR(255)),null,null,null,null,CAST('OBSERVATION' AS VARCHAR(255)));
-insert into @results_schema.heracles_analysis (ANALYSIS_ID,ANALYSIS_NAME,STRATUM_1_NAME,STRATUM_2_NAME,STRATUM_3_NAME,STRATUM_4_NAME,STRATUM_5_NAME,ANALYSIS_TYPE) values (111,CAST('Number of persons by observation period start month' AS VARCHAR(255)),CAST('calendar month' AS VARCHAR(255)),null,null,null,null,CAST('OBSERVATION' AS VARCHAR(255)));
-insert into @results_schema.heracles_analysis (ANALYSIS_ID,ANALYSIS_NAME,STRATUM_1_NAME,STRATUM_2_NAME,STRATUM_3_NAME,STRATUM_4_NAME,STRATUM_5_NAME,ANALYSIS_TYPE) values (112,CAST('Number of persons by observation period end month' AS VARCHAR(255)),CAST('calendar month' AS VARCHAR(255)),null,null,null,null,CAST('OBSERVATION' AS VARCHAR(255)));
-insert into @results_schema.heracles_analysis (ANALYSIS_ID,ANALYSIS_NAME,STRATUM_1_NAME,STRATUM_2_NAME,STRATUM_3_NAME,STRATUM_4_NAME,STRATUM_5_NAME,ANALYSIS_TYPE) values (113,CAST('Number of persons by number of observation periods' AS VARCHAR(255)),CAST('number of observation periods' AS VARCHAR(255)),null,null,null,null,CAST('OBSERVATION' AS VARCHAR(255)));
-insert into @results_schema.heracles_analysis (ANALYSIS_ID,ANALYSIS_NAME,STRATUM_1_NAME,STRATUM_2_NAME,STRATUM_3_NAME,STRATUM_4_NAME,STRATUM_5_NAME,ANALYSIS_TYPE) values (114,CAST('Number of persons with observation period before year-of-birth' AS VARCHAR(255)),null,null,null,null,null,CAST('OBSERVATION' AS VARCHAR(255)));
-insert into @results_schema.heracles_analysis (ANALYSIS_ID,ANALYSIS_NAME,STRATUM_1_NAME,STRATUM_2_NAME,STRATUM_3_NAME,STRATUM_4_NAME,STRATUM_5_NAME,ANALYSIS_TYPE) values (115,CAST('Number of persons with observation period end < observation period start' AS VARCHAR(255)),null,null,null,null,null,CAST('OBSERVATION' AS VARCHAR(255)));
-insert into @results_schema.heracles_analysis (ANALYSIS_ID,ANALYSIS_NAME,STRATUM_1_NAME,STRATUM_2_NAME,STRATUM_3_NAME,STRATUM_4_NAME,STRATUM_5_NAME,ANALYSIS_TYPE) values (116,CAST('Number of persons with at least one day of observation in each year by gender and age decile' AS VARCHAR(255)),CAST('calendar year' AS VARCHAR(255)),CAST('gender_concept_id' AS VARCHAR(255)),CAST('age decile' AS VARCHAR(255)),null,null,CAST('OBSERVATION' AS VARCHAR(255)));
-insert into @results_schema.heracles_analysis (ANALYSIS_ID,ANALYSIS_NAME,STRATUM_1_NAME,STRATUM_2_NAME,STRATUM_3_NAME,STRATUM_4_NAME,STRATUM_5_NAME,ANALYSIS_TYPE) values (117,CAST('Number of persons with at least one day of observation in each month' AS VARCHAR(255)),CAST('calendar month' AS VARCHAR(255)),null,null,null,null,CAST('OBSERVATION' AS VARCHAR(255)));
-insert into @results_schema.heracles_analysis (ANALYSIS_ID,ANALYSIS_NAME,STRATUM_1_NAME,STRATUM_2_NAME,STRATUM_3_NAME,STRATUM_4_NAME,STRATUM_5_NAME,ANALYSIS_TYPE) values (200,CAST('Number of persons with at least one visit occurrence, by visit_concept_id' AS VARCHAR(255)),CAST('visit_concept_id' AS VARCHAR(255)),null,null,null,null,CAST('VISITS' AS VARCHAR(255)));
-insert into @results_schema.heracles_analysis (ANALYSIS_ID,ANALYSIS_NAME,STRATUM_1_NAME,STRATUM_2_NAME,STRATUM_3_NAME,STRATUM_4_NAME,STRATUM_5_NAME,ANALYSIS_TYPE) values (201,CAST('Number of visit occurrence records, by visit_concept_id' AS VARCHAR(255)),CAST('visit_concept_id' AS VARCHAR(255)),null,null,null,null,CAST('VISITS' AS VARCHAR(255)));
-insert into @results_schema.heracles_analysis (ANALYSIS_ID,ANALYSIS_NAME,STRATUM_1_NAME,STRATUM_2_NAME,STRATUM_3_NAME,STRATUM_4_NAME,STRATUM_5_NAME,ANALYSIS_TYPE) values (202,CAST('Number of persons by visit occurrence start month, by visit_concept_id' AS VARCHAR(255)),CAST('visit_concept_id' AS VARCHAR(255)),CAST('calendar month' AS VARCHAR(255)),null,null,null,CAST('VISITS' AS VARCHAR(255)));
-insert into @results_schema.heracles_analysis (ANALYSIS_ID,ANALYSIS_NAME,STRATUM_1_NAME,STRATUM_2_NAME,STRATUM_3_NAME,STRATUM_4_NAME,STRATUM_5_NAME,ANALYSIS_TYPE) values (203,CAST('Number of distinct visit occurrence concepts per person' AS VARCHAR(255)),null,null,null,null,null,CAST('VISITS' AS VARCHAR(255)));
-insert into @results_schema.heracles_analysis (ANALYSIS_ID,ANALYSIS_NAME,STRATUM_1_NAME,STRATUM_2_NAME,STRATUM_3_NAME,STRATUM_4_NAME,STRATUM_5_NAME,ANALYSIS_TYPE) values (204,CAST('Number of persons with at least one visit occurrence, by visit_concept_id by calendar year by gender by age decile' AS VARCHAR(255)),CAST('visit_concept_id' AS VARCHAR(255)),CAST('calendar year' AS VARCHAR(255)),CAST('gender_concept_id' AS VARCHAR(255)),CAST('age decile' AS VARCHAR(255)),null,CAST('VISITS' AS VARCHAR(255)));
-insert into @results_schema.heracles_analysis (ANALYSIS_ID,ANALYSIS_NAME,STRATUM_1_NAME,STRATUM_2_NAME,STRATUM_3_NAME,STRATUM_4_NAME,STRATUM_5_NAME,ANALYSIS_TYPE) values (206,CAST('Distribution of age by visit_concept_id' AS VARCHAR(255)),CAST('visit_concept_id' AS VARCHAR(255)),CAST('gender_concept_id' AS VARCHAR(255)),null,null,null,CAST('VISITS' AS VARCHAR(255)));
-insert into @results_schema.heracles_analysis (ANALYSIS_ID,ANALYSIS_NAME,STRATUM_1_NAME,STRATUM_2_NAME,STRATUM_3_NAME,STRATUM_4_NAME,STRATUM_5_NAME,ANALYSIS_TYPE) values (207,CAST('Number of visit records with invalid person_id' AS VARCHAR(255)),null,null,null,null,null,CAST('VISITS' AS VARCHAR(255)));
-insert into @results_schema.heracles_analysis (ANALYSIS_ID,ANALYSIS_NAME,STRATUM_1_NAME,STRATUM_2_NAME,STRATUM_3_NAME,STRATUM_4_NAME,STRATUM_5_NAME,ANALYSIS_TYPE) values (208,CAST('Number of visit records outside valid observation period' AS VARCHAR(255)),null,null,null,null,null,CAST('VISITS' AS VARCHAR(255)));
-insert into @results_schema.heracles_analysis (ANALYSIS_ID,ANALYSIS_NAME,STRATUM_1_NAME,STRATUM_2_NAME,STRATUM_3_NAME,STRATUM_4_NAME,STRATUM_5_NAME,ANALYSIS_TYPE) values (209,CAST('Number of visit records with end date < start date' AS VARCHAR(255)),null,null,null,null,null,CAST('VISITS' AS VARCHAR(255)));
-insert into @results_schema.heracles_analysis (ANALYSIS_ID,ANALYSIS_NAME,STRATUM_1_NAME,STRATUM_2_NAME,STRATUM_3_NAME,STRATUM_4_NAME,STRATUM_5_NAME,ANALYSIS_TYPE) values (210,CAST('Number of visit records with invalid care_site_id' AS VARCHAR(255)),null,null,null,null,null,CAST('VISITS' AS VARCHAR(255)));
-insert into @results_schema.heracles_analysis (ANALYSIS_ID,ANALYSIS_NAME,STRATUM_1_NAME,STRATUM_2_NAME,STRATUM_3_NAME,STRATUM_4_NAME,STRATUM_5_NAME,ANALYSIS_TYPE) values (211,CAST('Distribution of length of stay by visit_concept_id' AS VARCHAR(255)),CAST('visit_concept_id' AS VARCHAR(255)),null,null,null,null,CAST('VISITS' AS VARCHAR(255)));
-insert into @results_schema.heracles_analysis (ANALYSIS_ID,ANALYSIS_NAME,STRATUM_1_NAME,STRATUM_2_NAME,STRATUM_3_NAME,STRATUM_4_NAME,STRATUM_5_NAME,ANALYSIS_TYPE) values (220,CAST('Number of visit occurrence records by visit occurrence start month' AS VARCHAR(255)),CAST('calendar month' AS VARCHAR(255)),null,null,null,null,CAST('VISITS' AS VARCHAR(255)));
-insert into @results_schema.heracles_analysis (ANALYSIS_ID,ANALYSIS_NAME,STRATUM_1_NAME,STRATUM_2_NAME,STRATUM_3_NAME,STRATUM_4_NAME,STRATUM_5_NAME,ANALYSIS_TYPE) values (400,CAST('Number of persons with at least one condition occurrence, by condition_concept_id' AS VARCHAR(255)),CAST('condition_concept_id' AS VARCHAR(255)),null,null,null,null,CAST('CONDITION' AS VARCHAR(255)));
-insert into @results_schema.heracles_analysis (ANALYSIS_ID,ANALYSIS_NAME,STRATUM_1_NAME,STRATUM_2_NAME,STRATUM_3_NAME,STRATUM_4_NAME,STRATUM_5_NAME,ANALYSIS_TYPE) values (401,CAST('Number of condition occurrence records, by condition_concept_id' AS VARCHAR(255)),CAST('condition_concept_id' AS VARCHAR(255)),null,null,null,null,CAST('CONDITION' AS VARCHAR(255)));
-insert into @results_schema.heracles_analysis (ANALYSIS_ID,ANALYSIS_NAME,STRATUM_1_NAME,STRATUM_2_NAME,STRATUM_3_NAME,STRATUM_4_NAME,STRATUM_5_NAME,ANALYSIS_TYPE) values (402,CAST('Number of persons by condition occurrence start month, by condition_concept_id' AS VARCHAR(255)),CAST('condition_concept_id' AS VARCHAR(255)),CAST('calendar month' AS VARCHAR(255)),null,null,null,CAST('CONDITION' AS VARCHAR(255)));
-insert into @results_schema.heracles_analysis (ANALYSIS_ID,ANALYSIS_NAME,STRATUM_1_NAME,STRATUM_2_NAME,STRATUM_3_NAME,STRATUM_4_NAME,STRATUM_5_NAME,ANALYSIS_TYPE) values (403,CAST('Number of distinct condition occurrence concepts per person' AS VARCHAR(255)),null,null,null,null,null,CAST('CONDITION' AS VARCHAR(255)));
-insert into @results_schema.heracles_analysis (ANALYSIS_ID,ANALYSIS_NAME,STRATUM_1_NAME,STRATUM_2_NAME,STRATUM_3_NAME,STRATUM_4_NAME,STRATUM_5_NAME,ANALYSIS_TYPE) values (404,CAST('Number of persons with at least one condition occurrence, by condition_concept_id by calendar year by gender by age decile' AS VARCHAR(255)),CAST('condition_concept_id' AS VARCHAR(255)),CAST('calendar year' AS VARCHAR(255)),CAST('gender_concept_id' AS VARCHAR(255)),CAST('age decile' AS VARCHAR(255)),null,CAST('CONDITION' AS VARCHAR(255)));
-insert into @results_schema.heracles_analysis (ANALYSIS_ID,ANALYSIS_NAME,STRATUM_1_NAME,STRATUM_2_NAME,STRATUM_3_NAME,STRATUM_4_NAME,STRATUM_5_NAME,ANALYSIS_TYPE) values (405,CAST('Number of condition occurrence records, by condition_concept_id by condition_type_concept_id' AS VARCHAR(255)),CAST('condition_concept_id' AS VARCHAR(255)),CAST('condition_type_concept_id' AS VARCHAR(255)),null,null,null,CAST('CONDITION' AS VARCHAR(255)));
-insert into @results_schema.heracles_analysis (ANALYSIS_ID,ANALYSIS_NAME,STRATUM_1_NAME,STRATUM_2_NAME,STRATUM_3_NAME,STRATUM_4_NAME,STRATUM_5_NAME,ANALYSIS_TYPE) values (406,CAST('Distribution of age by condition_concept_id' AS VARCHAR(255)),CAST('condition_concept_id' AS VARCHAR(255)),CAST('gender_concept_id' AS VARCHAR(255)),null,null,null,CAST('CONDITION' AS VARCHAR(255)));
-insert into @results_schema.heracles_analysis (ANALYSIS_ID,ANALYSIS_NAME,STRATUM_1_NAME,STRATUM_2_NAME,STRATUM_3_NAME,STRATUM_4_NAME,STRATUM_5_NAME,ANALYSIS_TYPE) values (409,CAST('Number of condition occurrence records with invalid person_id' AS VARCHAR(255)),null,null,null,null,null,CAST('CONDITION' AS VARCHAR(255)));
-insert into @results_schema.heracles_analysis (ANALYSIS_ID,ANALYSIS_NAME,STRATUM_1_NAME,STRATUM_2_NAME,STRATUM_3_NAME,STRATUM_4_NAME,STRATUM_5_NAME,ANALYSIS_TYPE) values (410,CAST('Number of condition occurrence records outside valid observation period' AS VARCHAR(255)),null,null,null,null,null,CAST('CONDITION' AS VARCHAR(255)));
-insert into @results_schema.heracles_analysis (ANALYSIS_ID,ANALYSIS_NAME,STRATUM_1_NAME,STRATUM_2_NAME,STRATUM_3_NAME,STRATUM_4_NAME,STRATUM_5_NAME,ANALYSIS_TYPE) values (411,CAST('Number of condition occurrence records with end date < start date' AS VARCHAR(255)),null,null,null,null,null,CAST('CONDITION' AS VARCHAR(255)));
-insert into @results_schema.heracles_analysis (ANALYSIS_ID,ANALYSIS_NAME,STRATUM_1_NAME,STRATUM_2_NAME,STRATUM_3_NAME,STRATUM_4_NAME,STRATUM_5_NAME,ANALYSIS_TYPE) values (412,CAST('Number of condition occurrence records with invalid provider_id' AS VARCHAR(255)),null,null,null,null,null,CAST('CONDITION' AS VARCHAR(255)));
-insert into @results_schema.heracles_analysis (ANALYSIS_ID,ANALYSIS_NAME,STRATUM_1_NAME,STRATUM_2_NAME,STRATUM_3_NAME,STRATUM_4_NAME,STRATUM_5_NAME,ANALYSIS_TYPE) values (413,CAST('Number of condition occurrence records with invalid visit_id' AS VARCHAR(255)),null,null,null,null,null,CAST('CONDITION' AS VARCHAR(255)));
-insert into @results_schema.heracles_analysis (ANALYSIS_ID,ANALYSIS_NAME,STRATUM_1_NAME,STRATUM_2_NAME,STRATUM_3_NAME,STRATUM_4_NAME,STRATUM_5_NAME,ANALYSIS_TYPE) values (420,CAST('Number of condition occurrence records by condition occurrence start month' AS VARCHAR(255)),CAST('calendar month' AS VARCHAR(255)),null,null,null,null,CAST('CONDITION' AS VARCHAR(255)));
-insert into @results_schema.heracles_analysis (ANALYSIS_ID,ANALYSIS_NAME,STRATUM_1_NAME,STRATUM_2_NAME,STRATUM_3_NAME,STRATUM_4_NAME,STRATUM_5_NAME,ANALYSIS_TYPE) values (500,CAST('Number of persons with death, by cause_of_death_concept_id' AS VARCHAR(255)),CAST('cause_of_death_concept_id' AS VARCHAR(255)),null,null,null,null,CAST('DEATH' AS VARCHAR(255)));
-insert into @results_schema.heracles_analysis (ANALYSIS_ID,ANALYSIS_NAME,STRATUM_1_NAME,STRATUM_2_NAME,STRATUM_3_NAME,STRATUM_4_NAME,STRATUM_5_NAME,ANALYSIS_TYPE) values (501,CAST('Number of records of death, by cause_of_death_concept_id' AS VARCHAR(255)),CAST('cause_of_death_concept_id' AS VARCHAR(255)),null,null,null,null,CAST('DEATH' AS VARCHAR(255)));
-insert into @results_schema.heracles_analysis (ANALYSIS_ID,ANALYSIS_NAME,STRATUM_1_NAME,STRATUM_2_NAME,STRATUM_3_NAME,STRATUM_4_NAME,STRATUM_5_NAME,ANALYSIS_TYPE) values (502,CAST('Number of persons by death month' AS VARCHAR(255)),CAST('calendar month' AS VARCHAR(255)),null,null,null,null,CAST('DEATH' AS VARCHAR(255)));
-insert into @results_schema.heracles_analysis (ANALYSIS_ID,ANALYSIS_NAME,STRATUM_1_NAME,STRATUM_2_NAME,STRATUM_3_NAME,STRATUM_4_NAME,STRATUM_5_NAME,ANALYSIS_TYPE) values (504,CAST('Number of persons with a death, by calendar year by gender by age decile' AS VARCHAR(255)),CAST('calendar year' AS VARCHAR(255)),CAST('gender_concept_id' AS VARCHAR(255)),CAST('age decile' AS VARCHAR(255)),null,null,CAST('DEATH' AS VARCHAR(255)));
-insert into @results_schema.heracles_analysis (ANALYSIS_ID,ANALYSIS_NAME,STRATUM_1_NAME,STRATUM_2_NAME,STRATUM_3_NAME,STRATUM_4_NAME,STRATUM_5_NAME,ANALYSIS_TYPE) values (505,CAST('Number of death records, by death_type_concept_id' AS VARCHAR(255)),CAST('death_type_concept_id' AS VARCHAR(255)),null,null,null,null,CAST('DEATH' AS VARCHAR(255)));
-insert into @results_schema.heracles_analysis (ANALYSIS_ID,ANALYSIS_NAME,STRATUM_1_NAME,STRATUM_2_NAME,STRATUM_3_NAME,STRATUM_4_NAME,STRATUM_5_NAME,ANALYSIS_TYPE) values (506,CAST('Distribution of age at death by gender' AS VARCHAR(255)),CAST('gender_concept_id' AS VARCHAR(255)),null,null,null,null,CAST('DEATH' AS VARCHAR(255)));
-insert into @results_schema.heracles_analysis (ANALYSIS_ID,ANALYSIS_NAME,STRATUM_1_NAME,STRATUM_2_NAME,STRATUM_3_NAME,STRATUM_4_NAME,STRATUM_5_NAME,ANALYSIS_TYPE) values (509,CAST('Number of death records with invalid person_id' AS VARCHAR(255)),null,null,null,null,null,CAST('DEATH' AS VARCHAR(255)));
-insert into @results_schema.heracles_analysis (ANALYSIS_ID,ANALYSIS_NAME,STRATUM_1_NAME,STRATUM_2_NAME,STRATUM_3_NAME,STRATUM_4_NAME,STRATUM_5_NAME,ANALYSIS_TYPE) values (510,CAST('Number of death records outside valid observation period' AS VARCHAR(255)),null,null,null,null,null,CAST('DEATH' AS VARCHAR(255)));
-insert into @results_schema.heracles_analysis (ANALYSIS_ID,ANALYSIS_NAME,STRATUM_1_NAME,STRATUM_2_NAME,STRATUM_3_NAME,STRATUM_4_NAME,STRATUM_5_NAME,ANALYSIS_TYPE) values (511,CAST('Distribution of time from death to last condition' AS VARCHAR(255)),null,null,null,null,null,CAST('DEATH' AS VARCHAR(255)));
-insert into @results_schema.heracles_analysis (ANALYSIS_ID,ANALYSIS_NAME,STRATUM_1_NAME,STRATUM_2_NAME,STRATUM_3_NAME,STRATUM_4_NAME,STRATUM_5_NAME,ANALYSIS_TYPE) values (512,CAST('Distribution of time from death to last drug' AS VARCHAR(255)),null,null,null,null,null,CAST('DEATH' AS VARCHAR(255)));
-insert into @results_schema.heracles_analysis (ANALYSIS_ID,ANALYSIS_NAME,STRATUM_1_NAME,STRATUM_2_NAME,STRATUM_3_NAME,STRATUM_4_NAME,STRATUM_5_NAME,ANALYSIS_TYPE) values (513,CAST('Distribution of time from death to last visit' AS VARCHAR(255)),null,null,null,null,null,CAST('DEATH' AS VARCHAR(255)));
-insert into @results_schema.heracles_analysis (ANALYSIS_ID,ANALYSIS_NAME,STRATUM_1_NAME,STRATUM_2_NAME,STRATUM_3_NAME,STRATUM_4_NAME,STRATUM_5_NAME,ANALYSIS_TYPE) values (514,CAST('Distribution of time from death to last procedure' AS VARCHAR(255)),null,null,null,null,null,CAST('DEATH' AS VARCHAR(255)));
-insert into @results_schema.heracles_analysis (ANALYSIS_ID,ANALYSIS_NAME,STRATUM_1_NAME,STRATUM_2_NAME,STRATUM_3_NAME,STRATUM_4_NAME,STRATUM_5_NAME,ANALYSIS_TYPE) values (515,CAST('Distribution of time from death to last observation' AS VARCHAR(255)),null,null,null,null,null,CAST('DEATH' AS VARCHAR(255)));
-insert into @results_schema.heracles_analysis (ANALYSIS_ID,ANALYSIS_NAME,STRATUM_1_NAME,STRATUM_2_NAME,STRATUM_3_NAME,STRATUM_4_NAME,STRATUM_5_NAME,ANALYSIS_TYPE) values (600,CAST('Number of persons with at least one procedure occurrence, by procedure_concept_id' AS VARCHAR(255)),CAST('procedure_concept_id' AS VARCHAR(255)),null,null,null,null,CAST('PROCEDURE' AS VARCHAR(255)));
-insert into @results_schema.heracles_analysis (ANALYSIS_ID,ANALYSIS_NAME,STRATUM_1_NAME,STRATUM_2_NAME,STRATUM_3_NAME,STRATUM_4_NAME,STRATUM_5_NAME,ANALYSIS_TYPE) values (601,CAST('Number of procedure occurrence records, by procedure_concept_id' AS VARCHAR(255)),CAST('procedure_concept_id' AS VARCHAR(255)),null,null,null,null,CAST('PROCEDURE' AS VARCHAR(255)));
-insert into @results_schema.heracles_analysis (ANALYSIS_ID,ANALYSIS_NAME,STRATUM_1_NAME,STRATUM_2_NAME,STRATUM_3_NAME,STRATUM_4_NAME,STRATUM_5_NAME,ANALYSIS_TYPE) values (602,CAST('Number of persons by procedure occurrence start month, by procedure_concept_id' AS VARCHAR(255)),CAST('procedure_concept_id' AS VARCHAR(255)),CAST('calendar month' AS VARCHAR(255)),null,null,null,CAST('PROCEDURE' AS VARCHAR(255)));
-insert into @results_schema.heracles_analysis (ANALYSIS_ID,ANALYSIS_NAME,STRATUM_1_NAME,STRATUM_2_NAME,STRATUM_3_NAME,STRATUM_4_NAME,STRATUM_5_NAME,ANALYSIS_TYPE) values (603,CAST('Number of distinct procedure occurrence concepts per person' AS VARCHAR(255)),null,null,null,null,null,CAST('PROCEDURE' AS VARCHAR(255)));
-insert into @results_schema.heracles_analysis (ANALYSIS_ID,ANALYSIS_NAME,STRATUM_1_NAME,STRATUM_2_NAME,STRATUM_3_NAME,STRATUM_4_NAME,STRATUM_5_NAME,ANALYSIS_TYPE) values (604,CAST('Number of persons with at least one procedure occurrence, by procedure_concept_id by calendar year by gender by age decile' AS VARCHAR(255)),CAST('procedure_concept_id' AS VARCHAR(255)),CAST('calendar year' AS VARCHAR(255)),CAST('gender_concept_id' AS VARCHAR(255)),CAST('age decile' AS VARCHAR(255)),null,CAST('PROCEDURE' AS VARCHAR(255)));
-insert into @results_schema.heracles_analysis (ANALYSIS_ID,ANALYSIS_NAME,STRATUM_1_NAME,STRATUM_2_NAME,STRATUM_3_NAME,STRATUM_4_NAME,STRATUM_5_NAME,ANALYSIS_TYPE) values (605,CAST('Number of procedure occurrence records, by procedure_concept_id by procedure_type_concept_id' AS VARCHAR(255)),CAST('procedure_concept_id' AS VARCHAR(255)),CAST('procedure_type_concept_id' AS VARCHAR(255)),null,null,null,CAST('PROCEDURE' AS VARCHAR(255)));
-insert into @results_schema.heracles_analysis (ANALYSIS_ID,ANALYSIS_NAME,STRATUM_1_NAME,STRATUM_2_NAME,STRATUM_3_NAME,STRATUM_4_NAME,STRATUM_5_NAME,ANALYSIS_TYPE) values (606,CAST('Distribution of age by procedure_concept_id' AS VARCHAR(255)),CAST('procedure_concept_id' AS VARCHAR(255)),CAST('gender_concept_id' AS VARCHAR(255)),null,null,null,CAST('PROCEDURE' AS VARCHAR(255)));
-insert into @results_schema.heracles_analysis (ANALYSIS_ID,ANALYSIS_NAME,STRATUM_1_NAME,STRATUM_2_NAME,STRATUM_3_NAME,STRATUM_4_NAME,STRATUM_5_NAME,ANALYSIS_TYPE) values (609,CAST('Number of procedure occurrence records with invalid person_id' AS VARCHAR(255)),null,null,null,null,null,CAST('PROCEDURE' AS VARCHAR(255)));
-insert into @results_schema.heracles_analysis (ANALYSIS_ID,ANALYSIS_NAME,STRATUM_1_NAME,STRATUM_2_NAME,STRATUM_3_NAME,STRATUM_4_NAME,STRATUM_5_NAME,ANALYSIS_TYPE) values (610,CAST('Number of procedure occurrence records outside valid observation period' AS VARCHAR(255)),null,null,null,null,null,CAST('PROCEDURE' AS VARCHAR(255)));
-insert into @results_schema.heracles_analysis (ANALYSIS_ID,ANALYSIS_NAME,STRATUM_1_NAME,STRATUM_2_NAME,STRATUM_3_NAME,STRATUM_4_NAME,STRATUM_5_NAME,ANALYSIS_TYPE) values (612,CAST('Number of procedure occurrence records with invalid provider_id' AS VARCHAR(255)),null,null,null,null,null,CAST('PROCEDURE' AS VARCHAR(255)));
-insert into @results_schema.heracles_analysis (ANALYSIS_ID,ANALYSIS_NAME,STRATUM_1_NAME,STRATUM_2_NAME,STRATUM_3_NAME,STRATUM_4_NAME,STRATUM_5_NAME,ANALYSIS_TYPE) values (613,CAST('Number of procedure occurrence records with invalid visit_id' AS VARCHAR(255)),null,null,null,null,null,CAST('PROCEDURE' AS VARCHAR(255)));
-insert into @results_schema.heracles_analysis (ANALYSIS_ID,ANALYSIS_NAME,STRATUM_1_NAME,STRATUM_2_NAME,STRATUM_3_NAME,STRATUM_4_NAME,STRATUM_5_NAME,ANALYSIS_TYPE) values (620,CAST('Number of procedure occurrence records  by procedure occurrence start month' AS VARCHAR(255)),CAST('calendar month' AS VARCHAR(255)),null,null,null,null,CAST('PROCEDURE' AS VARCHAR(255)));
-insert into @results_schema.heracles_analysis (ANALYSIS_ID,ANALYSIS_NAME,STRATUM_1_NAME,STRATUM_2_NAME,STRATUM_3_NAME,STRATUM_4_NAME,STRATUM_5_NAME,ANALYSIS_TYPE) values (700,CAST('Number of persons with at least one drug exposure, by drug_concept_id' AS VARCHAR(255)),CAST('drug_concept_id' AS VARCHAR(255)),null,null,null,null,CAST('DRUG' AS VARCHAR(255)));
-insert into @results_schema.heracles_analysis (ANALYSIS_ID,ANALYSIS_NAME,STRATUM_1_NAME,STRATUM_2_NAME,STRATUM_3_NAME,STRATUM_4_NAME,STRATUM_5_NAME,ANALYSIS_TYPE) values (701,CAST('Number of drug exposure records, by drug_concept_id' AS VARCHAR(255)),CAST('drug_concept_id' AS VARCHAR(255)),null,null,null,null,CAST('DRUG' AS VARCHAR(255)));
-insert into @results_schema.heracles_analysis (ANALYSIS_ID,ANALYSIS_NAME,STRATUM_1_NAME,STRATUM_2_NAME,STRATUM_3_NAME,STRATUM_4_NAME,STRATUM_5_NAME,ANALYSIS_TYPE) values (702,CAST('Number of persons by drug exposure start month, by drug_concept_id' AS VARCHAR(255)),CAST('drug_concept_id' AS VARCHAR(255)),CAST('calendar month' AS VARCHAR(255)),null,null,null,CAST('DRUG' AS VARCHAR(255)));
-insert into @results_schema.heracles_analysis (ANALYSIS_ID,ANALYSIS_NAME,STRATUM_1_NAME,STRATUM_2_NAME,STRATUM_3_NAME,STRATUM_4_NAME,STRATUM_5_NAME,ANALYSIS_TYPE) values (703,CAST('Number of distinct drug exposure concepts per person' AS VARCHAR(255)),null,null,null,null,null,CAST('DRUG' AS VARCHAR(255)));
-insert into @results_schema.heracles_analysis (ANALYSIS_ID,ANALYSIS_NAME,STRATUM_1_NAME,STRATUM_2_NAME,STRATUM_3_NAME,STRATUM_4_NAME,STRATUM_5_NAME,ANALYSIS_TYPE) values (704,CAST('Number of persons with at least one drug exposure, by drug_concept_id by calendar year by gender by age decile' AS VARCHAR(255)),CAST('drug_concept_id' AS VARCHAR(255)),CAST('calendar year' AS VARCHAR(255)),CAST('gender_concept_id' AS VARCHAR(255)),CAST('age decile' AS VARCHAR(255)),null,CAST('DRUG' AS VARCHAR(255)));
-insert into @results_schema.heracles_analysis (ANALYSIS_ID,ANALYSIS_NAME,STRATUM_1_NAME,STRATUM_2_NAME,STRATUM_3_NAME,STRATUM_4_NAME,STRATUM_5_NAME,ANALYSIS_TYPE) values (705,CAST('Number of drug exposure records, by drug_concept_id by drug_type_concept_id' AS VARCHAR(255)),CAST('drug_concept_id' AS VARCHAR(255)),CAST('drug_type_concept_id' AS VARCHAR(255)),null,null,null,CAST('DRUG' AS VARCHAR(255)));
-insert into @results_schema.heracles_analysis (ANALYSIS_ID,ANALYSIS_NAME,STRATUM_1_NAME,STRATUM_2_NAME,STRATUM_3_NAME,STRATUM_4_NAME,STRATUM_5_NAME,ANALYSIS_TYPE) values (706,CAST('Distribution of age by drug_concept_id' AS VARCHAR(255)),CAST('drug_concept_id' AS VARCHAR(255)),CAST('gender_concept_id' AS VARCHAR(255)),null,null,null,CAST('DRUG' AS VARCHAR(255)));
-insert into @results_schema.heracles_analysis (ANALYSIS_ID,ANALYSIS_NAME,STRATUM_1_NAME,STRATUM_2_NAME,STRATUM_3_NAME,STRATUM_4_NAME,STRATUM_5_NAME,ANALYSIS_TYPE) values (709,CAST('Number of drug exposure records with invalid person_id' AS VARCHAR(255)),null,null,null,null,null,CAST('DRUG' AS VARCHAR(255)));
-insert into @results_schema.heracles_analysis (ANALYSIS_ID,ANALYSIS_NAME,STRATUM_1_NAME,STRATUM_2_NAME,STRATUM_3_NAME,STRATUM_4_NAME,STRATUM_5_NAME,ANALYSIS_TYPE) values (710,CAST('Number of drug exposure records outside valid observation period' AS VARCHAR(255)),null,null,null,null,null,CAST('DRUG' AS VARCHAR(255)));
-insert into @results_schema.heracles_analysis (ANALYSIS_ID,ANALYSIS_NAME,STRATUM_1_NAME,STRATUM_2_NAME,STRATUM_3_NAME,STRATUM_4_NAME,STRATUM_5_NAME,ANALYSIS_TYPE) values (711,CAST('Number of drug exposure records with end date < start date' AS VARCHAR(255)),null,null,null,null,null,CAST('DRUG' AS VARCHAR(255)));
-insert into @results_schema.heracles_analysis (ANALYSIS_ID,ANALYSIS_NAME,STRATUM_1_NAME,STRATUM_2_NAME,STRATUM_3_NAME,STRATUM_4_NAME,STRATUM_5_NAME,ANALYSIS_TYPE) values (712,CAST('Number of drug exposure records with invalid provider_id' AS VARCHAR(255)),null,null,null,null,null,CAST('DRUG' AS VARCHAR(255)));
-insert into @results_schema.heracles_analysis (ANALYSIS_ID,ANALYSIS_NAME,STRATUM_1_NAME,STRATUM_2_NAME,STRATUM_3_NAME,STRATUM_4_NAME,STRATUM_5_NAME,ANALYSIS_TYPE) values (713,CAST('Number of drug exposure records with invalid visit_id' AS VARCHAR(255)),null,null,null,null,null,CAST('DRUG' AS VARCHAR(255)));
-insert into @results_schema.heracles_analysis (ANALYSIS_ID,ANALYSIS_NAME,STRATUM_1_NAME,STRATUM_2_NAME,STRATUM_3_NAME,STRATUM_4_NAME,STRATUM_5_NAME,ANALYSIS_TYPE) values (715,CAST('Distribution of days_supply by drug_concept_id' AS VARCHAR(255)),CAST('drug_concept_id' AS VARCHAR(255)),null,null,null,null,CAST('DRUG' AS VARCHAR(255)));
-insert into @results_schema.heracles_analysis (ANALYSIS_ID,ANALYSIS_NAME,STRATUM_1_NAME,STRATUM_2_NAME,STRATUM_3_NAME,STRATUM_4_NAME,STRATUM_5_NAME,ANALYSIS_TYPE) values (716,CAST('Distribution of refills by drug_concept_id' AS VARCHAR(255)),CAST('drug_concept_id' AS VARCHAR(255)),null,null,null,null,CAST('DRUG' AS VARCHAR(255)));
-insert into @results_schema.heracles_analysis (ANALYSIS_ID,ANALYSIS_NAME,STRATUM_1_NAME,STRATUM_2_NAME,STRATUM_3_NAME,STRATUM_4_NAME,STRATUM_5_NAME,ANALYSIS_TYPE) values (717,CAST('Distribution of quantity by drug_concept_id' AS VARCHAR(255)),CAST('drug_concept_id' AS VARCHAR(255)),null,null,null,null,CAST('DRUG' AS VARCHAR(255)));
-insert into @results_schema.heracles_analysis (ANALYSIS_ID,ANALYSIS_NAME,STRATUM_1_NAME,STRATUM_2_NAME,STRATUM_3_NAME,STRATUM_4_NAME,STRATUM_5_NAME,ANALYSIS_TYPE) values (720,CAST('Number of drug exposure records  by drug exposure start month' AS VARCHAR(255)),CAST('calendar month' AS VARCHAR(255)),null,null,null,null,CAST('DRUG' AS VARCHAR(255)));
-insert into @results_schema.heracles_analysis (ANALYSIS_ID,ANALYSIS_NAME,STRATUM_1_NAME,STRATUM_2_NAME,STRATUM_3_NAME,STRATUM_4_NAME,STRATUM_5_NAME,ANALYSIS_TYPE) values (800,CAST('Number of persons with at least one observation occurrence, by observation_concept_id' AS VARCHAR(255)),CAST('observation_concept_id' AS VARCHAR(255)),null,null,null,null,CAST('OBSERVATION' AS VARCHAR(255)));
-insert into @results_schema.heracles_analysis (ANALYSIS_ID,ANALYSIS_NAME,STRATUM_1_NAME,STRATUM_2_NAME,STRATUM_3_NAME,STRATUM_4_NAME,STRATUM_5_NAME,ANALYSIS_TYPE) values (801,CAST('Number of observation occurrence records, by observation_concept_id' AS VARCHAR(255)),CAST('observation_concept_id' AS VARCHAR(255)),null,null,null,null,CAST('OBSERVATION' AS VARCHAR(255)));
-insert into @results_schema.heracles_analysis (ANALYSIS_ID,ANALYSIS_NAME,STRATUM_1_NAME,STRATUM_2_NAME,STRATUM_3_NAME,STRATUM_4_NAME,STRATUM_5_NAME,ANALYSIS_TYPE) values (802,CAST('Number of persons by observation occurrence start month, by observation_concept_id' AS VARCHAR(255)),CAST('observation_concept_id' AS VARCHAR(255)),CAST('calendar month' AS VARCHAR(255)),null,null,null,CAST('OBSERVATION' AS VARCHAR(255)));
-insert into @results_schema.heracles_analysis (ANALYSIS_ID,ANALYSIS_NAME,STRATUM_1_NAME,STRATUM_2_NAME,STRATUM_3_NAME,STRATUM_4_NAME,STRATUM_5_NAME,ANALYSIS_TYPE) values (803,CAST('Number of distinct observation occurrence concepts per person' AS VARCHAR(255)),null,null,null,null,null,CAST('OBSERVATION' AS VARCHAR(255)));
-insert into @results_schema.heracles_analysis (ANALYSIS_ID,ANALYSIS_NAME,STRATUM_1_NAME,STRATUM_2_NAME,STRATUM_3_NAME,STRATUM_4_NAME,STRATUM_5_NAME,ANALYSIS_TYPE) values (804,CAST('Number of persons with at least one observation occurrence, by observation_concept_id by calendar year by gender by age decile' AS VARCHAR(255)),CAST('observation_concept_id' AS VARCHAR(255)),CAST('calendar year' AS VARCHAR(255)),CAST('gender_concept_id' AS VARCHAR(255)),CAST('age decile' AS VARCHAR(255)),null,CAST('OBSERVATION' AS VARCHAR(255)));
-insert into @results_schema.heracles_analysis (ANALYSIS_ID,ANALYSIS_NAME,STRATUM_1_NAME,STRATUM_2_NAME,STRATUM_3_NAME,STRATUM_4_NAME,STRATUM_5_NAME,ANALYSIS_TYPE) values (805,CAST('Number of observation occurrence records, by observation_concept_id by observation_type_concept_id' AS VARCHAR(255)),CAST('observation_concept_id' AS VARCHAR(255)),CAST('observation_type_concept_id' AS VARCHAR(255)),null,null,null,CAST('OBSERVATION' AS VARCHAR(255)));
-insert into @results_schema.heracles_analysis (ANALYSIS_ID,ANALYSIS_NAME,STRATUM_1_NAME,STRATUM_2_NAME,STRATUM_3_NAME,STRATUM_4_NAME,STRATUM_5_NAME,ANALYSIS_TYPE) values (806,CAST('Distribution of age by observation_concept_id' AS VARCHAR(255)),CAST('observation_concept_id' AS VARCHAR(255)),CAST('gender_concept_id' AS VARCHAR(255)),null,null,null,CAST('OBSERVATION' AS VARCHAR(255)));
-insert into @results_schema.heracles_analysis (ANALYSIS_ID,ANALYSIS_NAME,STRATUM_1_NAME,STRATUM_2_NAME,STRATUM_3_NAME,STRATUM_4_NAME,STRATUM_5_NAME,ANALYSIS_TYPE) values (807,CAST('Number of observation occurrence records, by observation_concept_id and unit_concept_id' AS VARCHAR(255)),CAST('observation_concept_id' AS VARCHAR(255)),CAST('unit_concept_id' AS VARCHAR(255)),null,null,null,CAST('OBSERVATION' AS VARCHAR(255)));
-insert into @results_schema.heracles_analysis (ANALYSIS_ID,ANALYSIS_NAME,STRATUM_1_NAME,STRATUM_2_NAME,STRATUM_3_NAME,STRATUM_4_NAME,STRATUM_5_NAME,ANALYSIS_TYPE) values (809,CAST('Number of observation records with invalid person_id' AS VARCHAR(255)),null,null,null,null,null,CAST('OBSERVATION' AS VARCHAR(255)));
-insert into @results_schema.heracles_analysis (ANALYSIS_ID,ANALYSIS_NAME,STRATUM_1_NAME,STRATUM_2_NAME,STRATUM_3_NAME,STRATUM_4_NAME,STRATUM_5_NAME,ANALYSIS_TYPE) values (810,CAST('Number of observation records outside valid observation period' AS VARCHAR(255)),null,null,null,null,null,CAST('OBSERVATION' AS VARCHAR(255)));
-insert into @results_schema.heracles_analysis (ANALYSIS_ID,ANALYSIS_NAME,STRATUM_1_NAME,STRATUM_2_NAME,STRATUM_3_NAME,STRATUM_4_NAME,STRATUM_5_NAME,ANALYSIS_TYPE) values (812,CAST('Number of observation records with invalid provider_id' AS VARCHAR(255)),null,null,null,null,null,CAST('OBSERVATION' AS VARCHAR(255)));
-insert into @results_schema.heracles_analysis (ANALYSIS_ID,ANALYSIS_NAME,STRATUM_1_NAME,STRATUM_2_NAME,STRATUM_3_NAME,STRATUM_4_NAME,STRATUM_5_NAME,ANALYSIS_TYPE) values (813,CAST('Number of observation records with invalid visit_id' AS VARCHAR(255)),null,null,null,null,null,CAST('OBSERVATION' AS VARCHAR(255)));
-insert into @results_schema.heracles_analysis (ANALYSIS_ID,ANALYSIS_NAME,STRATUM_1_NAME,STRATUM_2_NAME,STRATUM_3_NAME,STRATUM_4_NAME,STRATUM_5_NAME,ANALYSIS_TYPE) values (814,CAST('Number of observation records with no value (numeric, string, or concept)' AS VARCHAR(255)),null,null,null,null,null,CAST('OBSERVATION' AS VARCHAR(255)));
-insert into @results_schema.heracles_analysis (ANALYSIS_ID,ANALYSIS_NAME,STRATUM_1_NAME,STRATUM_2_NAME,STRATUM_3_NAME,STRATUM_4_NAME,STRATUM_5_NAME,ANALYSIS_TYPE) values (815,CAST('Distribution of numeric values, by observation_concept_id and unit_concept_id' AS VARCHAR(255)),null,null,null,null,null,CAST('OBSERVATION' AS VARCHAR(255)));
-insert into @results_schema.heracles_analysis (ANALYSIS_ID,ANALYSIS_NAME,STRATUM_1_NAME,STRATUM_2_NAME,STRATUM_3_NAME,STRATUM_4_NAME,STRATUM_5_NAME,ANALYSIS_TYPE) values (816,CAST('Distribution of low range, by observation_concept_id and unit_concept_id' AS VARCHAR(255)),null,null,null,null,null,CAST('OBSERVATION' AS VARCHAR(255)));
-insert into @results_schema.heracles_analysis (ANALYSIS_ID,ANALYSIS_NAME,STRATUM_1_NAME,STRATUM_2_NAME,STRATUM_3_NAME,STRATUM_4_NAME,STRATUM_5_NAME,ANALYSIS_TYPE) values (817,CAST('Distribution of high range, by observation_concept_id and unit_concept_id' AS VARCHAR(255)),null,null,null,null,null,CAST('OBSERVATION' AS VARCHAR(255)));
-insert into @results_schema.heracles_analysis (ANALYSIS_ID,ANALYSIS_NAME,STRATUM_1_NAME,STRATUM_2_NAME,STRATUM_3_NAME,STRATUM_4_NAME,STRATUM_5_NAME,ANALYSIS_TYPE) values (818,CAST('Number of observation records below/within/above normal range, by observation_concept_id and unit_concept_id' AS VARCHAR(255)),null,null,null,null,null,CAST('OBSERVATION' AS VARCHAR(255)));
-insert into @results_schema.heracles_analysis (ANALYSIS_ID,ANALYSIS_NAME,STRATUM_1_NAME,STRATUM_2_NAME,STRATUM_3_NAME,STRATUM_4_NAME,STRATUM_5_NAME,ANALYSIS_TYPE) values (820,CAST('Number of observation records  by observation start month' AS VARCHAR(255)),CAST('calendar month' AS VARCHAR(255)),null,null,null,null,CAST('OBSERVATION' AS VARCHAR(255)));
-insert into @results_schema.heracles_analysis (ANALYSIS_ID,ANALYSIS_NAME,STRATUM_1_NAME,STRATUM_2_NAME,STRATUM_3_NAME,STRATUM_4_NAME,STRATUM_5_NAME,ANALYSIS_TYPE) values (900,CAST('Number of persons with at least one drug era, by drug_concept_id' AS VARCHAR(255)),CAST('drug_concept_id' AS VARCHAR(255)),null,null,null,null,CAST('DRUG_ERA' AS VARCHAR(255)));
-insert into @results_schema.heracles_analysis (ANALYSIS_ID,ANALYSIS_NAME,STRATUM_1_NAME,STRATUM_2_NAME,STRATUM_3_NAME,STRATUM_4_NAME,STRATUM_5_NAME,ANALYSIS_TYPE) values (901,CAST('Number of drug era records, by drug_concept_id' AS VARCHAR(255)),CAST('drug_concept_id' AS VARCHAR(255)),null,null,null,null,CAST('DRUG_ERA' AS VARCHAR(255)));
-insert into @results_schema.heracles_analysis (ANALYSIS_ID,ANALYSIS_NAME,STRATUM_1_NAME,STRATUM_2_NAME,STRATUM_3_NAME,STRATUM_4_NAME,STRATUM_5_NAME,ANALYSIS_TYPE) values (902,CAST('Number of persons by drug era start month, by drug_concept_id' AS VARCHAR(255)),CAST('drug_concept_id' AS VARCHAR(255)),CAST('calendar month' AS VARCHAR(255)),null,null,null,CAST('DRUG_ERA' AS VARCHAR(255)));
-insert into @results_schema.heracles_analysis (ANALYSIS_ID,ANALYSIS_NAME,STRATUM_1_NAME,STRATUM_2_NAME,STRATUM_3_NAME,STRATUM_4_NAME,STRATUM_5_NAME,ANALYSIS_TYPE) values (903,CAST('Number of distinct drug era concepts per person' AS VARCHAR(255)),null,null,null,null,null,CAST('DRUG_ERA' AS VARCHAR(255)));
-insert into @results_schema.heracles_analysis (ANALYSIS_ID,ANALYSIS_NAME,STRATUM_1_NAME,STRATUM_2_NAME,STRATUM_3_NAME,STRATUM_4_NAME,STRATUM_5_NAME,ANALYSIS_TYPE) values (904,CAST('Number of persons with at least one drug era, by drug_concept_id by calendar year by gender by age decile' AS VARCHAR(255)),CAST('drug_concept_id' AS VARCHAR(255)),CAST('calendar year' AS VARCHAR(255)),CAST('gender_concept_id' AS VARCHAR(255)),CAST('age decile' AS VARCHAR(255)),null,CAST('DRUG_ERA' AS VARCHAR(255)));
-insert into @results_schema.heracles_analysis (ANALYSIS_ID,ANALYSIS_NAME,STRATUM_1_NAME,STRATUM_2_NAME,STRATUM_3_NAME,STRATUM_4_NAME,STRATUM_5_NAME,ANALYSIS_TYPE) values (906,CAST('Distribution of age by drug_concept_id' AS VARCHAR(255)),CAST('drug_concept_id' AS VARCHAR(255)),CAST('gender_concept_id' AS VARCHAR(255)),null,null,null,CAST('DRUG_ERA' AS VARCHAR(255)));
-insert into @results_schema.heracles_analysis (ANALYSIS_ID,ANALYSIS_NAME,STRATUM_1_NAME,STRATUM_2_NAME,STRATUM_3_NAME,STRATUM_4_NAME,STRATUM_5_NAME,ANALYSIS_TYPE) values (907,CAST('Distribution of drug era length, by drug_concept_id' AS VARCHAR(255)),CAST('drug_concept_id' AS VARCHAR(255)),null,null,null,null,CAST('DRUG_ERA' AS VARCHAR(255)));
-insert into @results_schema.heracles_analysis (ANALYSIS_ID,ANALYSIS_NAME,STRATUM_1_NAME,STRATUM_2_NAME,STRATUM_3_NAME,STRATUM_4_NAME,STRATUM_5_NAME,ANALYSIS_TYPE) values (908,CAST('Number of drug eras without valid person' AS VARCHAR(255)),null,null,null,null,null,CAST('DRUG_ERA' AS VARCHAR(255)));
-insert into @results_schema.heracles_analysis (ANALYSIS_ID,ANALYSIS_NAME,STRATUM_1_NAME,STRATUM_2_NAME,STRATUM_3_NAME,STRATUM_4_NAME,STRATUM_5_NAME,ANALYSIS_TYPE) values (909,CAST('Number of drug eras outside valid observation period' AS VARCHAR(255)),null,null,null,null,null,CAST('DRUG_ERA' AS VARCHAR(255)));
-insert into @results_schema.heracles_analysis (ANALYSIS_ID,ANALYSIS_NAME,STRATUM_1_NAME,STRATUM_2_NAME,STRATUM_3_NAME,STRATUM_4_NAME,STRATUM_5_NAME,ANALYSIS_TYPE) values (910,CAST('Number of drug eras with end date < start date' AS VARCHAR(255)),null,null,null,null,null,CAST('DRUG_ERA' AS VARCHAR(255)));
-insert into @results_schema.heracles_analysis (ANALYSIS_ID,ANALYSIS_NAME,STRATUM_1_NAME,STRATUM_2_NAME,STRATUM_3_NAME,STRATUM_4_NAME,STRATUM_5_NAME,ANALYSIS_TYPE) values (920,CAST('Number of drug era records  by drug era start month' AS VARCHAR(255)),CAST('calendar month' AS VARCHAR(255)),null,null,null,null,CAST('DRUG_ERA' AS VARCHAR(255)));
-insert into @results_schema.heracles_analysis (ANALYSIS_ID,ANALYSIS_NAME,STRATUM_1_NAME,STRATUM_2_NAME,STRATUM_3_NAME,STRATUM_4_NAME,STRATUM_5_NAME,ANALYSIS_TYPE) values (1000,CAST('Number of persons with at least one condition era, by condition_concept_id' AS VARCHAR(255)),CAST('condition_concept_id' AS VARCHAR(255)),null,null,null,null,CAST('CONDITION_ERA' AS VARCHAR(255)));
-insert into @results_schema.heracles_analysis (ANALYSIS_ID,ANALYSIS_NAME,STRATUM_1_NAME,STRATUM_2_NAME,STRATUM_3_NAME,STRATUM_4_NAME,STRATUM_5_NAME,ANALYSIS_TYPE) values (1001,CAST('Number of condition era records, by condition_concept_id' AS VARCHAR(255)),CAST('condition_concept_id' AS VARCHAR(255)),null,null,null,null,CAST('CONDITION_ERA' AS VARCHAR(255)));
-insert into @results_schema.heracles_analysis (ANALYSIS_ID,ANALYSIS_NAME,STRATUM_1_NAME,STRATUM_2_NAME,STRATUM_3_NAME,STRATUM_4_NAME,STRATUM_5_NAME,ANALYSIS_TYPE) values (1002,CAST('Number of persons by condition era start month, by condition_concept_id' AS VARCHAR(255)),CAST('condition_concept_id' AS VARCHAR(255)),CAST('calendar month' AS VARCHAR(255)),null,null,null,CAST('CONDITION_ERA' AS VARCHAR(255)));
-insert into @results_schema.heracles_analysis (ANALYSIS_ID,ANALYSIS_NAME,STRATUM_1_NAME,STRATUM_2_NAME,STRATUM_3_NAME,STRATUM_4_NAME,STRATUM_5_NAME,ANALYSIS_TYPE) values (1003,CAST('Number of distinct condition era concepts per person' AS VARCHAR(255)),null,null,null,null,null,CAST('CONDITION_ERA' AS VARCHAR(255)));
-insert into @results_schema.heracles_analysis (ANALYSIS_ID,ANALYSIS_NAME,STRATUM_1_NAME,STRATUM_2_NAME,STRATUM_3_NAME,STRATUM_4_NAME,STRATUM_5_NAME,ANALYSIS_TYPE) values (1004,CAST('Number of persons with at least one condition era, by condition_concept_id by calendar year by gender by age decile' AS VARCHAR(255)),CAST('condition_concept_id' AS VARCHAR(255)),CAST('calendar year' AS VARCHAR(255)),CAST('gender_concept_id' AS VARCHAR(255)),CAST('age decile' AS VARCHAR(255)),null,CAST('CONDITION_ERA' AS VARCHAR(255)));
-insert into @results_schema.heracles_analysis (ANALYSIS_ID,ANALYSIS_NAME,STRATUM_1_NAME,STRATUM_2_NAME,STRATUM_3_NAME,STRATUM_4_NAME,STRATUM_5_NAME,ANALYSIS_TYPE) values (1006,CAST('Distribution of age by condition_concept_id' AS VARCHAR(255)),CAST('condition_concept_id' AS VARCHAR(255)),CAST('gender_concept_id' AS VARCHAR(255)),null,null,null,CAST('CONDITION_ERA' AS VARCHAR(255)));
-insert into @results_schema.heracles_analysis (ANALYSIS_ID,ANALYSIS_NAME,STRATUM_1_NAME,STRATUM_2_NAME,STRATUM_3_NAME,STRATUM_4_NAME,STRATUM_5_NAME,ANALYSIS_TYPE) values (1007,CAST('Distribution of condition era length, by condition_concept_id' AS VARCHAR(255)),CAST('condition_concept_id' AS VARCHAR(255)),null,null,null,null,CAST('CONDITION_ERA' AS VARCHAR(255)));
-insert into @results_schema.heracles_analysis (ANALYSIS_ID,ANALYSIS_NAME,STRATUM_1_NAME,STRATUM_2_NAME,STRATUM_3_NAME,STRATUM_4_NAME,STRATUM_5_NAME,ANALYSIS_TYPE) values (1008,CAST('Number of condition eras without valid person' AS VARCHAR(255)),null,null,null,null,null,CAST('CONDITION_ERA' AS VARCHAR(255)));
-insert into @results_schema.heracles_analysis (ANALYSIS_ID,ANALYSIS_NAME,STRATUM_1_NAME,STRATUM_2_NAME,STRATUM_3_NAME,STRATUM_4_NAME,STRATUM_5_NAME,ANALYSIS_TYPE) values (1009,CAST('Number of condition eras outside valid observation period' AS VARCHAR(255)),null,null,null,null,null,CAST('CONDITION_ERA' AS VARCHAR(255)));
-insert into @results_schema.heracles_analysis (ANALYSIS_ID,ANALYSIS_NAME,STRATUM_1_NAME,STRATUM_2_NAME,STRATUM_3_NAME,STRATUM_4_NAME,STRATUM_5_NAME,ANALYSIS_TYPE) values (1010,CAST('Number of condition eras with end date < start date' AS VARCHAR(255)),null,null,null,null,null,CAST('CONDITION_ERA' AS VARCHAR(255)));
-insert into @results_schema.heracles_analysis (ANALYSIS_ID,ANALYSIS_NAME,STRATUM_1_NAME,STRATUM_2_NAME,STRATUM_3_NAME,STRATUM_4_NAME,STRATUM_5_NAME,ANALYSIS_TYPE) values (1020,CAST('Number of condition era records by condition era start month' AS VARCHAR(255)),CAST('calendar month' AS VARCHAR(255)),null,null,null,null,CAST('CONDITION_ERA' AS VARCHAR(255)));
-insert into @results_schema.heracles_analysis (ANALYSIS_ID,ANALYSIS_NAME,STRATUM_1_NAME,STRATUM_2_NAME,STRATUM_3_NAME,STRATUM_4_NAME,STRATUM_5_NAME,ANALYSIS_TYPE) values (1100,CAST('Number of persons by location 3-digit zip' AS VARCHAR(255)),CAST('3-digit zip' AS VARCHAR(255)),null,null,null,null,CAST('LOCATION' AS VARCHAR(255)));
-insert into @results_schema.heracles_analysis (ANALYSIS_ID,ANALYSIS_NAME,STRATUM_1_NAME,STRATUM_2_NAME,STRATUM_3_NAME,STRATUM_4_NAME,STRATUM_5_NAME,ANALYSIS_TYPE) values (1101,CAST('Number of persons by location state' AS VARCHAR(255)),CAST('state' AS VARCHAR(255)),null,null,null,null,CAST('LOCATION' AS VARCHAR(255)));
-insert into @results_schema.heracles_analysis (ANALYSIS_ID,ANALYSIS_NAME,STRATUM_1_NAME,STRATUM_2_NAME,STRATUM_3_NAME,STRATUM_4_NAME,STRATUM_5_NAME,ANALYSIS_TYPE) values (1200,CAST('Number of persons by place of service' AS VARCHAR(255)),CAST('place_of_service_concept_id' AS VARCHAR(255)),null,null,null,null,CAST('CARE_SITE' AS VARCHAR(255)));
-insert into @results_schema.heracles_analysis (ANALYSIS_ID,ANALYSIS_NAME,STRATUM_1_NAME,STRATUM_2_NAME,STRATUM_3_NAME,STRATUM_4_NAME,STRATUM_5_NAME,ANALYSIS_TYPE) values (1201,CAST('Number of visits by place of service' AS VARCHAR(255)),CAST('place_of_service_concept_id' AS VARCHAR(255)),null,null,null,null,CAST('CARE_SITE' AS VARCHAR(255)));
-insert into @results_schema.heracles_analysis (ANALYSIS_ID,ANALYSIS_NAME,STRATUM_1_NAME,STRATUM_2_NAME,STRATUM_3_NAME,STRATUM_4_NAME,STRATUM_5_NAME,ANALYSIS_TYPE) values (1700,CAST('Number of records by cohort_definition_id' AS VARCHAR(255)),CAST('cohort_definition_id' AS VARCHAR(255)),null,null,null,null,CAST('COHORT' AS VARCHAR(255)));
-insert into @results_schema.heracles_analysis (ANALYSIS_ID,ANALYSIS_NAME,STRATUM_1_NAME,STRATUM_2_NAME,STRATUM_3_NAME,STRATUM_4_NAME,STRATUM_5_NAME,ANALYSIS_TYPE) values (1701,CAST('Number of records with cohort end date < cohort start date' AS VARCHAR(255)),null,null,null,null,null,CAST('COHORT' AS VARCHAR(255)));
-insert into @results_schema.heracles_analysis (ANALYSIS_ID,ANALYSIS_NAME,STRATUM_1_NAME,STRATUM_2_NAME,STRATUM_3_NAME,STRATUM_4_NAME,STRATUM_5_NAME,ANALYSIS_TYPE) values (1800,CAST('Number of persons by age, with age at cohort start' AS VARCHAR(255)),CAST('age' AS VARCHAR(255)),null,null,null,null,CAST('COHORT_SPECIFIC_ANALYSES' AS VARCHAR(255)));
-insert into @results_schema.heracles_analysis (ANALYSIS_ID,ANALYSIS_NAME,STRATUM_1_NAME,STRATUM_2_NAME,STRATUM_3_NAME,STRATUM_4_NAME,STRATUM_5_NAME,ANALYSIS_TYPE) values (1801,CAST('Distribution of age at cohort start' AS VARCHAR(255)),null,null,null,null,null,CAST('COHORT_SPECIFIC_ANALYSES' AS VARCHAR(255)));
-insert into @results_schema.heracles_analysis (ANALYSIS_ID,ANALYSIS_NAME,STRATUM_1_NAME,STRATUM_2_NAME,STRATUM_3_NAME,STRATUM_4_NAME,STRATUM_5_NAME,ANALYSIS_TYPE) values (1802,CAST('Distribution of age at cohort start by gender' AS VARCHAR(255)),CAST('gender_concept_id' AS VARCHAR(255)),null,null,null,null,CAST('COHORT_SPECIFIC_ANALYSES' AS VARCHAR(255)));
-insert into @results_schema.heracles_analysis (ANALYSIS_ID,ANALYSIS_NAME,STRATUM_1_NAME,STRATUM_2_NAME,STRATUM_3_NAME,STRATUM_4_NAME,STRATUM_5_NAME,ANALYSIS_TYPE) values (1803,CAST('Distribution of age at cohort start by cohort start year' AS VARCHAR(255)),CAST('calendar year' AS VARCHAR(255)),null,null,null,null,CAST('COHORT_SPECIFIC_ANALYSES' AS VARCHAR(255)));
-insert into @results_schema.heracles_analysis (ANALYSIS_ID,ANALYSIS_NAME,STRATUM_1_NAME,STRATUM_2_NAME,STRATUM_3_NAME,STRATUM_4_NAME,STRATUM_5_NAME,ANALYSIS_TYPE) values (1804,CAST('Number of persons by duration from cohort start to cohort end, in 30d increments' AS VARCHAR(255)),CAST('Cohort period length 30d increments' AS VARCHAR(255)),null,null,null,null,CAST('COHORT_SPECIFIC_ANALYSES' AS VARCHAR(255)));
-insert into @results_schema.heracles_analysis (ANALYSIS_ID,ANALYSIS_NAME,STRATUM_1_NAME,STRATUM_2_NAME,STRATUM_3_NAME,STRATUM_4_NAME,STRATUM_5_NAME,ANALYSIS_TYPE) values (1805,CAST('Number of persons by duration from observation start to cohort start, in 30d increments' AS VARCHAR(255)),CAST('Baseline period length 30d increments' AS VARCHAR(255)),null,null,null,null,CAST('COHORT_SPECIFIC_ANALYSES' AS VARCHAR(255)));
-insert into @results_schema.heracles_analysis (ANALYSIS_ID,ANALYSIS_NAME,STRATUM_1_NAME,STRATUM_2_NAME,STRATUM_3_NAME,STRATUM_4_NAME,STRATUM_5_NAME,ANALYSIS_TYPE) values (1806,CAST('Number of persons by duration from cohort start to observation end, in 30d increments' AS VARCHAR(255)),CAST('Follow-up period length 30d increments' AS VARCHAR(255)),null,null,null,null,CAST('COHORT_SPECIFIC_ANALYSES' AS VARCHAR(255)));
-insert into @results_schema.heracles_analysis (ANALYSIS_ID,ANALYSIS_NAME,STRATUM_1_NAME,STRATUM_2_NAME,STRATUM_3_NAME,STRATUM_4_NAME,STRATUM_5_NAME,ANALYSIS_TYPE) values (1807,CAST('Number of persons by duration from cohort end to observation end, in 30d increments' AS VARCHAR(255)),CAST('Post-cohort period length 30d increments' AS VARCHAR(255)),null,null,null,null,CAST('COHORT_SPECIFIC_ANALYSES' AS VARCHAR(255)));
-insert into @results_schema.heracles_analysis (ANALYSIS_ID,ANALYSIS_NAME,STRATUM_1_NAME,STRATUM_2_NAME,STRATUM_3_NAME,STRATUM_4_NAME,STRATUM_5_NAME,ANALYSIS_TYPE) values (1808,CAST('Distribution of duration (days) from cohort start to cohort end' AS VARCHAR(255)),null,null,null,null,null,CAST('COHORT_SPECIFIC_ANALYSES' AS VARCHAR(255)));
-insert into @results_schema.heracles_analysis (ANALYSIS_ID,ANALYSIS_NAME,STRATUM_1_NAME,STRATUM_2_NAME,STRATUM_3_NAME,STRATUM_4_NAME,STRATUM_5_NAME,ANALYSIS_TYPE) values (1809,CAST('Distribution of duration (days) from cohort start to cohort end, by gender' AS VARCHAR(255)),CAST('gender_concept_id' AS VARCHAR(255)),null,null,null,null,CAST('COHORT_SPECIFIC_ANALYSES' AS VARCHAR(255)));
-insert into @results_schema.heracles_analysis (ANALYSIS_ID,ANALYSIS_NAME,STRATUM_1_NAME,STRATUM_2_NAME,STRATUM_3_NAME,STRATUM_4_NAME,STRATUM_5_NAME,ANALYSIS_TYPE) values (1810,CAST('Distribution of duration (days) from cohort start to cohort end, by age decile' AS VARCHAR(255)),CAST('age decile' AS VARCHAR(255)),null,null,null,null,CAST('COHORT_SPECIFIC_ANALYSES' AS VARCHAR(255)));
-insert into @results_schema.heracles_analysis (ANALYSIS_ID,ANALYSIS_NAME,STRATUM_1_NAME,STRATUM_2_NAME,STRATUM_3_NAME,STRATUM_4_NAME,STRATUM_5_NAME,ANALYSIS_TYPE) values (1811,CAST('Distribution of duration (days) from observation start to cohort start' AS VARCHAR(255)),null,null,null,null,null,CAST('COHORT_SPECIFIC_ANALYSES' AS VARCHAR(255)));
-insert into @results_schema.heracles_analysis (ANALYSIS_ID,ANALYSIS_NAME,STRATUM_1_NAME,STRATUM_2_NAME,STRATUM_3_NAME,STRATUM_4_NAME,STRATUM_5_NAME,ANALYSIS_TYPE) values (1812,CAST('Distribution of duration (days) from cohort start to observation end' AS VARCHAR(255)),null,null,null,null,null,CAST('COHORT_SPECIFIC_ANALYSES' AS VARCHAR(255)));
-insert into @results_schema.heracles_analysis (ANALYSIS_ID,ANALYSIS_NAME,STRATUM_1_NAME,STRATUM_2_NAME,STRATUM_3_NAME,STRATUM_4_NAME,STRATUM_5_NAME,ANALYSIS_TYPE) values (1813,CAST('Distribution of duration (days) from cohort end to observation end' AS VARCHAR(255)),null,null,null,null,null,CAST('COHORT_SPECIFIC_ANALYSES' AS VARCHAR(255)));
-insert into @results_schema.heracles_analysis (ANALYSIS_ID,ANALYSIS_NAME,STRATUM_1_NAME,STRATUM_2_NAME,STRATUM_3_NAME,STRATUM_4_NAME,STRATUM_5_NAME,ANALYSIS_TYPE) values (1814,CAST('Number of persons by cohort start year by gender by age decile' AS VARCHAR(255)),CAST('calendar year' AS VARCHAR(255)),CAST('gender_concept_id' AS VARCHAR(255)),CAST('age decile' AS VARCHAR(255)),null,null,CAST('COHORT_SPECIFIC_ANALYSES' AS VARCHAR(255)));
-insert into @results_schema.heracles_analysis (ANALYSIS_ID,ANALYSIS_NAME,STRATUM_1_NAME,STRATUM_2_NAME,STRATUM_3_NAME,STRATUM_4_NAME,STRATUM_5_NAME,ANALYSIS_TYPE) values (1815,CAST('Number of persons by cohort start month' AS VARCHAR(255)),CAST('calendar month' AS VARCHAR(255)),null,null,null,null,CAST('COHORT_SPECIFIC_ANALYSES' AS VARCHAR(255)));
-insert into @results_schema.heracles_analysis (ANALYSIS_ID,ANALYSIS_NAME,STRATUM_1_NAME,STRATUM_2_NAME,STRATUM_3_NAME,STRATUM_4_NAME,STRATUM_5_NAME,ANALYSIS_TYPE) values (1816,CAST('Number of persons by number of cohort periods' AS VARCHAR(255)),CAST('number of cohort periods' AS VARCHAR(255)),null,null,null,null,CAST('COHORT_SPECIFIC_ANALYSES' AS VARCHAR(255)));
-insert into @results_schema.heracles_analysis (ANALYSIS_ID,ANALYSIS_NAME,STRATUM_1_NAME,STRATUM_2_NAME,STRATUM_3_NAME,STRATUM_4_NAME,STRATUM_5_NAME,ANALYSIS_TYPE) values (1820,CAST('Number of persons by duration from cohort start to first occurrence of condition occurrence, by condition_concept_id' AS VARCHAR(255)),CAST('condition_concept_id' AS VARCHAR(255)),CAST('time-to-event 30d increments' AS VARCHAR(255)),null,null,null,CAST('COHORT_SPECIFIC_ANALYSES' AS VARCHAR(255)));
-insert into @results_schema.heracles_analysis (ANALYSIS_ID,ANALYSIS_NAME,STRATUM_1_NAME,STRATUM_2_NAME,STRATUM_3_NAME,STRATUM_4_NAME,STRATUM_5_NAME,ANALYSIS_TYPE) values (1821,CAST('Number of events by duration from cohort start to all occurrences of condition occurrence, by condition_concept_id' AS VARCHAR(255)),CAST('condition_concept_id' AS VARCHAR(255)),CAST('time-to-event 30d increments' AS VARCHAR(255)),null,null,null,CAST('COHORT_SPECIFIC_ANALYSES' AS VARCHAR(255)));
-insert into @results_schema.heracles_analysis (ANALYSIS_ID,ANALYSIS_NAME,STRATUM_1_NAME,STRATUM_2_NAME,STRATUM_3_NAME,STRATUM_4_NAME,STRATUM_5_NAME,ANALYSIS_TYPE) values (1830,CAST('Number of persons by duration from cohort start to first occurrence of procedure occurrence, by procedure_concept_id' AS VARCHAR(255)),CAST('procedure_concept_id' AS VARCHAR(255)),CAST('time-to-event 30d increments' AS VARCHAR(255)),null,null,null,CAST('COHORT_SPECIFIC_ANALYSES' AS VARCHAR(255)));
-insert into @results_schema.heracles_analysis (ANALYSIS_ID,ANALYSIS_NAME,STRATUM_1_NAME,STRATUM_2_NAME,STRATUM_3_NAME,STRATUM_4_NAME,STRATUM_5_NAME,ANALYSIS_TYPE) values (1831,CAST('Number of events by duration from cohort start to all occurrences of procedure occurrence, by procedure_concept_id' AS VARCHAR(255)),CAST('procedure_concept_id' AS VARCHAR(255)),CAST('time-to-event 30d increments' AS VARCHAR(255)),null,null,null,CAST('COHORT_SPECIFIC_ANALYSES' AS VARCHAR(255)));
-insert into @results_schema.heracles_analysis (ANALYSIS_ID,ANALYSIS_NAME,STRATUM_1_NAME,STRATUM_2_NAME,STRATUM_3_NAME,STRATUM_4_NAME,STRATUM_5_NAME,ANALYSIS_TYPE) values (1840,CAST('Number of persons by duration from cohort start to first occurrence of drug exposure, by drug_concept_id' AS VARCHAR(255)),CAST('drug_concept_id' AS VARCHAR(255)),CAST('time-to-event 30d increments' AS VARCHAR(255)),null,null,null,CAST('COHORT_SPECIFIC_ANALYSES' AS VARCHAR(255)));
-insert into @results_schema.heracles_analysis (ANALYSIS_ID,ANALYSIS_NAME,STRATUM_1_NAME,STRATUM_2_NAME,STRATUM_3_NAME,STRATUM_4_NAME,STRATUM_5_NAME,ANALYSIS_TYPE) values (1841,CAST('Number of events by duration from cohort start to all occurrences of drug exposure, by drug_concept_id' AS VARCHAR(255)),CAST('drug_concept_id' AS VARCHAR(255)),CAST('time-to-event 30d increments' AS VARCHAR(255)),null,null,null,CAST('COHORT_SPECIFIC_ANALYSES' AS VARCHAR(255)));
-insert into @results_schema.heracles_analysis (ANALYSIS_ID,ANALYSIS_NAME,STRATUM_1_NAME,STRATUM_2_NAME,STRATUM_3_NAME,STRATUM_4_NAME,STRATUM_5_NAME,ANALYSIS_TYPE) values (1850,CAST('Number of persons by duration from cohort start to first occurrence of observation, by observation_concept_id' AS VARCHAR(255)),CAST('observation_concept_id' AS VARCHAR(255)),CAST('time-to-event 30d increments' AS VARCHAR(255)),null,null,null,CAST('COHORT_SPECIFIC_ANALYSES' AS VARCHAR(255)));
-insert into @results_schema.heracles_analysis (ANALYSIS_ID,ANALYSIS_NAME,STRATUM_1_NAME,STRATUM_2_NAME,STRATUM_3_NAME,STRATUM_4_NAME,STRATUM_5_NAME,ANALYSIS_TYPE) values (1851,CAST('Number of events by duration from cohort start to all occurrences of observation, by observation_concept_id' AS VARCHAR(255)),CAST('observation_concept_id' AS VARCHAR(255)),CAST('time-to-event 30d increments' AS VARCHAR(255)),null,null,null,CAST('COHORT_SPECIFIC_ANALYSES' AS VARCHAR(255)));
-insert into @results_schema.heracles_analysis (ANALYSIS_ID,ANALYSIS_NAME,STRATUM_1_NAME,STRATUM_2_NAME,STRATUM_3_NAME,STRATUM_4_NAME,STRATUM_5_NAME,ANALYSIS_TYPE) values (1860,CAST('Number of persons by duration from cohort start to first occurrence of condition era, by condition_concept_id' AS VARCHAR(255)),CAST('condition_concept_id' AS VARCHAR(255)),CAST('time-to-event 30d increments' AS VARCHAR(255)),null,null,null,CAST('COHORT_SPECIFIC_ANALYSES' AS VARCHAR(255)));
-insert into @results_schema.heracles_analysis (ANALYSIS_ID,ANALYSIS_NAME,STRATUM_1_NAME,STRATUM_2_NAME,STRATUM_3_NAME,STRATUM_4_NAME,STRATUM_5_NAME,ANALYSIS_TYPE) values (1861,CAST('Number of events by duration from cohort start to all occurrences of condition era, by condition_concept_id' AS VARCHAR(255)),CAST('condition_concept_id' AS VARCHAR(255)),CAST('time-to-event 30d increments' AS VARCHAR(255)),null,null,null,CAST('COHORT_SPECIFIC_ANALYSES' AS VARCHAR(255)));
-insert into @results_schema.heracles_analysis (ANALYSIS_ID,ANALYSIS_NAME,STRATUM_1_NAME,STRATUM_2_NAME,STRATUM_3_NAME,STRATUM_4_NAME,STRATUM_5_NAME,ANALYSIS_TYPE) values (1870,CAST('Number of persons by duration from cohort start to first occurrence of drug era, by drug_concept_id' AS VARCHAR(255)),CAST('drug_concept_id' AS VARCHAR(255)),CAST('time-to-event 30d increments' AS VARCHAR(255)),null,null,null,CAST('COHORT_SPECIFIC_ANALYSES' AS VARCHAR(255)));
-insert into @results_schema.heracles_analysis (ANALYSIS_ID,ANALYSIS_NAME,STRATUM_1_NAME,STRATUM_2_NAME,STRATUM_3_NAME,STRATUM_4_NAME,STRATUM_5_NAME,ANALYSIS_TYPE) values (1871,CAST('Number of events by duration from cohort start to all occurrences of drug era, by drug_concept_id' AS VARCHAR(255)),CAST('drug_concept_id' AS VARCHAR(255)),CAST('time-to-event 30d increments' AS VARCHAR(255)),null,null,null,CAST('COHORT_SPECIFIC_ANALYSES' AS VARCHAR(255)));
-
-insert into @results_schema.heracles_analysis (ANALYSIS_ID,ANALYSIS_NAME,STRATUM_1_NAME,STRATUM_2_NAME,STRATUM_3_NAME,STRATUM_4_NAME,STRATUM_5_NAME,ANALYSIS_TYPE) values (1300,CAST('Number of persons with at least one measurement occurrence, by measurement_concept_id' AS VARCHAR(255)),CAST('measurement_concept_id' AS VARCHAR(255)),null,null,null,null,CAST('MEASUREMENT' AS VARCHAR(255)));
-insert into @results_schema.heracles_analysis (ANALYSIS_ID,ANALYSIS_NAME,STRATUM_1_NAME,STRATUM_2_NAME,STRATUM_3_NAME,STRATUM_4_NAME,STRATUM_5_NAME,ANALYSIS_TYPE) values (1301,CAST('Number of measurement occurrence records, by measurement_concept_id' AS VARCHAR(255)),CAST('measurement_concept_id' AS VARCHAR(255)),null,null,null,null,CAST('MEASUREMENT' AS VARCHAR(255)));
-insert into @results_schema.heracles_analysis (ANALYSIS_ID,ANALYSIS_NAME,STRATUM_1_NAME,STRATUM_2_NAME,STRATUM_3_NAME,STRATUM_4_NAME,STRATUM_5_NAME,ANALYSIS_TYPE) values (1302,CAST('Number of persons by measurement occurrence start month, by measurement_concept_id' AS VARCHAR(255)),CAST('measurement_concept_id' AS VARCHAR(255)),CAST('calendar month' AS VARCHAR(255)),null,null,null,CAST('MEASUREMENT' AS VARCHAR(255)));
-insert into @results_schema.heracles_analysis (ANALYSIS_ID,ANALYSIS_NAME,STRATUM_1_NAME,STRATUM_2_NAME,STRATUM_3_NAME,STRATUM_4_NAME,STRATUM_5_NAME,ANALYSIS_TYPE) values (1303,CAST('Number of distinct measurement occurrence concepts per person' AS VARCHAR(255)),null,null,null,null,null,CAST('MEASUREMENT' AS VARCHAR(255)));
-insert into @results_schema.heracles_analysis (ANALYSIS_ID,ANALYSIS_NAME,STRATUM_1_NAME,STRATUM_2_NAME,STRATUM_3_NAME,STRATUM_4_NAME,STRATUM_5_NAME,ANALYSIS_TYPE) values (1304,CAST('Number of persons with at least one measurement occurrence, by measurement_concept_id by calendar year by gender by age decile' AS VARCHAR(255)),CAST('measurement_concept_id' AS VARCHAR(255)),CAST('calendar year' AS VARCHAR(255)),CAST('gender_concept_id' AS VARCHAR(255)),CAST('age decile' AS VARCHAR(255)),null,CAST('MEASUREMENT' AS VARCHAR(255)));
-insert into @results_schema.heracles_analysis (ANALYSIS_ID,ANALYSIS_NAME,STRATUM_1_NAME,STRATUM_2_NAME,STRATUM_3_NAME,STRATUM_4_NAME,STRATUM_5_NAME,ANALYSIS_TYPE) values (1305,CAST('Number of measurement occurrence records, by measurement_concept_id by measurement_type_concept_id' AS VARCHAR(255)),CAST('measurement_concept_id' AS VARCHAR(255)),CAST('measurement_type_concept_id' AS VARCHAR(255)),null,null,null,CAST('MEASUREMENT' AS VARCHAR(255)));
-insert into @results_schema.heracles_analysis (ANALYSIS_ID,ANALYSIS_NAME,STRATUM_1_NAME,STRATUM_2_NAME,STRATUM_3_NAME,STRATUM_4_NAME,STRATUM_5_NAME,ANALYSIS_TYPE) values (1306,CAST('Distribution of age by measurement_concept_id' AS VARCHAR(255)),CAST('measurement_concept_id' AS VARCHAR(255)),CAST('gender_concept_id' AS VARCHAR(255)),null,null,null,CAST('MEASUREMENT' AS VARCHAR(255)));
-insert into @results_schema.heracles_analysis (ANALYSIS_ID,ANALYSIS_NAME,STRATUM_1_NAME,STRATUM_2_NAME,STRATUM_3_NAME,STRATUM_4_NAME,STRATUM_5_NAME,ANALYSIS_TYPE) values (1307,CAST('Number of measurement occurrence records, by measurement_concept_id and unit_concept_id' AS VARCHAR(255)),CAST('measurement_concept_id' AS VARCHAR(255)),CAST('unit_concept_id' AS VARCHAR(255)),null,null,null,CAST('MEASUREMENT' AS VARCHAR(255)));
-insert into @results_schema.heracles_analysis (ANALYSIS_ID,ANALYSIS_NAME,STRATUM_1_NAME,STRATUM_2_NAME,STRATUM_3_NAME,STRATUM_4_NAME,STRATUM_5_NAME,ANALYSIS_TYPE) values (1309,CAST('Number of measurement records with invalid person_id' AS VARCHAR(255)),null,null,null,null,null,CAST('MEASUREMENT' AS VARCHAR(255)));
-insert into @results_schema.heracles_analysis (ANALYSIS_ID,ANALYSIS_NAME,STRATUM_1_NAME,STRATUM_2_NAME,STRATUM_3_NAME,STRATUM_4_NAME,STRATUM_5_NAME,ANALYSIS_TYPE) values (1310,CAST('Number of measurement records outside valid measurement period' AS VARCHAR(255)),null,null,null,null,null,CAST('MEASUREMENT' AS VARCHAR(255)));
-insert into @results_schema.heracles_analysis (ANALYSIS_ID,ANALYSIS_NAME,STRATUM_1_NAME,STRATUM_2_NAME,STRATUM_3_NAME,STRATUM_4_NAME,STRATUM_5_NAME,ANALYSIS_TYPE) values (1312,CAST('Number of measurement records with invalid provider_id' AS VARCHAR(255)),null,null,null,null,null,CAST('MEASUREMENT' AS VARCHAR(255)));
-insert into @results_schema.heracles_analysis (ANALYSIS_ID,ANALYSIS_NAME,STRATUM_1_NAME,STRATUM_2_NAME,STRATUM_3_NAME,STRATUM_4_NAME,STRATUM_5_NAME,ANALYSIS_TYPE) values (1313,CAST('Number of measurement records with invalid visit_id' AS VARCHAR(255)),null,null,null,null,null,CAST('MEASUREMENT' AS VARCHAR(255)));
-insert into @results_schema.heracles_analysis (ANALYSIS_ID,ANALYSIS_NAME,STRATUM_1_NAME,STRATUM_2_NAME,STRATUM_3_NAME,STRATUM_4_NAME,STRATUM_5_NAME,ANALYSIS_TYPE) values (1314,CAST('Number of measurement records with no value (numeric, string, or concept)' AS VARCHAR(255)),null,null,null,null,null,CAST('MEASUREMENT' AS VARCHAR(255)));
-insert into @results_schema.heracles_analysis (ANALYSIS_ID,ANALYSIS_NAME,STRATUM_1_NAME,STRATUM_2_NAME,STRATUM_3_NAME,STRATUM_4_NAME,STRATUM_5_NAME,ANALYSIS_TYPE) values (1315,CAST('Distribution of numeric values, by measurement_concept_id and unit_concept_id' AS VARCHAR(255)),null,null,null,null,null,CAST('MEASUREMENT' AS VARCHAR(255)));
-insert into @results_schema.heracles_analysis (ANALYSIS_ID,ANALYSIS_NAME,STRATUM_1_NAME,STRATUM_2_NAME,STRATUM_3_NAME,STRATUM_4_NAME,STRATUM_5_NAME,ANALYSIS_TYPE) values (1316,CAST('Distribution of low range, by measurement_concept_id and unit_concept_id' AS VARCHAR(255)),null,null,null,null,null,CAST('MEASUREMENT' AS VARCHAR(255)));
-insert into @results_schema.heracles_analysis (ANALYSIS_ID,ANALYSIS_NAME,STRATUM_1_NAME,STRATUM_2_NAME,STRATUM_3_NAME,STRATUM_4_NAME,STRATUM_5_NAME,ANALYSIS_TYPE) values (1317,CAST('Distribution of high range, by measurement_concept_id and unit_concept_id' AS VARCHAR(255)),null,null,null,null,null,CAST('MEASUREMENT' AS VARCHAR(255)));
-insert into @results_schema.heracles_analysis (ANALYSIS_ID,ANALYSIS_NAME,STRATUM_1_NAME,STRATUM_2_NAME,STRATUM_3_NAME,STRATUM_4_NAME,STRATUM_5_NAME,ANALYSIS_TYPE) values (1318,CAST('Number of measurement records below/within/above normal range, by measurement_concept_id and unit_concept_id' AS VARCHAR(255)),null,null,null,null,null,CAST('MEASUREMENT' AS VARCHAR(255)));
-insert into @results_schema.heracles_analysis (ANALYSIS_ID,ANALYSIS_NAME,STRATUM_1_NAME,STRATUM_2_NAME,STRATUM_3_NAME,STRATUM_4_NAME,STRATUM_5_NAME,ANALYSIS_TYPE) values (1320,CAST('Number of measurement records  by measurement start month' AS VARCHAR(255)),CAST('calendar month' AS VARCHAR(255)),null,null,null,null,CAST('MEASUREMENT' AS VARCHAR(255)));
-insert into @results_schema.heracles_analysis (ANALYSIS_ID,ANALYSIS_NAME,STRATUM_1_NAME,STRATUM_2_NAME,STRATUM_3_NAME,STRATUM_4_NAME,STRATUM_5_NAME,ANALYSIS_TYPE) values (4000,CAST('Distribution of observation period days by period_id  in the 365 days prior to first cohort_start_date' AS VARCHAR(255)),CAST('period_id' AS VARCHAR(255)),null,null,null,null,CAST('HEALTH_UTILIZATION' AS VARCHAR(255)));
-insert into @results_schema.heracles_analysis (ANALYSIS_ID,ANALYSIS_NAME,STRATUM_1_NAME,STRATUM_2_NAME,STRATUM_3_NAME,STRATUM_4_NAME,STRATUM_5_NAME,ANALYSIS_TYPE) values (4001,CAST('Number of subjects with visits by period_id, by visit_concept_id, by visit_type_concept_id in the 365d prior to first cohort start date' AS VARCHAR(255)),CAST('period_id' AS VARCHAR(255)),CAST('visit_concept_id' AS VARCHAR(255)),CAST('visit_type_concept_id' AS VARCHAR(255)),null,null,CAST('HEALTH_UTILIZATION' AS VARCHAR(255)));
-insert into @results_schema.heracles_analysis (ANALYSIS_ID,ANALYSIS_NAME,STRATUM_1_NAME,STRATUM_2_NAME,STRATUM_3_NAME,STRATUM_4_NAME,STRATUM_5_NAME,ANALYSIS_TYPE) values (4002,CAST('Distribution of number of visit occurrence records per subject, by period_id, by visit_concept_id, by visit_type_concept_id in 365d prior to first cohort start date' AS VARCHAR(255)),CAST('period_id' AS VARCHAR(255)),CAST('visit_concept_id' AS VARCHAR(255)),CAST('visit_type_concept_id' AS VARCHAR(255)),null,null,CAST('HEALTH_UTILIZATION' AS VARCHAR(255)));
-insert into @results_schema.heracles_analysis (ANALYSIS_ID,ANALYSIS_NAME,STRATUM_1_NAME,STRATUM_2_NAME,STRATUM_3_NAME,STRATUM_4_NAME,STRATUM_5_NAME,ANALYSIS_TYPE) values (4003,CAST('Distribution of number of visit dates per subject by period_id, by visit_concept_id, by visit_type_concept_id in 365d prior to first cohort start date' AS VARCHAR(255)),CAST('period_id' AS VARCHAR(255)),CAST('visit_concept_id' AS VARCHAR(255)),CAST('visit_type_concept_id' AS VARCHAR(255)),null,null,CAST('HEALTH_UTILIZATION' AS VARCHAR(255)));
-insert into @results_schema.heracles_analysis (ANALYSIS_ID,ANALYSIS_NAME,STRATUM_1_NAME,STRATUM_2_NAME,STRATUM_3_NAME,STRATUM_4_NAME,STRATUM_5_NAME,ANALYSIS_TYPE) values (4004,CAST('Distribution of number of care_site+visit dates per subject by period_id, by visit_concept_id, by visit_type_concept_id in 365d prior to first cohort start date' AS VARCHAR(255)),CAST('period_id' AS VARCHAR(255)),CAST('visit_concept_id' AS VARCHAR(255)),CAST('visit_type_concept_id' AS VARCHAR(255)),null,null,CAST('HEALTH_UTILIZATION' AS VARCHAR(255)));
-insert into @results_schema.heracles_analysis (ANALYSIS_ID,ANALYSIS_NAME,STRATUM_1_NAME,STRATUM_2_NAME,STRATUM_3_NAME,STRATUM_4_NAME,STRATUM_5_NAME,ANALYSIS_TYPE) values (4006,CAST('Distribution of observation period days per subject, by period_id during cohort period' AS VARCHAR(255)),CAST('period id' AS VARCHAR(255)),null,null,null,null,CAST('COHORT_SPECIFIC_ANALYSES' AS VARCHAR(255)));
-insert into @results_schema.heracles_analysis (ANALYSIS_ID,ANALYSIS_NAME,STRATUM_1_NAME,STRATUM_2_NAME,STRATUM_3_NAME,STRATUM_4_NAME,STRATUM_5_NAME,ANALYSIS_TYPE) values (4007,CAST('Number of subjects with visits by period_id, by visit_concept_id, by visit_type_concept_id during the cohort period' AS VARCHAR(255)),CAST('period_id' AS VARCHAR(255)),CAST('visit_concept_id' AS VARCHAR(255)),CAST('visit_type_concept_id' AS VARCHAR(255)),null,null,CAST('HEALTH_UTILIZATION' AS VARCHAR(255)));
-insert into @results_schema.heracles_analysis (ANALYSIS_ID,ANALYSIS_NAME,STRATUM_1_NAME,STRATUM_2_NAME,STRATUM_3_NAME,STRATUM_4_NAME,STRATUM_5_NAME,ANALYSIS_TYPE) values (4008,CAST('Distribution of number of visit occurrence records per subject, by period_id, by visit_concept_id, by visit_type_concept_id during the cohort period' AS VARCHAR(255)),CAST('period_id' AS VARCHAR(255)),CAST('visit_concept_id' AS VARCHAR(255)),CAST('visit_type_concept_id' AS VARCHAR(255)),null,null,CAST('HEALTH_UTILIZATION' AS VARCHAR(255)));
-insert into @results_schema.heracles_analysis (ANALYSIS_ID,ANALYSIS_NAME,STRATUM_1_NAME,STRATUM_2_NAME,STRATUM_3_NAME,STRATUM_4_NAME,STRATUM_5_NAME,ANALYSIS_TYPE) values (4009,CAST('Distribution of number of visit dates per subject by period_id, by visit_concept_id, by visit_type_concept_id during the cohort period' AS VARCHAR(255)),CAST('period_id' AS VARCHAR(255)),CAST('visit_concept_id' AS VARCHAR(255)),CAST('visit_type_concept_id' AS VARCHAR(255)),null,null,CAST('HEALTH_UTILIZATION' AS VARCHAR(255)));
-insert into @results_schema.heracles_analysis (ANALYSIS_ID,ANALYSIS_NAME,STRATUM_1_NAME,STRATUM_2_NAME,STRATUM_3_NAME,STRATUM_4_NAME,STRATUM_5_NAME,ANALYSIS_TYPE) values (4010,CAST('Distribution of number of care_site+visit dates per subject by period_id, by visit_concept_id, by visit_type_concept_id during the cohort period' AS VARCHAR(255)),CAST('period_id' AS VARCHAR(255)),CAST('visit_concept_id' AS VARCHAR(255)),CAST('visit_type_concept_id' AS VARCHAR(255)),null,null,CAST('HEALTH_UTILIZATION' AS VARCHAR(255)));
+insert into @results_schema.heracles_analysis
+select    0 as analysis_id,
+CAST('Source name' as VARCHAR(255)) as analysis_name,
+NULL as stratum_1_name,
+NULL as stratum_2_name,
+NULL as stratum_3_name,
+NULL as stratum_4_name,
+NULL as stratum_5_name,
+CAST('PERSON' as VARCHAR(255)) as analysis_type
+union all
+select    1 as analysis_id,
+CAST('Number of persons' as VARCHAR(255)) as analysis_name,
+NULL as stratum_1_name,
+NULL as stratum_2_name,
+NULL as stratum_3_name,
+NULL as stratum_4_name,
+NULL as stratum_5_name,
+CAST('PERSON' as VARCHAR(255)) as analysis_type
+union all
+select    2 as analysis_id,
+CAST('Number of persons by gender' as VARCHAR(255)) as analysis_name,
+CAST('gender_concept_id' as VARCHAR(255)) as stratum_1_name,
+NULL as stratum_2_name,
+NULL as stratum_3_name,
+NULL as stratum_4_name,
+NULL as stratum_5_name,
+CAST('PERSON' as VARCHAR(255)) as analysis_type
+union all
+select    3 as analysis_id,
+CAST('Number of persons by year of birth' as VARCHAR(255)) as analysis_name,
+CAST('year_of_birth' as VARCHAR(255)) as stratum_1_name,
+NULL as stratum_2_name,
+NULL as stratum_3_name,
+NULL as stratum_4_name,
+NULL as stratum_5_name,
+CAST('PERSON' as VARCHAR(255)) as analysis_type
+union all
+select    4 as analysis_id,
+CAST('Number of persons by race' as VARCHAR(255)) as analysis_name,
+CAST('race_concept_id' as VARCHAR(255)) as stratum_1_name,
+NULL as stratum_2_name,
+NULL as stratum_3_name,
+NULL as stratum_4_name,
+NULL as stratum_5_name,
+CAST('PERSON' as VARCHAR(255)) as analysis_type
+union all
+select    5 as analysis_id,
+CAST('Number of persons by ethnicity' as VARCHAR(255)) as analysis_name,
+CAST('ethnicity_concept_id' as VARCHAR(255)) as stratum_1_name,
+NULL as stratum_2_name,
+NULL as stratum_3_name,
+NULL as stratum_4_name,
+NULL as stratum_5_name,
+CAST('PERSON' as VARCHAR(255)) as analysis_type
+union all
+select    7 as analysis_id,
+CAST('Number of persons with invalid provider_id' as VARCHAR(255)) as analysis_name,
+NULL as stratum_1_name,
+NULL as stratum_2_name,
+NULL as stratum_3_name,
+NULL as stratum_4_name,
+NULL as stratum_5_name,
+CAST('PERSON' as VARCHAR(255)) as analysis_type
+union all
+select    8 as analysis_id,
+CAST('Number of persons with invalid location_id' as VARCHAR(255)) as analysis_name,
+NULL as stratum_1_name,
+NULL as stratum_2_name,
+NULL as stratum_3_name,
+NULL as stratum_4_name,
+NULL as stratum_5_name,
+CAST('PERSON' as VARCHAR(255)) as analysis_type
+union all
+select    9 as analysis_id,
+CAST('Number of persons with invalid care_site_id' as VARCHAR(255)) as analysis_name,
+NULL as stratum_1_name,
+NULL as stratum_2_name,
+NULL as stratum_3_name,
+NULL as stratum_4_name,
+NULL as stratum_5_name,
+CAST('PERSON' as VARCHAR(255)) as analysis_type
+union all
+select  101 as analysis_id,
+CAST('Number of persons by age, with age at first observation period' as VARCHAR(255)) as analysis_name,
+CAST('age' as VARCHAR(255)) as stratum_1_name,
+NULL as stratum_2_name,
+NULL as stratum_3_name,
+NULL as stratum_4_name,
+NULL as stratum_5_name,
+CAST('OBSERVATION' as VARCHAR(255)) as analysis_type
+union all
+select  102 as analysis_id,
+CAST('Number of persons by gender by age, with age at first observation period' as VARCHAR(255)) as analysis_name,
+CAST('gender_concept_id' as VARCHAR(255)) as stratum_1_name,
+CAST('age' as VARCHAR(255)) as stratum_2_name,
+NULL as stratum_3_name,
+NULL as stratum_4_name,
+NULL as stratum_5_name,
+CAST('OBSERVATION' as VARCHAR(255)) as analysis_type
+union all
+select  103 as analysis_id,
+CAST('Distribution of age at first observation period' as VARCHAR(255)) as analysis_name,
+NULL as stratum_1_name,
+NULL as stratum_2_name,
+NULL as stratum_3_name,
+NULL as stratum_4_name,
+NULL as stratum_5_name,
+CAST('OBSERVATION' as VARCHAR(255)) as analysis_type
+union all
+select  104 as analysis_id,
+CAST('Distribution of age at first observation period by gender' as VARCHAR(255)) as analysis_name,
+CAST('gender_concept_id' as VARCHAR(255)) as stratum_1_name,
+NULL as stratum_2_name,
+NULL as stratum_3_name,
+NULL as stratum_4_name,
+NULL as stratum_5_name,
+CAST('OBSERVATION' as VARCHAR(255)) as analysis_type
+union all
+select  105 as analysis_id,
+CAST('Length of observation (days) of first observation period' as VARCHAR(255)) as analysis_name,
+NULL as stratum_1_name,
+NULL as stratum_2_name,
+NULL as stratum_3_name,
+NULL as stratum_4_name,
+NULL as stratum_5_name,
+CAST('OBSERVATION' as VARCHAR(255)) as analysis_type
+union all
+select  106 as analysis_id,
+CAST('Length of observation (days) of first observation period by gender' as VARCHAR(255)) as analysis_name,
+CAST('gender_concept_id' as VARCHAR(255)) as stratum_1_name,
+NULL as stratum_2_name,
+NULL as stratum_3_name,
+NULL as stratum_4_name,
+NULL as stratum_5_name,
+CAST('OBSERVATION' as VARCHAR(255)) as analysis_type
+union all
+select  107 as analysis_id,
+CAST('Length of observation (days) of first observation period by age decile' as VARCHAR(255)) as analysis_name,
+CAST('age decile' as VARCHAR(255)) as stratum_1_name,
+NULL as stratum_2_name,
+NULL as stratum_3_name,
+NULL as stratum_4_name,
+NULL as stratum_5_name,
+CAST('OBSERVATION' as VARCHAR(255)) as analysis_type
+union all
+select  108 as analysis_id,
+CAST('Number of persons by length of observation period, in 30d increments' as VARCHAR(255)) as analysis_name,
+CAST('Observation period length 30d increments' as VARCHAR(255)) as stratum_1_name,
+NULL as stratum_2_name,
+NULL as stratum_3_name,
+NULL as stratum_4_name,
+NULL as stratum_5_name,
+CAST('OBSERVATION' as VARCHAR(255)) as analysis_type
+union all
+select  109 as analysis_id,
+CAST('Number of persons with continuous observation in each year' as VARCHAR(255)) as analysis_name,
+CAST('calendar year' as VARCHAR(255)) as stratum_1_name,
+NULL as stratum_2_name,
+NULL as stratum_3_name,
+NULL as stratum_4_name,
+NULL as stratum_5_name,
+CAST('OBSERVATION' as VARCHAR(255)) as analysis_type
+union all
+select  110 as analysis_id,
+CAST('Number of persons with continuous observation in each month' as VARCHAR(255)) as analysis_name,
+CAST('calendar month' as VARCHAR(255)) as stratum_1_name,
+NULL as stratum_2_name,
+NULL as stratum_3_name,
+NULL as stratum_4_name,
+NULL as stratum_5_name,
+CAST('OBSERVATION' as VARCHAR(255)) as analysis_type
+union all
+select  111 as analysis_id,
+CAST('Number of persons by observation period start month' as VARCHAR(255)) as analysis_name,
+CAST('calendar month' as VARCHAR(255)) as stratum_1_name,
+NULL as stratum_2_name,
+NULL as stratum_3_name,
+NULL as stratum_4_name,
+NULL as stratum_5_name,
+CAST('OBSERVATION' as VARCHAR(255)) as analysis_type
+union all
+select  112 as analysis_id,
+CAST('Number of persons by observation period end month' as VARCHAR(255)) as analysis_name,
+CAST('calendar month' as VARCHAR(255)) as stratum_1_name,
+NULL as stratum_2_name,
+NULL as stratum_3_name,
+NULL as stratum_4_name,
+NULL as stratum_5_name,
+CAST('OBSERVATION' as VARCHAR(255)) as analysis_type
+union all
+select  113 as analysis_id,
+CAST('Number of persons by number of observation periods' as VARCHAR(255)) as analysis_name,
+CAST('number of observation periods' as VARCHAR(255)) as stratum_1_name,
+NULL as stratum_2_name,
+NULL as stratum_3_name,
+NULL as stratum_4_name,
+NULL as stratum_5_name,
+CAST('OBSERVATION' as VARCHAR(255)) as analysis_type
+union all
+select  114 as analysis_id,
+CAST('Number of persons with observation period before year-of-birth' as VARCHAR(255)) as analysis_name,
+NULL as stratum_1_name,
+NULL as stratum_2_name,
+NULL as stratum_3_name,
+NULL as stratum_4_name,
+NULL as stratum_5_name,
+CAST('OBSERVATION' as VARCHAR(255)) as analysis_type
+union all
+select  115 as analysis_id,
+CAST('Number of persons with observation period end < observation period start' as VARCHAR(255)) as analysis_name,
+NULL as stratum_1_name,
+NULL as stratum_2_name,
+NULL as stratum_3_name,
+NULL as stratum_4_name,
+NULL as stratum_5_name,
+CAST('OBSERVATION' as VARCHAR(255)) as analysis_type
+union all
+select  116 as analysis_id,
+CAST('Number of persons with at least one day of observation in each year by gender and age decile' as VARCHAR(255)) as analysis_name,
+CAST('calendar year' as VARCHAR(255)) as stratum_1_name,
+CAST('gender_concept_id' as VARCHAR(255)) as stratum_2_name,
+CAST('age decile' as VARCHAR(255)) as stratum_3_name,
+NULL as stratum_4_name,
+NULL as stratum_5_name,
+CAST('OBSERVATION' as VARCHAR(255)) as analysis_type
+union all
+select  117 as analysis_id,
+CAST('Number of persons with at least one day of observation in each month' as VARCHAR(255)) as analysis_name,
+CAST('calendar month' as VARCHAR(255)) as stratum_1_name,
+NULL as stratum_2_name,
+NULL as stratum_3_name,
+NULL as stratum_4_name,
+NULL as stratum_5_name,
+CAST('OBSERVATION' as VARCHAR(255)) as analysis_type
+union all
+select  200 as analysis_id,
+CAST('Number of persons with at least one visit occurrence, by visit_concept_id' as VARCHAR(255)) as analysis_name,
+CAST('visit_concept_id' as VARCHAR(255)) as stratum_1_name,
+NULL as stratum_2_name,
+NULL as stratum_3_name,
+NULL as stratum_4_name,
+NULL as stratum_5_name,
+CAST('VISITS' as VARCHAR(255)) as analysis_type
+union all
+select  201 as analysis_id,
+CAST('Number of visit occurrence records, by visit_concept_id' as VARCHAR(255)) as analysis_name,
+CAST('visit_concept_id' as VARCHAR(255)) as stratum_1_name,
+NULL as stratum_2_name,
+NULL as stratum_3_name,
+NULL as stratum_4_name,
+NULL as stratum_5_name,
+CAST('VISITS' as VARCHAR(255)) as analysis_type
+union all
+select  202 as analysis_id,
+CAST('Number of persons by visit occurrence start month, by visit_concept_id' as VARCHAR(255)) as analysis_name,
+CAST('visit_concept_id' as VARCHAR(255)) as stratum_1_name,
+CAST('calendar month' as VARCHAR(255)) as stratum_2_name,
+NULL as stratum_3_name,
+NULL as stratum_4_name,
+NULL as stratum_5_name,
+CAST('VISITS' as VARCHAR(255)) as analysis_type
+union all
+select  203 as analysis_id,
+CAST('Number of distinct visit occurrence concepts per person' as VARCHAR(255)) as analysis_name,
+NULL as stratum_1_name,
+NULL as stratum_2_name,
+NULL as stratum_3_name,
+NULL as stratum_4_name,
+NULL as stratum_5_name,
+CAST('VISITS' as VARCHAR(255)) as analysis_type
+union all
+select  204 as analysis_id,
+CAST('Number of persons with at least one visit occurrence, by visit_concept_id by calendar year by gender by age decile' as VARCHAR(255)) as analysis_name,
+CAST('visit_concept_id' as VARCHAR(255)) as stratum_1_name,
+CAST('calendar year' as VARCHAR(255)) as stratum_2_name,
+CAST('gender_concept_id' as VARCHAR(255)) as stratum_3_name,
+CAST('age decile' as VARCHAR(255)) as stratum_4_name,
+NULL as stratum_5_name,
+CAST('VISITS' as VARCHAR(255)) as analysis_type
+union all
+select  206 as analysis_id,
+CAST('Distribution of age by visit_concept_id' as VARCHAR(255)) as analysis_name,
+CAST('visit_concept_id' as VARCHAR(255)) as stratum_1_name,
+CAST('gender_concept_id' as VARCHAR(255)) as stratum_2_name,
+NULL as stratum_3_name,
+NULL as stratum_4_name,
+NULL as stratum_5_name,
+CAST('VISITS' as VARCHAR(255)) as analysis_type
+union all
+select  207 as analysis_id,
+CAST('Number of visit records with invalid person_id' as VARCHAR(255)) as analysis_name,
+NULL as stratum_1_name,
+NULL as stratum_2_name,
+NULL as stratum_3_name,
+NULL as stratum_4_name,
+NULL as stratum_5_name,
+CAST('VISITS' as VARCHAR(255)) as analysis_type
+union all
+select  208 as analysis_id,
+CAST('Number of visit records outside valid observation period' as VARCHAR(255)) as analysis_name,
+NULL as stratum_1_name,
+NULL as stratum_2_name,
+NULL as stratum_3_name,
+NULL as stratum_4_name,
+NULL as stratum_5_name,
+CAST('VISITS' as VARCHAR(255)) as analysis_type
+union all
+select  209 as analysis_id,
+CAST('Number of visit records with end date < start date' as VARCHAR(255)) as analysis_name,
+NULL as stratum_1_name,
+NULL as stratum_2_name,
+NULL as stratum_3_name,
+NULL as stratum_4_name,
+NULL as stratum_5_name,
+CAST('VISITS' as VARCHAR(255)) as analysis_type
+union all
+select  210 as analysis_id,
+CAST('Number of visit records with invalid care_site_id' as VARCHAR(255)) as analysis_name,
+NULL as stratum_1_name,
+NULL as stratum_2_name,
+NULL as stratum_3_name,
+NULL as stratum_4_name,
+NULL as stratum_5_name,
+CAST('VISITS' as VARCHAR(255)) as analysis_type
+union all
+select  211 as analysis_id,
+CAST('Distribution of length of stay by visit_concept_id' as VARCHAR(255)) as analysis_name,
+CAST('visit_concept_id' as VARCHAR(255)) as stratum_1_name,
+NULL as stratum_2_name,
+NULL as stratum_3_name,
+NULL as stratum_4_name,
+NULL as stratum_5_name,
+CAST('VISITS' as VARCHAR(255)) as analysis_type
+union all
+select  220 as analysis_id,
+CAST('Number of visit occurrence records by visit occurrence start month' as VARCHAR(255)) as analysis_name,
+CAST('calendar month' as VARCHAR(255)) as stratum_1_name,
+NULL as stratum_2_name,
+NULL as stratum_3_name,
+NULL as stratum_4_name,
+NULL as stratum_5_name,
+CAST('VISITS' as VARCHAR(255)) as analysis_type
+union all
+select  400 as analysis_id,
+CAST('Number of persons with at least one condition occurrence, by condition_concept_id' as VARCHAR(255)) as analysis_name,
+CAST('condition_concept_id' as VARCHAR(255)) as stratum_1_name,
+NULL as stratum_2_name,
+NULL as stratum_3_name,
+NULL as stratum_4_name,
+NULL as stratum_5_name,
+CAST('CONDITION' as VARCHAR(255)) as analysis_type
+union all
+select  401 as analysis_id,
+CAST('Number of condition occurrence records, by condition_concept_id' as VARCHAR(255)) as analysis_name,
+CAST('condition_concept_id' as VARCHAR(255)) as stratum_1_name,
+NULL as stratum_2_name,
+NULL as stratum_3_name,
+NULL as stratum_4_name,
+NULL as stratum_5_name,
+CAST('CONDITION' as VARCHAR(255)) as analysis_type
+union all
+select  402 as analysis_id,
+CAST('Number of persons by condition occurrence start month, by condition_concept_id' as VARCHAR(255)) as analysis_name,
+CAST('condition_concept_id' as VARCHAR(255)) as stratum_1_name,
+CAST('calendar month' as VARCHAR(255)) as stratum_2_name,
+NULL as stratum_3_name,
+NULL as stratum_4_name,
+NULL as stratum_5_name,
+CAST('CONDITION' as VARCHAR(255)) as analysis_type
+union all
+select  403 as analysis_id,
+CAST('Number of distinct condition occurrence concepts per person' as VARCHAR(255)) as analysis_name,
+NULL as stratum_1_name,
+NULL as stratum_2_name,
+NULL as stratum_3_name,
+NULL as stratum_4_name,
+NULL as stratum_5_name,
+CAST('CONDITION' as VARCHAR(255)) as analysis_type
+union all
+select  404 as analysis_id,
+CAST('Number of persons with at least one condition occurrence, by condition_concept_id by calendar year by gender by age decile' as VARCHAR(255)) as analysis_name,
+CAST('condition_concept_id' as VARCHAR(255)) as stratum_1_name,
+CAST('calendar year' as VARCHAR(255)) as stratum_2_name,
+CAST('gender_concept_id' as VARCHAR(255)) as stratum_3_name,
+CAST('age decile' as VARCHAR(255)) as stratum_4_name,
+NULL as stratum_5_name,
+CAST('CONDITION' as VARCHAR(255)) as analysis_type
+union all
+select  405 as analysis_id,
+CAST('Number of condition occurrence records, by condition_concept_id by condition_type_concept_id' as VARCHAR(255)) as analysis_name,
+CAST('condition_concept_id' as VARCHAR(255)) as stratum_1_name,
+CAST('condition_type_concept_id' as VARCHAR(255)) as stratum_2_name,
+NULL as stratum_3_name,
+NULL as stratum_4_name,
+NULL as stratum_5_name,
+CAST('CONDITION' as VARCHAR(255)) as analysis_type
+union all
+select  406 as analysis_id,
+CAST('Distribution of age by condition_concept_id' as VARCHAR(255)) as analysis_name,
+CAST('condition_concept_id' as VARCHAR(255)) as stratum_1_name,
+CAST('gender_concept_id' as VARCHAR(255)) as stratum_2_name,
+NULL as stratum_3_name,
+NULL as stratum_4_name,
+NULL as stratum_5_name,
+CAST('CONDITION' as VARCHAR(255)) as analysis_type
+union all
+select  409 as analysis_id,
+CAST('Number of condition occurrence records with invalid person_id' as VARCHAR(255)) as analysis_name,
+NULL as stratum_1_name,
+NULL as stratum_2_name,
+NULL as stratum_3_name,
+NULL as stratum_4_name,
+NULL as stratum_5_name,
+CAST('CONDITION' as VARCHAR(255)) as analysis_type
+union all
+select  410 as analysis_id,
+CAST('Number of condition occurrence records outside valid observation period' as VARCHAR(255)) as analysis_name,
+NULL as stratum_1_name,
+NULL as stratum_2_name,
+NULL as stratum_3_name,
+NULL as stratum_4_name,
+NULL as stratum_5_name,
+CAST('CONDITION' as VARCHAR(255)) as analysis_type
+union all
+select  411 as analysis_id,
+CAST('Number of condition occurrence records with end date < start date' as VARCHAR(255)) as analysis_name,
+NULL as stratum_1_name,
+NULL as stratum_2_name,
+NULL as stratum_3_name,
+NULL as stratum_4_name,
+NULL as stratum_5_name,
+CAST('CONDITION' as VARCHAR(255)) as analysis_type
+union all
+select  412 as analysis_id,
+CAST('Number of condition occurrence records with invalid provider_id' as VARCHAR(255)) as analysis_name,
+NULL as stratum_1_name,
+NULL as stratum_2_name,
+NULL as stratum_3_name,
+NULL as stratum_4_name,
+NULL as stratum_5_name,
+CAST('CONDITION' as VARCHAR(255)) as analysis_type
+union all
+select  413 as analysis_id,
+CAST('Number of condition occurrence records with invalid visit_id' as VARCHAR(255)) as analysis_name,
+NULL as stratum_1_name,
+NULL as stratum_2_name,
+NULL as stratum_3_name,
+NULL as stratum_4_name,
+NULL as stratum_5_name,
+CAST('CONDITION' as VARCHAR(255)) as analysis_type
+union all
+select  420 as analysis_id,
+CAST('Number of condition occurrence records by condition occurrence start month' as VARCHAR(255)) as analysis_name,
+CAST('calendar month' as VARCHAR(255)) as stratum_1_name,
+NULL as stratum_2_name,
+NULL as stratum_3_name,
+NULL as stratum_4_name,
+NULL as stratum_5_name,
+CAST('CONDITION' as VARCHAR(255)) as analysis_type
+union all
+select  500 as analysis_id,
+CAST('Number of persons with death, by cause_of_death_concept_id' as VARCHAR(255)) as analysis_name,
+CAST('cause_of_death_concept_id' as VARCHAR(255)) as stratum_1_name,
+NULL as stratum_2_name,
+NULL as stratum_3_name,
+NULL as stratum_4_name,
+NULL as stratum_5_name,
+CAST('DEATH' as VARCHAR(255)) as analysis_type
+union all
+select  501 as analysis_id,
+CAST('Number of records of death, by cause_of_death_concept_id' as VARCHAR(255)) as analysis_name,
+CAST('cause_of_death_concept_id' as VARCHAR(255)) as stratum_1_name,
+NULL as stratum_2_name,
+NULL as stratum_3_name,
+NULL as stratum_4_name,
+NULL as stratum_5_name,
+CAST('DEATH' as VARCHAR(255)) as analysis_type
+union all
+select  502 as analysis_id,
+CAST('Number of persons by death month' as VARCHAR(255)) as analysis_name,
+CAST('calendar month' as VARCHAR(255)) as stratum_1_name,
+NULL as stratum_2_name,
+NULL as stratum_3_name,
+NULL as stratum_4_name,
+NULL as stratum_5_name,
+CAST('DEATH' as VARCHAR(255)) as analysis_type
+union all
+select  504 as analysis_id,
+CAST('Number of persons with a death, by calendar year by gender by age decile' as VARCHAR(255)) as analysis_name,
+CAST('calendar year' as VARCHAR(255)) as stratum_1_name,
+CAST('gender_concept_id' as VARCHAR(255)) as stratum_2_name,
+CAST('age decile' as VARCHAR(255)) as stratum_3_name,
+NULL as stratum_4_name,
+NULL as stratum_5_name,
+CAST('DEATH' as VARCHAR(255)) as analysis_type
+union all
+select  505 as analysis_id,
+CAST('Number of death records, by death_type_concept_id' as VARCHAR(255)) as analysis_name,
+CAST('death_type_concept_id' as VARCHAR(255)) as stratum_1_name,
+NULL as stratum_2_name,
+NULL as stratum_3_name,
+NULL as stratum_4_name,
+NULL as stratum_5_name,
+CAST('DEATH' as VARCHAR(255)) as analysis_type
+union all
+select  506 as analysis_id,
+CAST('Distribution of age at death by gender' as VARCHAR(255)) as analysis_name,
+CAST('gender_concept_id' as VARCHAR(255)) as stratum_1_name,
+NULL as stratum_2_name,
+NULL as stratum_3_name,
+NULL as stratum_4_name,
+NULL as stratum_5_name,
+CAST('DEATH' as VARCHAR(255)) as analysis_type
+union all
+select  509 as analysis_id,
+CAST('Number of death records with invalid person_id' as VARCHAR(255)) as analysis_name,
+NULL as stratum_1_name,
+NULL as stratum_2_name,
+NULL as stratum_3_name,
+NULL as stratum_4_name,
+NULL as stratum_5_name,
+CAST('DEATH' as VARCHAR(255)) as analysis_type
+union all
+select  510 as analysis_id,
+CAST('Number of death records outside valid observation period' as VARCHAR(255)) as analysis_name,
+NULL as stratum_1_name,
+NULL as stratum_2_name,
+NULL as stratum_3_name,
+NULL as stratum_4_name,
+NULL as stratum_5_name,
+CAST('DEATH' as VARCHAR(255)) as analysis_type
+union all
+select  511 as analysis_id,
+CAST('Distribution of time from death to last condition' as VARCHAR(255)) as analysis_name,
+NULL as stratum_1_name,
+NULL as stratum_2_name,
+NULL as stratum_3_name,
+NULL as stratum_4_name,
+NULL as stratum_5_name,
+CAST('DEATH' as VARCHAR(255)) as analysis_type
+union all
+select  512 as analysis_id,
+CAST('Distribution of time from death to last drug' as VARCHAR(255)) as analysis_name,
+NULL as stratum_1_name,
+NULL as stratum_2_name,
+NULL as stratum_3_name,
+NULL as stratum_4_name,
+NULL as stratum_5_name,
+CAST('DEATH' as VARCHAR(255)) as analysis_type
+union all
+select  513 as analysis_id,
+CAST('Distribution of time from death to last visit' as VARCHAR(255)) as analysis_name,
+NULL as stratum_1_name,
+NULL as stratum_2_name,
+NULL as stratum_3_name,
+NULL as stratum_4_name,
+NULL as stratum_5_name,
+CAST('DEATH' as VARCHAR(255)) as analysis_type
+union all
+select  514 as analysis_id,
+CAST('Distribution of time from death to last procedure' as VARCHAR(255)) as analysis_name,
+NULL as stratum_1_name,
+NULL as stratum_2_name,
+NULL as stratum_3_name,
+NULL as stratum_4_name,
+NULL as stratum_5_name,
+CAST('DEATH' as VARCHAR(255)) as analysis_type
+union all
+select  515 as analysis_id,
+CAST('Distribution of time from death to last observation' as VARCHAR(255)) as analysis_name,
+NULL as stratum_1_name,
+NULL as stratum_2_name,
+NULL as stratum_3_name,
+NULL as stratum_4_name,
+NULL as stratum_5_name,
+CAST('DEATH' as VARCHAR(255)) as analysis_type
+union all
+select  600 as analysis_id,
+CAST('Number of persons with at least one procedure occurrence, by procedure_concept_id' as VARCHAR(255)) as analysis_name,
+CAST('procedure_concept_id' as VARCHAR(255)) as stratum_1_name,
+NULL as stratum_2_name,
+NULL as stratum_3_name,
+NULL as stratum_4_name,
+NULL as stratum_5_name,
+CAST('PROCEDURE' as VARCHAR(255)) as analysis_type
+union all
+select  601 as analysis_id,
+CAST('Number of procedure occurrence records, by procedure_concept_id' as VARCHAR(255)) as analysis_name,
+CAST('procedure_concept_id' as VARCHAR(255)) as stratum_1_name,
+NULL as stratum_2_name,
+NULL as stratum_3_name,
+NULL as stratum_4_name,
+NULL as stratum_5_name,
+CAST('PROCEDURE' as VARCHAR(255)) as analysis_type
+union all
+select  602 as analysis_id,
+CAST('Number of persons by procedure occurrence start month, by procedure_concept_id' as VARCHAR(255)) as analysis_name,
+CAST('procedure_concept_id' as VARCHAR(255)) as stratum_1_name,
+CAST('calendar month' as VARCHAR(255)) as stratum_2_name,
+NULL as stratum_3_name,
+NULL as stratum_4_name,
+NULL as stratum_5_name,
+CAST('PROCEDURE' as VARCHAR(255)) as analysis_type
+union all
+select  603 as analysis_id,
+CAST('Number of distinct procedure occurrence concepts per person' as VARCHAR(255)) as analysis_name,
+NULL as stratum_1_name,
+NULL as stratum_2_name,
+NULL as stratum_3_name,
+NULL as stratum_4_name,
+NULL as stratum_5_name,
+CAST('PROCEDURE' as VARCHAR(255)) as analysis_type
+union all
+select  604 as analysis_id,
+CAST('Number of persons with at least one procedure occurrence, by procedure_concept_id by calendar year by gender by age decile' as VARCHAR(255)) as analysis_name,
+CAST('procedure_concept_id' as VARCHAR(255)) as stratum_1_name,
+CAST('calendar year' as VARCHAR(255)) as stratum_2_name,
+CAST('gender_concept_id' as VARCHAR(255)) as stratum_3_name,
+CAST('age decile' as VARCHAR(255)) as stratum_4_name,
+NULL as stratum_5_name,
+CAST('PROCEDURE' as VARCHAR(255)) as analysis_type
+union all
+select  605 as analysis_id,
+CAST('Number of procedure occurrence records, by procedure_concept_id by procedure_type_concept_id' as VARCHAR(255)) as analysis_name,
+CAST('procedure_concept_id' as VARCHAR(255)) as stratum_1_name,
+CAST('procedure_type_concept_id' as VARCHAR(255)) as stratum_2_name,
+NULL as stratum_3_name,
+NULL as stratum_4_name,
+NULL as stratum_5_name,
+CAST('PROCEDURE' as VARCHAR(255)) as analysis_type
+union all
+select  606 as analysis_id,
+CAST('Distribution of age by procedure_concept_id' as VARCHAR(255)) as analysis_name,
+CAST('procedure_concept_id' as VARCHAR(255)) as stratum_1_name,
+CAST('gender_concept_id' as VARCHAR(255)) as stratum_2_name,
+NULL as stratum_3_name,
+NULL as stratum_4_name,
+NULL as stratum_5_name,
+CAST('PROCEDURE' as VARCHAR(255)) as analysis_type
+union all
+select  609 as analysis_id,
+CAST('Number of procedure occurrence records with invalid person_id' as VARCHAR(255)) as analysis_name,
+NULL as stratum_1_name,
+NULL as stratum_2_name,
+NULL as stratum_3_name,
+NULL as stratum_4_name,
+NULL as stratum_5_name,
+CAST('PROCEDURE' as VARCHAR(255)) as analysis_type
+union all
+select  610 as analysis_id,
+CAST('Number of procedure occurrence records outside valid observation period' as VARCHAR(255)) as analysis_name,
+NULL as stratum_1_name,
+NULL as stratum_2_name,
+NULL as stratum_3_name,
+NULL as stratum_4_name,
+NULL as stratum_5_name,
+CAST('PROCEDURE' as VARCHAR(255)) as analysis_type
+union all
+select  612 as analysis_id,
+CAST('Number of procedure occurrence records with invalid provider_id' as VARCHAR(255)) as analysis_name,
+NULL as stratum_1_name,
+NULL as stratum_2_name,
+NULL as stratum_3_name,
+NULL as stratum_4_name,
+NULL as stratum_5_name,
+CAST('PROCEDURE' as VARCHAR(255)) as analysis_type
+union all
+select  613 as analysis_id,
+CAST('Number of procedure occurrence records with invalid visit_id' as VARCHAR(255)) as analysis_name,
+NULL as stratum_1_name,
+NULL as stratum_2_name,
+NULL as stratum_3_name,
+NULL as stratum_4_name,
+NULL as stratum_5_name,
+CAST('PROCEDURE' as VARCHAR(255)) as analysis_type
+union all
+select  620 as analysis_id,
+CAST('Number of procedure occurrence records  by procedure occurrence start month' as VARCHAR(255)) as analysis_name,
+CAST('calendar month' as VARCHAR(255)) as stratum_1_name,
+NULL as stratum_2_name,
+NULL as stratum_3_name,
+NULL as stratum_4_name,
+NULL as stratum_5_name,
+CAST('PROCEDURE' as VARCHAR(255)) as analysis_type
+union all
+select  700 as analysis_id,
+CAST('Number of persons with at least one drug exposure, by drug_concept_id' as VARCHAR(255)) as analysis_name,
+CAST('drug_concept_id' as VARCHAR(255)) as stratum_1_name,
+NULL as stratum_2_name,
+NULL as stratum_3_name,
+NULL as stratum_4_name,
+NULL as stratum_5_name,
+CAST('DRUG' as VARCHAR(255)) as analysis_type
+union all
+select  701 as analysis_id,
+CAST('Number of drug exposure records, by drug_concept_id' as VARCHAR(255)) as analysis_name,
+CAST('drug_concept_id' as VARCHAR(255)) as stratum_1_name,
+NULL as stratum_2_name,
+NULL as stratum_3_name,
+NULL as stratum_4_name,
+NULL as stratum_5_name,
+CAST('DRUG' as VARCHAR(255)) as analysis_type
+union all
+select  702 as analysis_id,
+CAST('Number of persons by drug exposure start month, by drug_concept_id' as VARCHAR(255)) as analysis_name,
+CAST('drug_concept_id' as VARCHAR(255)) as stratum_1_name,
+CAST('calendar month' as VARCHAR(255)) as stratum_2_name,
+NULL as stratum_3_name,
+NULL as stratum_4_name,
+NULL as stratum_5_name,
+CAST('DRUG' as VARCHAR(255)) as analysis_type
+union all
+select  703 as analysis_id,
+CAST('Number of distinct drug exposure concepts per person' as VARCHAR(255)) as analysis_name,
+NULL as stratum_1_name,
+NULL as stratum_2_name,
+NULL as stratum_3_name,
+NULL as stratum_4_name,
+NULL as stratum_5_name,
+CAST('DRUG' as VARCHAR(255)) as analysis_type
+union all
+select  704 as analysis_id,
+CAST('Number of persons with at least one drug exposure, by drug_concept_id by calendar year by gender by age decile' as VARCHAR(255)) as analysis_name,
+CAST('drug_concept_id' as VARCHAR(255)) as stratum_1_name,
+CAST('calendar year' as VARCHAR(255)) as stratum_2_name,
+CAST('gender_concept_id' as VARCHAR(255)) as stratum_3_name,
+CAST('age decile' as VARCHAR(255)) as stratum_4_name,
+NULL as stratum_5_name,
+CAST('DRUG' as VARCHAR(255)) as analysis_type
+union all
+select  705 as analysis_id,
+CAST('Number of drug exposure records, by drug_concept_id by drug_type_concept_id' as VARCHAR(255)) as analysis_name,
+CAST('drug_concept_id' as VARCHAR(255)) as stratum_1_name,
+CAST('drug_type_concept_id' as VARCHAR(255)) as stratum_2_name,
+NULL as stratum_3_name,
+NULL as stratum_4_name,
+NULL as stratum_5_name,
+CAST('DRUG' as VARCHAR(255)) as analysis_type
+union all
+select  706 as analysis_id,
+CAST('Distribution of age by drug_concept_id' as VARCHAR(255)) as analysis_name,
+CAST('drug_concept_id' as VARCHAR(255)) as stratum_1_name,
+CAST('gender_concept_id' as VARCHAR(255)) as stratum_2_name,
+NULL as stratum_3_name,
+NULL as stratum_4_name,
+NULL as stratum_5_name,
+CAST('DRUG' as VARCHAR(255)) as analysis_type
+union all
+select  709 as analysis_id,
+CAST('Number of drug exposure records with invalid person_id' as VARCHAR(255)) as analysis_name,
+NULL as stratum_1_name,
+NULL as stratum_2_name,
+NULL as stratum_3_name,
+NULL as stratum_4_name,
+NULL as stratum_5_name,
+CAST('DRUG' as VARCHAR(255)) as analysis_type
+union all
+select  710 as analysis_id,
+CAST('Number of drug exposure records outside valid observation period' as VARCHAR(255)) as analysis_name,
+NULL as stratum_1_name,
+NULL as stratum_2_name,
+NULL as stratum_3_name,
+NULL as stratum_4_name,
+NULL as stratum_5_name,
+CAST('DRUG' as VARCHAR(255)) as analysis_type
+union all
+select  711 as analysis_id,
+CAST('Number of drug exposure records with end date < start date' as VARCHAR(255)) as analysis_name,
+NULL as stratum_1_name,
+NULL as stratum_2_name,
+NULL as stratum_3_name,
+NULL as stratum_4_name,
+NULL as stratum_5_name,
+CAST('DRUG' as VARCHAR(255)) as analysis_type
+union all
+select  712 as analysis_id,
+CAST('Number of drug exposure records with invalid provider_id' as VARCHAR(255)) as analysis_name,
+NULL as stratum_1_name,
+NULL as stratum_2_name,
+NULL as stratum_3_name,
+NULL as stratum_4_name,
+NULL as stratum_5_name,
+CAST('DRUG' as VARCHAR(255)) as analysis_type
+union all
+select  713 as analysis_id,
+CAST('Number of drug exposure records with invalid visit_id' as VARCHAR(255)) as analysis_name,
+NULL as stratum_1_name,
+NULL as stratum_2_name,
+NULL as stratum_3_name,
+NULL as stratum_4_name,
+NULL as stratum_5_name,
+CAST('DRUG' as VARCHAR(255)) as analysis_type
+union all
+select  715 as analysis_id,
+CAST('Distribution of days_supply by drug_concept_id' as VARCHAR(255)) as analysis_name,
+CAST('drug_concept_id' as VARCHAR(255)) as stratum_1_name,
+NULL as stratum_2_name,
+NULL as stratum_3_name,
+NULL as stratum_4_name,
+NULL as stratum_5_name,
+CAST('DRUG' as VARCHAR(255)) as analysis_type
+union all
+select  716 as analysis_id,
+CAST('Distribution of refills by drug_concept_id' as VARCHAR(255)) as analysis_name,
+CAST('drug_concept_id' as VARCHAR(255)) as stratum_1_name,
+NULL as stratum_2_name,
+NULL as stratum_3_name,
+NULL as stratum_4_name,
+NULL as stratum_5_name,
+CAST('DRUG' as VARCHAR(255)) as analysis_type
+union all
+select  717 as analysis_id,
+CAST('Distribution of quantity by drug_concept_id' as VARCHAR(255)) as analysis_name,
+CAST('drug_concept_id' as VARCHAR(255)) as stratum_1_name,
+NULL as stratum_2_name,
+NULL as stratum_3_name,
+NULL as stratum_4_name,
+NULL as stratum_5_name,
+CAST('DRUG' as VARCHAR(255)) as analysis_type
+union all
+select  720 as analysis_id,
+CAST('Number of drug exposure records  by drug exposure start month' as VARCHAR(255)) as analysis_name,
+CAST('calendar month' as VARCHAR(255)) as stratum_1_name,
+NULL as stratum_2_name,
+NULL as stratum_3_name,
+NULL as stratum_4_name,
+NULL as stratum_5_name,
+CAST('DRUG' as VARCHAR(255)) as analysis_type
+union all
+select  800 as analysis_id,
+CAST('Number of persons with at least one observation occurrence, by observation_concept_id' as VARCHAR(255)) as analysis_name,
+CAST('observation_concept_id' as VARCHAR(255)) as stratum_1_name,
+NULL as stratum_2_name,
+NULL as stratum_3_name,
+NULL as stratum_4_name,
+NULL as stratum_5_name,
+CAST('OBSERVATION' as VARCHAR(255)) as analysis_type
+union all
+select  801 as analysis_id,
+CAST('Number of observation occurrence records, by observation_concept_id' as VARCHAR(255)) as analysis_name,
+CAST('observation_concept_id' as VARCHAR(255)) as stratum_1_name,
+NULL as stratum_2_name,
+NULL as stratum_3_name,
+NULL as stratum_4_name,
+NULL as stratum_5_name,
+CAST('OBSERVATION' as VARCHAR(255)) as analysis_type
+union all
+select  802 as analysis_id,
+CAST('Number of persons by observation occurrence start month, by observation_concept_id' as VARCHAR(255)) as analysis_name,
+CAST('observation_concept_id' as VARCHAR(255)) as stratum_1_name,
+CAST('calendar month' as VARCHAR(255)) as stratum_2_name,
+NULL as stratum_3_name,
+NULL as stratum_4_name,
+NULL as stratum_5_name,
+CAST('OBSERVATION' as VARCHAR(255)) as analysis_type
+union all
+select  803 as analysis_id,
+CAST('Number of distinct observation occurrence concepts per person' as VARCHAR(255)) as analysis_name,
+NULL as stratum_1_name,
+NULL as stratum_2_name,
+NULL as stratum_3_name,
+NULL as stratum_4_name,
+NULL as stratum_5_name,
+CAST('OBSERVATION' as VARCHAR(255)) as analysis_type
+union all
+select  804 as analysis_id,
+CAST('Number of persons with at least one observation occurrence, by observation_concept_id by calendar year by gender by age decile' as VARCHAR(255)) as analysis_name,
+CAST('observation_concept_id' as VARCHAR(255)) as stratum_1_name,
+CAST('calendar year' as VARCHAR(255)) as stratum_2_name,
+CAST('gender_concept_id' as VARCHAR(255)) as stratum_3_name,
+CAST('age decile' as VARCHAR(255)) as stratum_4_name,
+NULL as stratum_5_name,
+CAST('OBSERVATION' as VARCHAR(255)) as analysis_type
+union all
+select  805 as analysis_id,
+CAST('Number of observation occurrence records, by observation_concept_id by observation_type_concept_id' as VARCHAR(255)) as analysis_name,
+CAST('observation_concept_id' as VARCHAR(255)) as stratum_1_name,
+CAST('observation_type_concept_id' as VARCHAR(255)) as stratum_2_name,
+NULL as stratum_3_name,
+NULL as stratum_4_name,
+NULL as stratum_5_name,
+CAST('OBSERVATION' as VARCHAR(255)) as analysis_type
+union all
+select  806 as analysis_id,
+CAST('Distribution of age by observation_concept_id' as VARCHAR(255)) as analysis_name,
+CAST('observation_concept_id' as VARCHAR(255)) as stratum_1_name,
+CAST('gender_concept_id' as VARCHAR(255)) as stratum_2_name,
+NULL as stratum_3_name,
+NULL as stratum_4_name,
+NULL as stratum_5_name,
+CAST('OBSERVATION' as VARCHAR(255)) as analysis_type
+union all
+select  807 as analysis_id,
+CAST('Number of observation occurrence records, by observation_concept_id and unit_concept_id' as VARCHAR(255)) as analysis_name,
+CAST('observation_concept_id' as VARCHAR(255)) as stratum_1_name,
+CAST('unit_concept_id' as VARCHAR(255)) as stratum_2_name,
+NULL as stratum_3_name,
+NULL as stratum_4_name,
+NULL as stratum_5_name,
+CAST('OBSERVATION' as VARCHAR(255)) as analysis_type
+union all
+select  809 as analysis_id,
+CAST('Number of observation records with invalid person_id' as VARCHAR(255)) as analysis_name,
+NULL as stratum_1_name,
+NULL as stratum_2_name,
+NULL as stratum_3_name,
+NULL as stratum_4_name,
+NULL as stratum_5_name,
+CAST('OBSERVATION' as VARCHAR(255)) as analysis_type
+union all
+select  810 as analysis_id,
+CAST('Number of observation records outside valid observation period' as VARCHAR(255)) as analysis_name,
+NULL as stratum_1_name,
+NULL as stratum_2_name,
+NULL as stratum_3_name,
+NULL as stratum_4_name,
+NULL as stratum_5_name,
+CAST('OBSERVATION' as VARCHAR(255)) as analysis_type
+union all
+select  812 as analysis_id,
+CAST('Number of observation records with invalid provider_id' as VARCHAR(255)) as analysis_name,
+NULL as stratum_1_name,
+NULL as stratum_2_name,
+NULL as stratum_3_name,
+NULL as stratum_4_name,
+NULL as stratum_5_name,
+CAST('OBSERVATION' as VARCHAR(255)) as analysis_type
+union all
+select  813 as analysis_id,
+CAST('Number of observation records with invalid visit_id' as VARCHAR(255)) as analysis_name,
+NULL as stratum_1_name,
+NULL as stratum_2_name,
+NULL as stratum_3_name,
+NULL as stratum_4_name,
+NULL as stratum_5_name,
+CAST('OBSERVATION' as VARCHAR(255)) as analysis_type
+union all
+select  814 as analysis_id,
+CAST('Number of observation records with no value (numeric, string, or concept)' as VARCHAR(255)) as analysis_name,
+NULL as stratum_1_name,
+NULL as stratum_2_name,
+NULL as stratum_3_name,
+NULL as stratum_4_name,
+NULL as stratum_5_name,
+CAST('OBSERVATION' as VARCHAR(255)) as analysis_type
+union all
+select  815 as analysis_id,
+CAST('Distribution of numeric values, by observation_concept_id and unit_concept_id' as VARCHAR(255)) as analysis_name,
+NULL as stratum_1_name,
+NULL as stratum_2_name,
+NULL as stratum_3_name,
+NULL as stratum_4_name,
+NULL as stratum_5_name,
+CAST('OBSERVATION' as VARCHAR(255)) as analysis_type
+union all
+select  816 as analysis_id,
+CAST('Distribution of low range, by observation_concept_id and unit_concept_id' as VARCHAR(255)) as analysis_name,
+NULL as stratum_1_name,
+NULL as stratum_2_name,
+NULL as stratum_3_name,
+NULL as stratum_4_name,
+NULL as stratum_5_name,
+CAST('OBSERVATION' as VARCHAR(255)) as analysis_type
+union all
+select  817 as analysis_id,
+CAST('Distribution of high range, by observation_concept_id and unit_concept_id' as VARCHAR(255)) as analysis_name,
+NULL as stratum_1_name,
+NULL as stratum_2_name,
+NULL as stratum_3_name,
+NULL as stratum_4_name,
+NULL as stratum_5_name,
+CAST('OBSERVATION' as VARCHAR(255)) as analysis_type
+union all
+select  818 as analysis_id,
+CAST('Number of observation records below/within/above normal range, by observation_concept_id and unit_concept_id' as VARCHAR(255)) as analysis_name,
+NULL as stratum_1_name,
+NULL as stratum_2_name,
+NULL as stratum_3_name,
+NULL as stratum_4_name,
+NULL as stratum_5_name,
+CAST('OBSERVATION' as VARCHAR(255)) as analysis_type
+union all
+select  820 as analysis_id,
+CAST('Number of observation records  by observation start month' as VARCHAR(255)) as analysis_name,
+CAST('calendar month' as VARCHAR(255)) as stratum_1_name,
+NULL as stratum_2_name,
+NULL as stratum_3_name,
+NULL as stratum_4_name,
+NULL as stratum_5_name,
+CAST('OBSERVATION' as VARCHAR(255)) as analysis_type
+union all
+select  900 as analysis_id,
+CAST('Number of persons with at least one drug era, by drug_concept_id' as VARCHAR(255)) as analysis_name,
+CAST('drug_concept_id' as VARCHAR(255)) as stratum_1_name,
+NULL as stratum_2_name,
+NULL as stratum_3_name,
+NULL as stratum_4_name,
+NULL as stratum_5_name,
+CAST('DRUG_ERA' as VARCHAR(255)) as analysis_type
+union all
+select  901 as analysis_id,
+CAST('Number of drug era records, by drug_concept_id' as VARCHAR(255)) as analysis_name,
+CAST('drug_concept_id' as VARCHAR(255)) as stratum_1_name,
+NULL as stratum_2_name,
+NULL as stratum_3_name,
+NULL as stratum_4_name,
+NULL as stratum_5_name,
+CAST('DRUG_ERA' as VARCHAR(255)) as analysis_type
+union all
+select  902 as analysis_id,
+CAST('Number of persons by drug era start month, by drug_concept_id' as VARCHAR(255)) as analysis_name,
+CAST('drug_concept_id' as VARCHAR(255)) as stratum_1_name,
+CAST('calendar month' as VARCHAR(255)) as stratum_2_name,
+NULL as stratum_3_name,
+NULL as stratum_4_name,
+NULL as stratum_5_name,
+CAST('DRUG_ERA' as VARCHAR(255)) as analysis_type
+union all
+select  903 as analysis_id,
+CAST('Number of distinct drug era concepts per person' as VARCHAR(255)) as analysis_name,
+NULL as stratum_1_name,
+NULL as stratum_2_name,
+NULL as stratum_3_name,
+NULL as stratum_4_name,
+NULL as stratum_5_name,
+CAST('DRUG_ERA' as VARCHAR(255)) as analysis_type
+union all
+select  904 as analysis_id,
+CAST('Number of persons with at least one drug era, by drug_concept_id by calendar year by gender by age decile' as VARCHAR(255)) as analysis_name,
+CAST('drug_concept_id' as VARCHAR(255)) as stratum_1_name,
+CAST('calendar year' as VARCHAR(255)) as stratum_2_name,
+CAST('gender_concept_id' as VARCHAR(255)) as stratum_3_name,
+CAST('age decile' as VARCHAR(255)) as stratum_4_name,
+NULL as stratum_5_name,
+CAST('DRUG_ERA' as VARCHAR(255)) as analysis_type
+union all
+select  906 as analysis_id,
+CAST('Distribution of age by drug_concept_id' as VARCHAR(255)) as analysis_name,
+CAST('drug_concept_id' as VARCHAR(255)) as stratum_1_name,
+CAST('gender_concept_id' as VARCHAR(255)) as stratum_2_name,
+NULL as stratum_3_name,
+NULL as stratum_4_name,
+NULL as stratum_5_name,
+CAST('DRUG_ERA' as VARCHAR(255)) as analysis_type
+union all
+select  907 as analysis_id,
+CAST('Distribution of drug era length, by drug_concept_id' as VARCHAR(255)) as analysis_name,
+CAST('drug_concept_id' as VARCHAR(255)) as stratum_1_name,
+NULL as stratum_2_name,
+NULL as stratum_3_name,
+NULL as stratum_4_name,
+NULL as stratum_5_name,
+CAST('DRUG_ERA' as VARCHAR(255)) as analysis_type
+union all
+select  908 as analysis_id,
+CAST('Number of drug eras without valid person' as VARCHAR(255)) as analysis_name,
+NULL as stratum_1_name,
+NULL as stratum_2_name,
+NULL as stratum_3_name,
+NULL as stratum_4_name,
+NULL as stratum_5_name,
+CAST('DRUG_ERA' as VARCHAR(255)) as analysis_type
+union all
+select  909 as analysis_id,
+CAST('Number of drug eras outside valid observation period' as VARCHAR(255)) as analysis_name,
+NULL as stratum_1_name,
+NULL as stratum_2_name,
+NULL as stratum_3_name,
+NULL as stratum_4_name,
+NULL as stratum_5_name,
+CAST('DRUG_ERA' as VARCHAR(255)) as analysis_type
+union all
+select  910 as analysis_id,
+CAST('Number of drug eras with end date < start date' as VARCHAR(255)) as analysis_name,
+NULL as stratum_1_name,
+NULL as stratum_2_name,
+NULL as stratum_3_name,
+NULL as stratum_4_name,
+NULL as stratum_5_name,
+CAST('DRUG_ERA' as VARCHAR(255)) as analysis_type
+union all
+select  920 as analysis_id,
+CAST('Number of drug era records  by drug era start month' as VARCHAR(255)) as analysis_name,
+CAST('calendar month' as VARCHAR(255)) as stratum_1_name,
+NULL as stratum_2_name,
+NULL as stratum_3_name,
+NULL as stratum_4_name,
+NULL as stratum_5_name,
+CAST('DRUG_ERA' as VARCHAR(255)) as analysis_type
+union all
+select 1000 as analysis_id,
+CAST('Number of persons with at least one condition era, by condition_concept_id' as VARCHAR(255)) as analysis_name,
+CAST('condition_concept_id' as VARCHAR(255)) as stratum_1_name,
+NULL as stratum_2_name,
+NULL as stratum_3_name,
+NULL as stratum_4_name,
+NULL as stratum_5_name,
+CAST('CONDITION_ERA' as VARCHAR(255)) as analysis_type
+union all
+select 1001 as analysis_id,
+CAST('Number of condition era records, by condition_concept_id' as VARCHAR(255)) as analysis_name,
+CAST('condition_concept_id' as VARCHAR(255)) as stratum_1_name,
+NULL as stratum_2_name,
+NULL as stratum_3_name,
+NULL as stratum_4_name,
+NULL as stratum_5_name,
+CAST('CONDITION_ERA' as VARCHAR(255)) as analysis_type
+union all
+select 1002 as analysis_id,
+CAST('Number of persons by condition era start month, by condition_concept_id' as VARCHAR(255)) as analysis_name,
+CAST('condition_concept_id' as VARCHAR(255)) as stratum_1_name,
+CAST('calendar month' as VARCHAR(255)) as stratum_2_name,
+NULL as stratum_3_name,
+NULL as stratum_4_name,
+NULL as stratum_5_name,
+CAST('CONDITION_ERA' as VARCHAR(255)) as analysis_type
+union all
+select 1003 as analysis_id,
+CAST('Number of distinct condition era concepts per person' as VARCHAR(255)) as analysis_name,
+NULL as stratum_1_name,
+NULL as stratum_2_name,
+NULL as stratum_3_name,
+NULL as stratum_4_name,
+NULL as stratum_5_name,
+CAST('CONDITION_ERA' as VARCHAR(255)) as analysis_type
+union all
+select 1004 as analysis_id,
+CAST('Number of persons with at least one condition era, by condition_concept_id by calendar year by gender by age decile' as VARCHAR(255)) as analysis_name,
+CAST('condition_concept_id' as VARCHAR(255)) as stratum_1_name,
+CAST('calendar year' as VARCHAR(255)) as stratum_2_name,
+CAST('gender_concept_id' as VARCHAR(255)) as stratum_3_name,
+CAST('age decile' as VARCHAR(255)) as stratum_4_name,
+NULL as stratum_5_name,
+CAST('CONDITION_ERA' as VARCHAR(255)) as analysis_type
+union all
+select 1006 as analysis_id,
+CAST('Distribution of age by condition_concept_id' as VARCHAR(255)) as analysis_name,
+CAST('condition_concept_id' as VARCHAR(255)) as stratum_1_name,
+CAST('gender_concept_id' as VARCHAR(255)) as stratum_2_name,
+NULL as stratum_3_name,
+NULL as stratum_4_name,
+NULL as stratum_5_name,
+CAST('CONDITION_ERA' as VARCHAR(255)) as analysis_type
+union all
+select 1007 as analysis_id,
+CAST('Distribution of condition era length, by condition_concept_id' as VARCHAR(255)) as analysis_name,
+CAST('condition_concept_id' as VARCHAR(255)) as stratum_1_name,
+NULL as stratum_2_name,
+NULL as stratum_3_name,
+NULL as stratum_4_name,
+NULL as stratum_5_name,
+CAST('CONDITION_ERA' as VARCHAR(255)) as analysis_type
+union all
+select 1008 as analysis_id,
+CAST('Number of condition eras without valid person' as VARCHAR(255)) as analysis_name,
+NULL as stratum_1_name,
+NULL as stratum_2_name,
+NULL as stratum_3_name,
+NULL as stratum_4_name,
+NULL as stratum_5_name,
+CAST('CONDITION_ERA' as VARCHAR(255)) as analysis_type
+union all
+select 1009 as analysis_id,
+CAST('Number of condition eras outside valid observation period' as VARCHAR(255)) as analysis_name,
+NULL as stratum_1_name,
+NULL as stratum_2_name,
+NULL as stratum_3_name,
+NULL as stratum_4_name,
+NULL as stratum_5_name,
+CAST('CONDITION_ERA' as VARCHAR(255)) as analysis_type
+union all
+select 1010 as analysis_id,
+CAST('Number of condition eras with end date < start date' as VARCHAR(255)) as analysis_name,
+NULL as stratum_1_name,
+NULL as stratum_2_name,
+NULL as stratum_3_name,
+NULL as stratum_4_name,
+NULL as stratum_5_name,
+CAST('CONDITION_ERA' as VARCHAR(255)) as analysis_type
+union all
+select 1020 as analysis_id,
+CAST('Number of condition era records by condition era start month' as VARCHAR(255)) as analysis_name,
+CAST('calendar month' as VARCHAR(255)) as stratum_1_name,
+NULL as stratum_2_name,
+NULL as stratum_3_name,
+NULL as stratum_4_name,
+NULL as stratum_5_name,
+CAST('CONDITION_ERA' as VARCHAR(255)) as analysis_type
+union all
+select 1100 as analysis_id,
+CAST('Number of persons by location 3-digit zip' as VARCHAR(255)) as analysis_name,
+CAST('3-digit zip' as VARCHAR(255)) as stratum_1_name,
+NULL as stratum_2_name,
+NULL as stratum_3_name,
+NULL as stratum_4_name,
+NULL as stratum_5_name,
+CAST('LOCATION' as VARCHAR(255)) as analysis_type
+union all
+select 1101 as analysis_id,
+CAST('Number of persons by location state' as VARCHAR(255)) as analysis_name,
+CAST('state' as VARCHAR(255)) as stratum_1_name,
+NULL as stratum_2_name,
+NULL as stratum_3_name,
+NULL as stratum_4_name,
+NULL as stratum_5_name,
+CAST('LOCATION' as VARCHAR(255)) as analysis_type
+union all
+select 1200 as analysis_id,
+CAST('Number of persons by place of service' as VARCHAR(255)) as analysis_name,
+CAST('place_of_service_concept_id' as VARCHAR(255)) as stratum_1_name,
+NULL as stratum_2_name,
+NULL as stratum_3_name,
+NULL as stratum_4_name,
+NULL as stratum_5_name,
+CAST('CARE_SITE' as VARCHAR(255)) as analysis_type
+union all
+select 1201 as analysis_id,
+CAST('Number of visits by place of service' as VARCHAR(255)) as analysis_name,
+CAST('place_of_service_concept_id' as VARCHAR(255)) as stratum_1_name,
+NULL as stratum_2_name,
+NULL as stratum_3_name,
+NULL as stratum_4_name,
+NULL as stratum_5_name,
+CAST('CARE_SITE' as VARCHAR(255)) as analysis_type
+union all
+select 1300 as analysis_id,
+CAST('Number of persons with at least one measurement occurrence, by measurement_concept_id' as VARCHAR(255)) as analysis_name,
+CAST('measurement_concept_id' as VARCHAR(255)) as stratum_1_name,
+NULL as stratum_2_name,
+NULL as stratum_3_name,
+NULL as stratum_4_name,
+NULL as stratum_5_name,
+CAST('MEASUREMENT' as VARCHAR(255)) as analysis_type
+union all
+select 1301 as analysis_id,
+CAST('Number of measurement occurrence records, by measurement_concept_id' as VARCHAR(255)) as analysis_name,
+CAST('measurement_concept_id' as VARCHAR(255)) as stratum_1_name,
+NULL as stratum_2_name,
+NULL as stratum_3_name,
+NULL as stratum_4_name,
+NULL as stratum_5_name,
+CAST('MEASUREMENT' as VARCHAR(255)) as analysis_type
+union all
+select 1302 as analysis_id,
+CAST('Number of persons by measurement occurrence start month, by measurement_concept_id' as VARCHAR(255)) as analysis_name,
+CAST('measurement_concept_id' as VARCHAR(255)) as stratum_1_name,
+CAST('calendar month' as VARCHAR(255)) as stratum_2_name,
+NULL as stratum_3_name,
+NULL as stratum_4_name,
+NULL as stratum_5_name,
+CAST('MEASUREMENT' as VARCHAR(255)) as analysis_type
+union all
+select 1303 as analysis_id,
+CAST('Number of distinct measurement occurrence concepts per person' as VARCHAR(255)) as analysis_name,
+NULL as stratum_1_name,
+NULL as stratum_2_name,
+NULL as stratum_3_name,
+NULL as stratum_4_name,
+NULL as stratum_5_name,
+CAST('MEASUREMENT' as VARCHAR(255)) as analysis_type
+union all
+select 1304 as analysis_id,
+CAST('Number of persons with at least one measurement occurrence, by measurement_concept_id by calendar year by gender by age decile' as VARCHAR(255)) as analysis_name,
+CAST('measurement_concept_id' as VARCHAR(255)) as stratum_1_name,
+CAST('calendar year' as VARCHAR(255)) as stratum_2_name,
+CAST('gender_concept_id' as VARCHAR(255)) as stratum_3_name,
+CAST('age decile' as VARCHAR(255)) as stratum_4_name,
+NULL as stratum_5_name,
+CAST('MEASUREMENT' as VARCHAR(255)) as analysis_type
+union all
+select 1305 as analysis_id,
+CAST('Number of measurement occurrence records, by measurement_concept_id by measurement_type_concept_id' as VARCHAR(255)) as analysis_name,
+CAST('measurement_concept_id' as VARCHAR(255)) as stratum_1_name,
+CAST('measurement_type_concept_id' as VARCHAR(255)) as stratum_2_name,
+NULL as stratum_3_name,
+NULL as stratum_4_name,
+NULL as stratum_5_name,
+CAST('MEASUREMENT' as VARCHAR(255)) as analysis_type
+union all
+select 1306 as analysis_id,
+CAST('Distribution of age by measurement_concept_id' as VARCHAR(255)) as analysis_name,
+CAST('measurement_concept_id' as VARCHAR(255)) as stratum_1_name,
+CAST('gender_concept_id' as VARCHAR(255)) as stratum_2_name,
+NULL as stratum_3_name,
+NULL as stratum_4_name,
+NULL as stratum_5_name,
+CAST('MEASUREMENT' as VARCHAR(255)) as analysis_type
+union all
+select 1307 as analysis_id,
+CAST('Number of measurement occurrence records, by measurement_concept_id and unit_concept_id' as VARCHAR(255)) as analysis_name,
+CAST('measurement_concept_id' as VARCHAR(255)) as stratum_1_name,
+CAST('unit_concept_id' as VARCHAR(255)) as stratum_2_name,
+NULL as stratum_3_name,
+NULL as stratum_4_name,
+NULL as stratum_5_name,
+CAST('MEASUREMENT' as VARCHAR(255)) as analysis_type
+union all
+select 1309 as analysis_id,
+CAST('Number of measurement records with invalid person_id' as VARCHAR(255)) as analysis_name,
+NULL as stratum_1_name,
+NULL as stratum_2_name,
+NULL as stratum_3_name,
+NULL as stratum_4_name,
+NULL as stratum_5_name,
+CAST('MEASUREMENT' as VARCHAR(255)) as analysis_type
+union all
+select 1310 as analysis_id,
+CAST('Number of measurement records outside valid measurement period' as VARCHAR(255)) as analysis_name,
+NULL as stratum_1_name,
+NULL as stratum_2_name,
+NULL as stratum_3_name,
+NULL as stratum_4_name,
+NULL as stratum_5_name,
+CAST('MEASUREMENT' as VARCHAR(255)) as analysis_type
+union all
+select 1312 as analysis_id,
+CAST('Number of measurement records with invalid provider_id' as VARCHAR(255)) as analysis_name,
+NULL as stratum_1_name,
+NULL as stratum_2_name,
+NULL as stratum_3_name,
+NULL as stratum_4_name,
+NULL as stratum_5_name,
+CAST('MEASUREMENT' as VARCHAR(255)) as analysis_type
+union all
+select 1313 as analysis_id,
+CAST('Number of measurement records with invalid visit_id' as VARCHAR(255)) as analysis_name,
+NULL as stratum_1_name,
+NULL as stratum_2_name,
+NULL as stratum_3_name,
+NULL as stratum_4_name,
+NULL as stratum_5_name,
+CAST('MEASUREMENT' as VARCHAR(255)) as analysis_type
+union all
+select 1314 as analysis_id,
+CAST('Number of measurement records with no value (numeric, string, or concept)' as VARCHAR(255)) as analysis_name,
+NULL as stratum_1_name,
+NULL as stratum_2_name,
+NULL as stratum_3_name,
+NULL as stratum_4_name,
+NULL as stratum_5_name,
+CAST('MEASUREMENT' as VARCHAR(255)) as analysis_type
+union all
+select 1315 as analysis_id,
+CAST('Distribution of numeric values, by measurement_concept_id and unit_concept_id' as VARCHAR(255)) as analysis_name,
+NULL as stratum_1_name,
+NULL as stratum_2_name,
+NULL as stratum_3_name,
+NULL as stratum_4_name,
+NULL as stratum_5_name,
+CAST('MEASUREMENT' as VARCHAR(255)) as analysis_type
+union all
+select 1316 as analysis_id,
+CAST('Distribution of low range, by measurement_concept_id and unit_concept_id' as VARCHAR(255)) as analysis_name,
+NULL as stratum_1_name,
+NULL as stratum_2_name,
+NULL as stratum_3_name,
+NULL as stratum_4_name,
+NULL as stratum_5_name,
+CAST('MEASUREMENT' as VARCHAR(255)) as analysis_type
+union all
+select 1317 as analysis_id,
+CAST('Distribution of high range, by measurement_concept_id and unit_concept_id' as VARCHAR(255)) as analysis_name,
+NULL as stratum_1_name,
+NULL as stratum_2_name,
+NULL as stratum_3_name,
+NULL as stratum_4_name,
+NULL as stratum_5_name,
+CAST('MEASUREMENT' as VARCHAR(255)) as analysis_type
+union all
+select 1318 as analysis_id,
+CAST('Number of measurement records below/within/above normal range, by measurement_concept_id and unit_concept_id' as VARCHAR(255)) as analysis_name,
+NULL as stratum_1_name,
+NULL as stratum_2_name,
+NULL as stratum_3_name,
+NULL as stratum_4_name,
+NULL as stratum_5_name,
+CAST('MEASUREMENT' as VARCHAR(255)) as analysis_type
+union all
+select 1320 as analysis_id,
+CAST('Number of measurement records  by measurement start month' as VARCHAR(255)) as analysis_name,
+CAST('calendar month' as VARCHAR(255)) as stratum_1_name,
+NULL as stratum_2_name,
+NULL as stratum_3_name,
+NULL as stratum_4_name,
+NULL as stratum_5_name,
+CAST('MEASUREMENT' as VARCHAR(255)) as analysis_type
+union all
+select 1700 as analysis_id,
+CAST('Number of records by cohort_definition_id' as VARCHAR(255)) as analysis_name,
+CAST('cohort_definition_id' as VARCHAR(255)) as stratum_1_name,
+NULL as stratum_2_name,
+NULL as stratum_3_name,
+NULL as stratum_4_name,
+NULL as stratum_5_name,
+CAST('COHORT' as VARCHAR(255)) as analysis_type
+union all
+select 1701 as analysis_id,
+CAST('Number of records with cohort end date < cohort start date' as VARCHAR(255)) as analysis_name,
+NULL as stratum_1_name,
+NULL as stratum_2_name,
+NULL as stratum_3_name,
+NULL as stratum_4_name,
+NULL as stratum_5_name,
+CAST('COHORT' as VARCHAR(255)) as analysis_type
+union all
+select 1800 as analysis_id,
+CAST('Number of persons by age, with age at cohort start' as VARCHAR(255)) as analysis_name,
+CAST('age' as VARCHAR(255)) as stratum_1_name,
+NULL as stratum_2_name,
+NULL as stratum_3_name,
+NULL as stratum_4_name,
+NULL as stratum_5_name,
+CAST('COHORT_SPECIFIC_ANALYSES' as VARCHAR(255)) as analysis_type
+union all
+select 1801 as analysis_id,
+CAST('Distribution of age at cohort start' as VARCHAR(255)) as analysis_name,
+NULL as stratum_1_name,
+NULL as stratum_2_name,
+NULL as stratum_3_name,
+NULL as stratum_4_name,
+NULL as stratum_5_name,
+CAST('COHORT_SPECIFIC_ANALYSES' as VARCHAR(255)) as analysis_type
+union all
+select 1802 as analysis_id,
+CAST('Distribution of age at cohort start by gender' as VARCHAR(255)) as analysis_name,
+CAST('gender_concept_id' as VARCHAR(255)) as stratum_1_name,
+NULL as stratum_2_name,
+NULL as stratum_3_name,
+NULL as stratum_4_name,
+NULL as stratum_5_name,
+CAST('COHORT_SPECIFIC_ANALYSES' as VARCHAR(255)) as analysis_type
+union all
+select 1803 as analysis_id,
+CAST('Distribution of age at cohort start by cohort start year' as VARCHAR(255)) as analysis_name,
+CAST('calendar year' as VARCHAR(255)) as stratum_1_name,
+NULL as stratum_2_name,
+NULL as stratum_3_name,
+NULL as stratum_4_name,
+NULL as stratum_5_name,
+CAST('COHORT_SPECIFIC_ANALYSES' as VARCHAR(255)) as analysis_type
+union all
+select 1804 as analysis_id,
+CAST('Number of persons by duration from cohort start to cohort end, in 30d increments' as VARCHAR(255)) as analysis_name,
+CAST('Cohort period length 30d increments' as VARCHAR(255)) as stratum_1_name,
+NULL as stratum_2_name,
+NULL as stratum_3_name,
+NULL as stratum_4_name,
+NULL as stratum_5_name,
+CAST('COHORT_SPECIFIC_ANALYSES' as VARCHAR(255)) as analysis_type
+union all
+select 1805 as analysis_id,
+CAST('Number of persons by duration from observation start to cohort start, in 30d increments' as VARCHAR(255)) as analysis_name,
+CAST('Baseline period length 30d increments' as VARCHAR(255)) as stratum_1_name,
+NULL as stratum_2_name,
+NULL as stratum_3_name,
+NULL as stratum_4_name,
+NULL as stratum_5_name,
+CAST('COHORT_SPECIFIC_ANALYSES' as VARCHAR(255)) as analysis_type
+union all
+select 1806 as analysis_id,
+CAST('Number of persons by duration from cohort start to observation end, in 30d increments' as VARCHAR(255)) as analysis_name,
+CAST('Follow-up period length 30d increments' as VARCHAR(255)) as stratum_1_name,
+NULL as stratum_2_name,
+NULL as stratum_3_name,
+NULL as stratum_4_name,
+NULL as stratum_5_name,
+CAST('COHORT_SPECIFIC_ANALYSES' as VARCHAR(255)) as analysis_type
+union all
+select 1807 as analysis_id,
+CAST('Number of persons by duration from cohort end to observation end, in 30d increments' as VARCHAR(255)) as analysis_name,
+CAST('Post-cohort period length 30d increments' as VARCHAR(255)) as stratum_1_name,
+NULL as stratum_2_name,
+NULL as stratum_3_name,
+NULL as stratum_4_name,
+NULL as stratum_5_name,
+CAST('COHORT_SPECIFIC_ANALYSES' as VARCHAR(255)) as analysis_type
+union all
+select 1808 as analysis_id,
+CAST('Distribution of duration (days) from cohort start to cohort end' as VARCHAR(255)) as analysis_name,
+NULL as stratum_1_name,
+NULL as stratum_2_name,
+NULL as stratum_3_name,
+NULL as stratum_4_name,
+NULL as stratum_5_name,
+CAST('COHORT_SPECIFIC_ANALYSES' as VARCHAR(255)) as analysis_type
+union all
+select 1809 as analysis_id,
+CAST('Distribution of duration (days) from cohort start to cohort end, by gender' as VARCHAR(255)) as analysis_name,
+CAST('gender_concept_id' as VARCHAR(255)) as stratum_1_name,
+NULL as stratum_2_name,
+NULL as stratum_3_name,
+NULL as stratum_4_name,
+NULL as stratum_5_name,
+CAST('COHORT_SPECIFIC_ANALYSES' as VARCHAR(255)) as analysis_type
+union all
+select 1810 as analysis_id,
+CAST('Distribution of duration (days) from cohort start to cohort end, by age decile' as VARCHAR(255)) as analysis_name,
+CAST('age decile' as VARCHAR(255)) as stratum_1_name,
+NULL as stratum_2_name,
+NULL as stratum_3_name,
+NULL as stratum_4_name,
+NULL as stratum_5_name,
+CAST('COHORT_SPECIFIC_ANALYSES' as VARCHAR(255)) as analysis_type
+union all
+select 1811 as analysis_id,
+CAST('Distribution of duration (days) from observation start to cohort start' as VARCHAR(255)) as analysis_name,
+NULL as stratum_1_name,
+NULL as stratum_2_name,
+NULL as stratum_3_name,
+NULL as stratum_4_name,
+NULL as stratum_5_name,
+CAST('COHORT_SPECIFIC_ANALYSES' as VARCHAR(255)) as analysis_type
+union all
+select 1812 as analysis_id,
+CAST('Distribution of duration (days) from cohort start to observation end' as VARCHAR(255)) as analysis_name,
+NULL as stratum_1_name,
+NULL as stratum_2_name,
+NULL as stratum_3_name,
+NULL as stratum_4_name,
+NULL as stratum_5_name,
+CAST('COHORT_SPECIFIC_ANALYSES' as VARCHAR(255)) as analysis_type
+union all
+select 1813 as analysis_id,
+CAST('Distribution of duration (days) from cohort end to observation end' as VARCHAR(255)) as analysis_name,
+NULL as stratum_1_name,
+NULL as stratum_2_name,
+NULL as stratum_3_name,
+NULL as stratum_4_name,
+NULL as stratum_5_name,
+CAST('COHORT_SPECIFIC_ANALYSES' as VARCHAR(255)) as analysis_type
+union all
+select 1814 as analysis_id,
+CAST('Number of persons by cohort start year by gender by age decile' as VARCHAR(255)) as analysis_name,
+CAST('calendar year' as VARCHAR(255)) as stratum_1_name,
+CAST('gender_concept_id' as VARCHAR(255)) as stratum_2_name,
+CAST('age decile' as VARCHAR(255)) as stratum_3_name,
+NULL as stratum_4_name,
+NULL as stratum_5_name,
+CAST('COHORT_SPECIFIC_ANALYSES' as VARCHAR(255)) as analysis_type
+union all
+select 1815 as analysis_id,
+CAST('Number of persons by cohort start month' as VARCHAR(255)) as analysis_name,
+CAST('calendar month' as VARCHAR(255)) as stratum_1_name,
+NULL as stratum_2_name,
+NULL as stratum_3_name,
+NULL as stratum_4_name,
+NULL as stratum_5_name,
+CAST('COHORT_SPECIFIC_ANALYSES' as VARCHAR(255)) as analysis_type
+union all
+select 1816 as analysis_id,
+CAST('Number of persons by number of cohort periods' as VARCHAR(255)) as analysis_name,
+CAST('number of cohort periods' as VARCHAR(255)) as stratum_1_name,
+NULL as stratum_2_name,
+NULL as stratum_3_name,
+NULL as stratum_4_name,
+NULL as stratum_5_name,
+CAST('COHORT_SPECIFIC_ANALYSES' as VARCHAR(255)) as analysis_type
+union all
+select 1820 as analysis_id,
+CAST('Number of persons by duration from cohort start to first occurrence of condition occurrence, by condition_concept_id' as VARCHAR(255)) as analysis_name,
+CAST('condition_concept_id' as VARCHAR(255)) as stratum_1_name,
+CAST('time-to-event 30d increments' as VARCHAR(255)) as stratum_2_name,
+NULL as stratum_3_name,
+NULL as stratum_4_name,
+NULL as stratum_5_name,
+CAST('COHORT_SPECIFIC_ANALYSES' as VARCHAR(255)) as analysis_type
+union all
+select 1821 as analysis_id,
+CAST('Number of events by duration from cohort start to all occurrences of condition occurrence, by condition_concept_id' as VARCHAR(255)) as analysis_name,
+CAST('condition_concept_id' as VARCHAR(255)) as stratum_1_name,
+CAST('time-to-event 30d increments' as VARCHAR(255)) as stratum_2_name,
+NULL as stratum_3_name,
+NULL as stratum_4_name,
+NULL as stratum_5_name,
+CAST('COHORT_SPECIFIC_ANALYSES' as VARCHAR(255)) as analysis_type
+union all
+select 1830 as analysis_id,
+CAST('Number of persons by duration from cohort start to first occurrence of procedure occurrence, by procedure_concept_id' as VARCHAR(255)) as analysis_name,
+CAST('procedure_concept_id' as VARCHAR(255)) as stratum_1_name,
+CAST('time-to-event 30d increments' as VARCHAR(255)) as stratum_2_name,
+NULL as stratum_3_name,
+NULL as stratum_4_name,
+NULL as stratum_5_name,
+CAST('COHORT_SPECIFIC_ANALYSES' as VARCHAR(255)) as analysis_type
+union all
+select 1831 as analysis_id,
+CAST('Number of events by duration from cohort start to all occurrences of procedure occurrence, by procedure_concept_id' as VARCHAR(255)) as analysis_name,
+CAST('procedure_concept_id' as VARCHAR(255)) as stratum_1_name,
+CAST('time-to-event 30d increments' as VARCHAR(255)) as stratum_2_name,
+NULL as stratum_3_name,
+NULL as stratum_4_name,
+NULL as stratum_5_name,
+CAST('COHORT_SPECIFIC_ANALYSES' as VARCHAR(255)) as analysis_type
+union all
+select 1840 as analysis_id,
+CAST('Number of persons by duration from cohort start to first occurrence of drug exposure, by drug_concept_id' as VARCHAR(255)) as analysis_name,
+CAST('drug_concept_id' as VARCHAR(255)) as stratum_1_name,
+CAST('time-to-event 30d increments' as VARCHAR(255)) as stratum_2_name,
+NULL as stratum_3_name,
+NULL as stratum_4_name,
+NULL as stratum_5_name,
+CAST('COHORT_SPECIFIC_ANALYSES' as VARCHAR(255)) as analysis_type
+union all
+select 1841 as analysis_id,
+CAST('Number of events by duration from cohort start to all occurrences of drug exposure, by drug_concept_id' as VARCHAR(255)) as analysis_name,
+CAST('drug_concept_id' as VARCHAR(255)) as stratum_1_name,
+CAST('time-to-event 30d increments' as VARCHAR(255)) as stratum_2_name,
+NULL as stratum_3_name,
+NULL as stratum_4_name,
+NULL as stratum_5_name,
+CAST('COHORT_SPECIFIC_ANALYSES' as VARCHAR(255)) as analysis_type
+union all
+select 1850 as analysis_id,
+CAST('Number of persons by duration from cohort start to first occurrence of observation, by observation_concept_id' as VARCHAR(255)) as analysis_name,
+CAST('observation_concept_id' as VARCHAR(255)) as stratum_1_name,
+CAST('time-to-event 30d increments' as VARCHAR(255)) as stratum_2_name,
+NULL as stratum_3_name,
+NULL as stratum_4_name,
+NULL as stratum_5_name,
+CAST('COHORT_SPECIFIC_ANALYSES' as VARCHAR(255)) as analysis_type
+union all
+select 1851 as analysis_id,
+CAST('Number of events by duration from cohort start to all occurrences of observation, by observation_concept_id' as VARCHAR(255)) as analysis_name,
+CAST('observation_concept_id' as VARCHAR(255)) as stratum_1_name,
+CAST('time-to-event 30d increments' as VARCHAR(255)) as stratum_2_name,
+NULL as stratum_3_name,
+NULL as stratum_4_name,
+NULL as stratum_5_name,
+CAST('COHORT_SPECIFIC_ANALYSES' as VARCHAR(255)) as analysis_type
+union all
+select 1860 as analysis_id,
+CAST('Number of persons by duration from cohort start to first occurrence of condition era, by condition_concept_id' as VARCHAR(255)) as analysis_name,
+CAST('condition_concept_id' as VARCHAR(255)) as stratum_1_name,
+CAST('time-to-event 30d increments' as VARCHAR(255)) as stratum_2_name,
+NULL as stratum_3_name,
+NULL as stratum_4_name,
+NULL as stratum_5_name,
+CAST('COHORT_SPECIFIC_ANALYSES' as VARCHAR(255)) as analysis_type
+union all
+select 1861 as analysis_id,
+CAST('Number of events by duration from cohort start to all occurrences of condition era, by condition_concept_id' as VARCHAR(255)) as analysis_name,
+CAST('condition_concept_id' as VARCHAR(255)) as stratum_1_name,
+CAST('time-to-event 30d increments' as VARCHAR(255)) as stratum_2_name,
+NULL as stratum_3_name,
+NULL as stratum_4_name,
+NULL as stratum_5_name,
+CAST('COHORT_SPECIFIC_ANALYSES' as VARCHAR(255)) as analysis_type
+union all
+select 1870 as analysis_id,
+CAST('Number of persons by duration from cohort start to first occurrence of drug era, by drug_concept_id' as VARCHAR(255)) as analysis_name,
+CAST('drug_concept_id' as VARCHAR(255)) as stratum_1_name,
+CAST('time-to-event 30d increments' as VARCHAR(255)) as stratum_2_name,
+NULL as stratum_3_name,
+NULL as stratum_4_name,
+NULL as stratum_5_name,
+CAST('COHORT_SPECIFIC_ANALYSES' as VARCHAR(255)) as analysis_type
+union all
+select 1871 as analysis_id,
+CAST('Number of events by duration from cohort start to all occurrences of drug era, by drug_concept_id' as VARCHAR(255)) as analysis_name,
+CAST('drug_concept_id' as VARCHAR(255)) as stratum_1_name,
+CAST('time-to-event 30d increments' as VARCHAR(255)) as stratum_2_name,
+NULL as stratum_3_name,
+NULL as stratum_4_name,
+NULL as stratum_5_name,
+CAST('COHORT_SPECIFIC_ANALYSES' as VARCHAR(255)) as analysis_type
+;


### PR DESCRIPTION
Using many single inserts is very slow on Redshift and PDW, so I've changed these two init scripts to use INSERT INTO SELECT syntax, which performs much better. Tested on Redshift, PDW, and Postgres.

**Previous version benchmarks:**
- Redshift: 406 seconds
- PDW: 30 seconds
- Postgres: 0.39 seconds

**New version benchmarks:**
- Redshift: 35 seconds (a pure CTAS runs better: 18.07 seconds; perhaps we can merge the DDLs with the init scripts in the future)
- PDW: 0.79 seconds
- Postgres: 0.03 seconds

The reason I'm concerned about this performance is because we will be pulling all of the results DDLs and scripts hosted in this repo when executing the [CdmAtlasCutover](https://github.com/OHDSI/CdmAtlasCutover) package, which we use to cutover new CDMs into Atlas. 