### PR TITLE
Utilization - Removed roll-up using concept_ancestor

### DIFF
--- a/src/main/resources/resources/cohortanalysis/sql/runHeraclesAnalyses.sql
+++ b/src/main/resources/resources/cohortanalysis/sql/runHeraclesAnalyses.sql
@@ -26,8 +26,8 @@
 {DEFAULT @runHERACLESHeel = FALSE}   --runHERACLESHeel = @runHERACLESHeel
 {DEFAULT @CDM_version = '4'}  --we support 4 or 5,   CDM_version = @CDM_version
 {DEFAULT @cohort_period_only = FALSE}
-{DEFAULT @rollupUtilizationVisit = 0} -- by default, do not roll up Visit utilization using concept ancestor
-{DEFAULT @rollupUtilizationDrug = 0} -- by default, do not roll up Drug utilization using concept ancestor
+{DEFAULT @rollupUtilizationVisit = FALSE} -- do not roll up Visit utilization using concept ancestor
+{DEFAULT @rollupUtilizationDrug = FALSE} -- do not roll up Drug utilization using concept ancestor
 {DEFAULT @periods = ''} -- default value for periods is blank. No calendar periods will be used. 
 
 {DEFAULT @cohort_definition_id = '2000003550,2000004386'}   --cohort_definition_id = @cohort_definition_id

--- a/src/main/resources/resources/cohortanalysis/sql/runHeraclesAnalyses.sql
+++ b/src/main/resources/resources/cohortanalysis/sql/runHeraclesAnalyses.sql
@@ -12465,7 +12465,7 @@ with drug_records(cohort_definition_id, subject_id, drug_concept_id, drug_type_c
 		cost
 	from #HERACLES_cohort c1
 	join @CDM_schema.drug_exposure de1 on c1.subject_id = de1.person_id
-		and de1.drug_exposure_start_date >= c1.cohort_start_date and de1.drug_exposure_start_date < c1.cohort_end_date
+		and de1.drug_exposure_start_date >= dateadd(d, -365, c1.cohort_start_date) and de1.drug_exposure_start_date < c1.cohort_start_date
 	join @CDM_schema.cost cst1 on c1.subject_id = cst1.person_id
 		and cst1.person_id = de1.person_id
 		and de1.visit_occurrence_id = cst1.cost_event_id
@@ -12521,7 +12521,7 @@ with drug_records(cohort_definition_id, subject_id, drug_concept_id, drug_type_c
 		cost
 	from #HERACLES_cohort c1
 	join @CDM_schema.drug_exposure de1 on c1.subject_id = de1.person_id
-		and de1.drug_exposure_start_date >= c1.cohort_start_date and de1.drug_exposure_start_date < c1.cohort_end_date
+		and de1.drug_exposure_start_date >= dateadd(d, -365, c1.cohort_start_date) and de1.drug_exposure_start_date < c1.cohort_start_date
 	join @CDM_schema.cost cst1 on c1.subject_id = cst1.person_id
 		and cst1.person_id = de1.person_id
 		and de1.visit_occurrence_id = cst1.cost_event_id

--- a/src/main/resources/resources/cohortanalysis/sql/runHeraclesAnalyses.sql
+++ b/src/main/resources/resources/cohortanalysis/sql/runHeraclesAnalyses.sql
@@ -26,6 +26,8 @@
 {DEFAULT @runHERACLESHeel = FALSE}   --runHERACLESHeel = @runHERACLESHeel
 {DEFAULT @CDM_version = '4'}  --we support 4 or 5,   CDM_version = @CDM_version
 {DEFAULT @cohort_period_only = FALSE}
+{DEFAULT @rollupUtilizationVisit = 0} -- by default, do not roll up Visit utilization using concept ancestor
+{DEFAULT @rollupUtilizationDrug = 0} -- by default, do not roll up Drug utilization using concept ancestor
 
 {DEFAULT @cohort_definition_id = '2000003550,2000004386'}   --cohort_definition_id = @cohort_definition_id
 

--- a/src/main/resources/resources/cohortanalysis/sql/runHeraclesAnalyses.sql
+++ b/src/main/resources/resources/cohortanalysis/sql/runHeraclesAnalyses.sql
@@ -28,6 +28,7 @@
 {DEFAULT @cohort_period_only = FALSE}
 {DEFAULT @rollupUtilizationVisit = 0} -- by default, do not roll up Visit utilization using concept ancestor
 {DEFAULT @rollupUtilizationDrug = 0} -- by default, do not roll up Drug utilization using concept ancestor
+{DEFAULT @periods = ''} -- default value for periods is blank. No calendar periods will be used. 
 
 {DEFAULT @cohort_definition_id = '2000003550,2000004386'}   --cohort_definition_id = @cohort_definition_id
 

--- a/src/main/resources/resources/cohortanalysis/sql/runHeraclesAnalyses.sql
+++ b/src/main/resources/resources/cohortanalysis/sql/runHeraclesAnalyses.sql
@@ -12465,7 +12465,7 @@ with drug_records(cohort_definition_id, subject_id, drug_concept_id, drug_type_c
 		cost
 	from #HERACLES_cohort c1
 	join @CDM_schema.drug_exposure de1 on c1.subject_id = de1.person_id
-		and de1.drug_exposure_start_date >= dateadd(d, -365, c1.cohort_start_date) and de1.drug_exposure_start_date < c1.cohort_start_date
+		and de1.drug_exposure_start_date >= c1.cohort_start_date and de1.drug_exposure_start_date < c1.cohort_end_date
 	join @CDM_schema.cost cst1 on c1.subject_id = cst1.person_id
 		and cst1.person_id = de1.person_id
 		and de1.visit_occurrence_id = cst1.cost_event_id
@@ -12521,7 +12521,7 @@ with drug_records(cohort_definition_id, subject_id, drug_concept_id, drug_type_c
 		cost
 	from #HERACLES_cohort c1
 	join @CDM_schema.drug_exposure de1 on c1.subject_id = de1.person_id
-		and de1.drug_exposure_start_date >= dateadd(d, -365, c1.cohort_start_date) and de1.drug_exposure_start_date < c1.cohort_start_date
+		and de1.drug_exposure_start_date >= c1.cohort_start_date and de1.drug_exposure_start_date < c1.cohort_end_date
 	join @CDM_schema.cost cst1 on c1.subject_id = cst1.person_id
 		and cst1.person_id = de1.person_id
 		and de1.visit_occurrence_id = cst1.cost_event_id

--- a/src/main/resources/resources/cohortanalysis/sql/runHeraclesAnalyses.sql
+++ b/src/main/resources/resources/cohortanalysis/sql/runHeraclesAnalyses.sql
@@ -8432,7 +8432,7 @@ select cohort_definition_id
 	, count(distinct visit_occurrence_id) as count_value
 into #raw_4002_u3
 from #raw_4002
-join #periods_baseline hp on visit_start_date >= hp.period_start_date and visit_start_date < hp.period_end_dat
+join #periods_baseline hp on visit_start_date >= hp.period_start_date and visit_start_date < hp.period_end_date
 {@rollupUtilizationVisit} ? {
 where ancestor = 0
 }


### PR DESCRIPTION
For analysis_id between 4000 and 4025, removed roll-up using concept_ancestor. With roll-up takes 10 to 20 times more time to run, compared to without.