### PR TITLE
Heracles reports casting fixes.

### DIFF
--- a/src/main/resources/resources/cdmresults/sql/getDrugEraPrevalenceByGenderAgeYear.sql
+++ b/src/main/resources/resources/cdmresults/sql/getDrugEraPrevalenceByGenderAgeYear.sql
@@ -10,31 +10,31 @@ SELECT
         5)                                                                                  AS y_prevalence_1000pp --prevalence, per 1000 persons
 FROM (
        SELECT
-         num.stratum_1                 num_stratum_1,
-         CAST(num.stratum_2 AS INT) AS num_stratum_2,
-         num.stratum_3                 num_stratum_3,
-         CAST(num.stratum_4 AS INT) AS num_stratum_4,
+         CAST(num.stratum_1 AS BIGINT) AS num_stratum_1,
+         CAST(num.stratum_2 AS BIGINT) AS num_stratum_2,
+         CAST(num.stratum_3 AS BIGINT) AS num_stratum_3,
+         CAST(num.stratum_4 AS BIGINT) AS num_stratum_4,
          num.count_value            AS num_count_value,
          denom.count_value          AS denom_count_value
        FROM (
-              SELECT *
+              SELECT stratum_1, stratum_2, stratum_3, stratum_4, count_value 
               FROM @ohdsi_database_schema.achilles_results
               WHERE analysis_id = 904
                     AND stratum_3 IN ('8507', '8532')
+							GROUP BY stratum_1, stratum_2, stratum_3, stratum_4, count_value 
             ) num
          INNER JOIN (
-                      SELECT *
+                      SELECT stratum_1, stratum_2, stratum_3, stratum_4, count_value 
                       FROM @ohdsi_database_schema.achilles_results
                       WHERE analysis_id = 116
                             AND stratum_2 IN ('8507', '8532')
+											GROUP BY stratum_1, stratum_2, stratum_3, stratum_4, count_value 
                     ) denom
            ON num.stratum_2 = denom.stratum_1
               AND num.stratum_3 = denom.stratum_2
               AND num.stratum_4 = denom.stratum_3
      ) tmp
-  INNER JOIN @vocabulary_database_schema.concept c1
-ON num_stratum_1 = CAST(c1.concept_id AS VARCHAR )
-INNER JOIN @vocabulary_database_schema.concept c2
-ON num_stratum_3 = CAST(c2.concept_id AS VARCHAR )
+INNER JOIN @vocabulary_database_schema.concept c1 ON num_stratum_1 = CAST(c1.concept_id AS VARCHAR )
+INNER JOIN @vocabulary_database_schema.concept c2 ON num_stratum_3 = CAST(c2.concept_id AS VARCHAR )
 WHERE c1.concept_id = @conceptId
 ORDER BY c1.concept_id, num_stratum_2

--- a/src/main/resources/resources/cdmresults/sql/getMonthlyConditionOccurrencePrevalence.sql
+++ b/src/main/resources/resources/cdmresults/sql/getMonthlyConditionOccurrencePrevalence.sql
@@ -8,13 +8,12 @@ FROM (
          count_value
        FROM @OHDSI_schema.ACHILLES_results
        WHERE analysis_id = 402 AND stratum_1 = '@conceptId'
-     ) num
-  INNER JOIN (
-               SELECT
-                 stratum_1,
-                 count_value
-               FROM @OHDSI_schema.ACHILLES_results
-               WHERE analysis_id = 117
-             ) denom
-    ON num.stratum_2 = denom.stratum_1
+) num
+INNER JOIN (
+	SELECT
+		 stratum_1,
+		 count_value
+	 FROM @OHDSI_schema.ACHILLES_results
+	 WHERE analysis_id = 117
+) denom ON num.stratum_2 = denom.stratum_1
 ORDER BY cast(num.stratum_2 AS INT)

--- a/src/main/resources/resources/cdmresults/sql/report/condition/drilldown/prevalenceByMonth.sql
+++ b/src/main/resources/resources/cdmresults/sql/report/condition/drilldown/prevalenceByMonth.sql
@@ -6,7 +6,7 @@ SELECT
   round(1000 * (1.0 * num.count_value / denom.count_value), 5) AS y_prevalence_1000_pp --prevalence, per 1000 persons
 FROM
   (SELECT
-     CAST(stratum_1 AS INT) stratum_1,
+     CAST(stratum_1 AS BIGINT) stratum_1,
      CAST(stratum_2 AS INT) stratum_2,
      count_value
    FROM

--- a/src/main/resources/resources/cdmresults/sql/report/death/sqlPrevalenceByGenderAgeYear.sql
+++ b/src/main/resources/resources/cdmresults/sql/report/death/sqlPrevalenceByGenderAgeYear.sql
@@ -10,15 +10,20 @@ SELECT
   -- calendar year, note, there could be blanks
   ROUND(1000 * (1.0 * num.count_value / denom.count_value), 5) AS y_Prevalence_1000Pp --prevalence, per 1000 persons
 FROM
-  (SELECT *
-   FROM @results_database_schema.ACHILLES_results WHERE analysis_id = 504) num
-  INNER JOIN
-  (SELECT *
-   FROM @results_database_schema.ACHILLES_results WHERE analysis_id = 116) denom
-    ON num.stratum_1 = denom.stratum_1  --calendar year
+  (SELECT stratum_1, stratum_2, stratum_3, count_value
+		FROM @results_database_schema.ACHILLES_results 
+		WHERE analysis_id = 504
+		GROUP BY stratum_1, stratum_2, stratum_3, count_value
+	) num
+  INNER JOIN (
+		SELECT stratum_1, stratum_2, stratum_3, count_value
+		FROM @results_database_schema.ACHILLES_results 
+		WHERE analysis_id = 116
+		GROUP BY stratum_1, stratum_2, stratum_3, count_value
+	) denom ON num.stratum_1 = denom.stratum_1  --calendar year
        AND num.stratum_2 = denom.stratum_2 --gender
        AND num.stratum_3 = denom.stratum_3
   --age decile
-  INNER JOIN @vocab_database_schema.concept c2 ON CAST(num.stratum_2 AS INT) = c2.concept_id
+  INNER JOIN @vocab_database_schema.concept c2 ON CAST(num.stratum_2 AS BIGINT) = c2.concept_id
 WHERE c2.concept_id IN (8507, 8532)
 

--- a/src/main/resources/resources/cdmresults/sql/report/procedure/drilldown/prevalenceByMonth.sql
+++ b/src/main/resources/resources/cdmresults/sql/report/procedure/drilldown/prevalenceByMonth.sql
@@ -4,14 +4,18 @@ SELECT
   num.stratum_2                                                AS x_calendar_month,
   -- calendar year, note, there could be blanks
   round(1000 * (1.0 * num.count_value / denom.count_value), 5) AS y_prevalence_1000_pp --prevalence, per 1000 persons
-FROM
-  (SELECT *
-   FROM @results_database_schema.ACHILLES_results WHERE analysis_id = 602) num
-  INNER JOIN
-  (SELECT *
-   FROM @results_database_schema.ACHILLES_results WHERE analysis_id = 117)
-  denom ON num.stratum_2 = denom.stratum_1
-  --calendar year
-  INNER JOIN @vocab_database_schema.concept c1 ON CAST(num.stratum_1 AS INT) = c1.concept_id
+FROM (
+	SELECT stratum_1, stratum_2, count_value
+	FROM @results_database_schema.ACHILLES_results 
+	WHERE analysis_id = 602
+	GROUP BY stratum_1, stratum_2, count_value
+) num
+INNER JOIN (
+	SELECT stratum_1, count_value
+	FROM @results_database_schema.ACHILLES_results 
+	WHERE analysis_id = 117
+	GROUP BY stratum_1, count_value
+) denom ON num.stratum_2 = denom.stratum_1 --calendar year
+INNER JOIN @vocab_database_schema.concept c1 ON CAST(num.stratum_1 AS BIGINT) = c1.concept_id
 WHERE c1.concept_id = @conceptId
 ORDER BY CAST(num.stratum_2 AS INT )

--- a/src/main/resources/resources/cohortresults/sql/cohortSpecific/ageAtIndex.sql
+++ b/src/main/resources/resources/cohortresults/sql/cohortSpecific/ageAtIndex.sql
@@ -2,4 +2,4 @@ select cast(stratum_1 as integer) as age_at_index,
 	count_value as num_persons
 from @ohdsi_database_schema.heracles_results
 where analysis_id in (1800)
-and cohort_definition_id in (@cohortDefinitionId)
+and cohort_definition_id = @cohortDefinitionId

--- a/src/main/resources/resources/cohortresults/sql/cohortSpecific/ageAtIndexDistribution.sql
+++ b/src/main/resources/resources/cohortresults/sql/cohortSpecific/ageAtIndexDistribution.sql
@@ -2,4 +2,4 @@ select 'Age at Index' as category, count_value,	min_value, max_value, avg_value,
 median_value, p75_value, p90_value, 0 as concept_id
 from @ohdsi_database_schema.heracles_results_dist
 where analysis_id in (1801)
-and cohort_definition_id in (@cohortDefinitionId)
+and cohort_definition_id = @cohortDefinitionId

--- a/src/main/resources/resources/cohortresults/sql/cohortSpecific/byConcept/drugOccursRelativeToIndex.sql
+++ b/src/main/resources/resources/cohortresults/sql/cohortSpecific/byConcept/drugOccursRelativeToIndex.sql
@@ -14,7 +14,7 @@ FROM   (SELECT cohort_definition_id,
                count_value 
         FROM   @ohdsi_database_schema.heracles_results 
         WHERE  analysis_id IN ( 1870 ) 
-               AND cohort_definition_id IN ( @cohortDefinitionId )) hr1 
+               AND cohort_definition_id = @cohortDefinitionId) hr1 
        INNER JOIN (SELECT cohort_definition_id, 
                           -1 * Cast(stratum_1 AS INTEGER) * 30                AS 
               duration, 
@@ -25,7 +25,7 @@ FROM   (SELECT cohort_definition_id,
               count_value 
                    FROM   @ohdsi_database_schema.heracles_results 
                    WHERE  analysis_id IN ( 1805 ) 
-                          AND cohort_definition_id IN ( @cohortDefinitionId ) 
+                          AND cohort_definition_id = @cohortDefinitionId 
                           AND Cast(stratum_1 AS INTEGER) > 0 
                    UNION 
                    SELECT hr1.cohort_definition_id, 
@@ -41,11 +41,9 @@ FROM   (SELECT cohort_definition_id,
                    FROM   @ohdsi_database_schema.heracles_results hr1 
                           INNER JOIN (SELECT cohort_definition_id, 
                                              Sum(count_value) AS count_value 
-                                      FROM 
-                          @ohdsi_database_schema.heracles_results 
-                                      WHERE  analysis_id = 1806 
-                                             AND cohort_definition_id IN ( 
-                                                 @cohortDefinitionId ) 
+                                      FROM @ohdsi_database_schema.heracles_results 
+                                      WHERE analysis_id = 1806 
+                                             AND cohort_definition_id = @cohortDefinitionId 
                                       GROUP  BY cohort_definition_id) t1 
                                   ON hr1.cohort_definition_id = 
                                      t1.cohort_definition_id 
@@ -59,7 +57,7 @@ FROM   (SELECT cohort_definition_id,
                           Sum(count_value)           AS count_value 
                    FROM   @ohdsi_database_schema.heracles_results 
                    WHERE  analysis_id IN ( 1870 ) 
-                          AND cohort_definition_id IN ( @cohortDefinitionId ) 
+                          AND cohort_definition_id = @cohortDefinitionId 
                    GROUP  BY cohort_definition_id, 
                              Cast(stratum_1 AS INTEGER) 
                    HAVING Sum(count_value) > @minCovariatePersonCount) ct1 
@@ -86,7 +84,7 @@ FROM   (SELECT cohort_definition_id,
                count_value 
         FROM   @ohdsi_database_schema.heracles_results 
         WHERE  analysis_id IN ( 1871 ) 
-               AND cohort_definition_id IN ( @cohortDefinitionId )) hr1 
+               AND cohort_definition_id = @cohortDefinitionId) hr1 
        INNER JOIN (SELECT cohort_definition_id, 
                           -1 * Cast(stratum_1 AS INTEGER) * 30                AS 
               duration, 
@@ -97,7 +95,7 @@ FROM   (SELECT cohort_definition_id,
               count_value 
                    FROM   @ohdsi_database_schema.heracles_results 
                    WHERE  analysis_id IN ( 1805 ) 
-                          AND cohort_definition_id IN ( @cohortDefinitionId ) 
+                          AND cohort_definition_id = @cohortDefinitionId 
                           AND Cast(stratum_1 AS INTEGER) > 0 
                    UNION 
                    SELECT hr1.cohort_definition_id, 
@@ -113,11 +111,9 @@ FROM   (SELECT cohort_definition_id,
                    FROM   @ohdsi_database_schema.heracles_results hr1 
                           INNER JOIN (SELECT cohort_definition_id, 
                                              Sum(count_value) AS count_value 
-                                      FROM 
-                          @ohdsi_database_schema.heracles_results 
+                                      FROM @ohdsi_database_schema.heracles_results 
                                       WHERE  analysis_id = 1806 
-                                             AND cohort_definition_id IN ( 
-                                                 @cohortDefinitionId ) 
+                                             AND cohort_definition_id = @cohortDefinitionId 
                                       GROUP  BY cohort_definition_id) t1 
                                   ON hr1.cohort_definition_id = 
                                      t1.cohort_definition_id 
@@ -131,7 +127,7 @@ FROM   (SELECT cohort_definition_id,
                           Sum(count_value)           AS count_value 
                    FROM   @ohdsi_database_schema.heracles_results 
                    WHERE  analysis_id IN ( 1871 ) 
-                          AND cohort_definition_id IN ( @cohortDefinitionId ) 
+                          AND cohort_definition_id = @cohortDefinitionId 
                    GROUP  BY cohort_definition_id, 
                              Cast(stratum_1 AS INTEGER) 
                    HAVING Sum(count_value) > @minCovariatePersonCount) ct1 

--- a/src/main/resources/resources/cohortresults/sql/cohortSpecific/byConcept/firstConditionRelativeToIndex.sql
+++ b/src/main/resources/resources/cohortresults/sql/cohortSpecific/byConcept/firstConditionRelativeToIndex.sql
@@ -14,7 +14,7 @@ FROM   (SELECT cohort_definition_id,
                count_value 
         FROM   @ohdsi_database_schema.heracles_results 
         WHERE  analysis_id IN ( 1820 ) 
-               AND cohort_definition_id IN ( @cohortDefinitionId )
+               AND cohort_definition_id = @cohortDefinitionId
                AND Cast(stratum_2 AS INTEGER) * 30 BETWEEN -1000 AND 1000
                         ) hr1 
        INNER JOIN (SELECT -1 * Cast(stratum_1 AS INTEGER) * 30                AS 
@@ -61,14 +61,12 @@ FROM   (SELECT cohort_definition_id,
                                       FROM 
                           @ohdsi_database_schema.heracles_results 
                                       WHERE  analysis_id = 1806 
-                                             AND cohort_definition_id IN ( 
-                                                 @cohortDefinitionId ) 
+                                             AND cohort_definition_id = @cohortDefinitionId 
                                       GROUP  BY cohort_definition_id) t1 
                                   ON hr1.cohort_definition_id = 
                                      t1.cohort_definition_id 
                    WHERE  hr1.analysis_id IN ( 1806 ) 
-                          AND hr1.cohort_definition_id IN 
-                              ( @cohortDefinitionId )
+                          AND hr1.cohort_definition_id = @cohortDefinitionId
                                                     ) t1 
                ON  hr1.duration = t1.duration 
        INNER JOIN (SELECT Cast(stratum_1 AS INTEGER) AS concept_id, 
@@ -99,7 +97,7 @@ FROM   (SELECT cohort_definition_id,
                count_value 
         FROM   @ohdsi_database_schema.heracles_results  
         WHERE  analysis_id IN ( 1821 ) 
-               AND cohort_definition_id IN ( @cohortDefinitionId )
+               AND cohort_definition_id = @cohortDefinitionId
                AND Cast(stratum_2 AS INTEGER) * 30 BETWEEN -1000 AND 1000
                ) hr1 
        INNER JOIN (SELECT -1 * Cast(stratum_1 AS INTEGER) * 30                AS 
@@ -146,8 +144,7 @@ FROM   (SELECT cohort_definition_id,
                                       FROM 
                           @ohdsi_database_schema.heracles_results 
                                       WHERE  analysis_id = 1806 
-                                             AND cohort_definition_id IN ( 
-                                                 @cohortDefinitionId ) 
+                                             AND cohort_definition_id = @cohortDefinitionId 
                                       GROUP  BY cohort_definition_id) t1 
                                   ON hr1.cohort_definition_id = 
                                      t1.cohort_definition_id 

--- a/src/main/resources/resources/cohortresults/sql/cohortSpecific/byConcept/procedureOccursRelativeToIndex.sql
+++ b/src/main/resources/resources/cohortresults/sql/cohortSpecific/byConcept/procedureOccursRelativeToIndex.sql
@@ -23,7 +23,7 @@ FROM   (SELECT cohort_definition_id,
                count_value 
         FROM   @ohdsi_database_schema.heracles_results 
         WHERE  analysis_id IN ( 1830 ) 
-               AND cohort_definition_id IN ( @cohortDefinitionId )) hr1 
+               AND cohort_definition_id = @cohortDefinitionId) hr1 
        INNER JOIN (SELECT cohort_definition_id, 
                           -1 * Cast(stratum_1 AS INTEGER) * 30                AS 
               duration, 
@@ -34,7 +34,7 @@ FROM   (SELECT cohort_definition_id,
               count_value 
                    FROM   @ohdsi_database_schema.heracles_results 
                    WHERE  analysis_id IN ( 1805 ) 
-                          AND cohort_definition_id IN ( @cohortDefinitionId ) 
+                          AND cohort_definition_id = @cohortDefinitionId 
                           AND Cast(stratum_1 AS INTEGER) > 0 
                    UNION 
                    SELECT hr1.cohort_definition_id, 
@@ -53,8 +53,7 @@ FROM   (SELECT cohort_definition_id,
                                       FROM 
                           @ohdsi_database_schema.heracles_results 
                                       WHERE  analysis_id = 1806 
-                                             AND cohort_definition_id IN ( 
-                                                 @cohortDefinitionId ) 
+                                             AND cohort_definition_id = @cohortDefinitionId 
                                       GROUP  BY cohort_definition_id) t1 
                                   ON hr1.cohort_definition_id = 
                                      t1.cohort_definition_id 
@@ -68,7 +67,7 @@ FROM   (SELECT cohort_definition_id,
                           Sum(count_value)           AS count_value 
                    FROM   @ohdsi_database_schema.heracles_results 
                    WHERE  analysis_id IN ( 1830 ) 
-                          AND cohort_definition_id IN ( @cohortDefinitionId ) 
+                          AND cohort_definition_id = @cohortDefinitionId 
                    GROUP  BY cohort_definition_id, 
                              Cast(stratum_1 AS INTEGER) 
                    HAVING Sum(count_value) > @minCovariatePersonCount) ct1 
@@ -95,7 +94,7 @@ FROM   (SELECT cohort_definition_id,
                count_value 
         FROM   @ohdsi_database_schema.heracles_results 
         WHERE  analysis_id IN ( 1831 ) 
-               AND cohort_definition_id IN ( @cohortDefinitionId )) hr1 
+               AND cohort_definition_id = @cohortDefinitionId) hr1 
        INNER JOIN (SELECT cohort_definition_id, 
                           -1 * Cast(stratum_1 AS INTEGER) * 30                AS 
               duration, 
@@ -106,7 +105,7 @@ FROM   (SELECT cohort_definition_id,
               count_value 
                    FROM   @ohdsi_database_schema.heracles_results 
                    WHERE  analysis_id IN ( 1805 ) 
-                          AND cohort_definition_id IN ( @cohortDefinitionId ) 
+                          AND cohort_definition_id = @cohortDefinitionId 
                           AND Cast(stratum_1 AS INTEGER) > 0 
                    UNION 
                    SELECT hr1.cohort_definition_id, 
@@ -125,8 +124,7 @@ FROM   (SELECT cohort_definition_id,
                                       FROM 
                           @ohdsi_database_schema.heracles_results 
                                       WHERE  analysis_id = 1806 
-                                             AND cohort_definition_id IN ( 
-                                                 @cohortDefinitionId ) 
+                                             AND cohort_definition_id = @cohortDefinitionId 
                                       GROUP  BY cohort_definition_id) t1 
                                   ON hr1.cohort_definition_id = 
                                      t1.cohort_definition_id 
@@ -140,7 +138,7 @@ FROM   (SELECT cohort_definition_id,
                           Sum(count_value)           AS count_value 
                    FROM   @ohdsi_database_schema.heracles_results 
                    WHERE  analysis_id IN ( 1831 ) 
-                          AND cohort_definition_id IN ( @cohortDefinitionId ) 
+                          AND cohort_definition_id = @cohortDefinitionId 
                    GROUP  BY cohort_definition_id, 
                              Cast(stratum_1 AS INTEGER) 
                    HAVING Sum(count_value) > @minCovariatePersonCount) ct1 

--- a/src/main/resources/resources/cohortresults/sql/cohortSpecific/cohortSize.sql
+++ b/src/main/resources/resources/cohortresults/sql/cohortSpecific/cohortSize.sql
@@ -1,4 +1,4 @@
 select count_value as num_persons
 from @ohdsi_database_schema.heracles_results
 where analysis_id in (1)
-and cohort_definition_id in (@cohortDefinitionId)
+and cohort_definition_id = @cohortDefinitionId

--- a/src/main/resources/resources/cohortresults/sql/cohortSpecific/conditionOccurrencePrevalenceOfCondition.sql
+++ b/src/main/resources/resources/cohortresults/sql/cohortSpecific/conditionOccurrencePrevalenceOfCondition.sql
@@ -27,7 +27,7 @@ from
 	sum(case when CAST(stratum_2 AS INT) > 0 then count_value else 0 end) as num_persons_after
 from @ohdsi_database_schema.heracles_results
 where analysis_id in (1820) --first occurrence of condition
-and cohort_definition_id in (@cohortDefinitionId)
+and cohort_definition_id = @cohortDefinitionId
 group by stratum_1
 ) hr1
 inner join
@@ -121,5 +121,5 @@ inner join
 (select count_value
 from @ohdsi_database_schema.heracles_results
 where analysis_id = 1
-and cohort_definition_id in (@cohortDefinitionId)
+and cohort_definition_id = @cohortDefinitionId
 ) denom

--- a/src/main/resources/resources/cohortresults/sql/cohortSpecific/distributionOfAgeAtCohortStartByCohortStartYear.sql
+++ b/src/main/resources/resources/cohortresults/sql/cohortSpecific/distributionOfAgeAtCohortStartByCohortStartYear.sql
@@ -12,4 +12,4 @@ hrd1.max_value as max_value,
 from @ohdsi_database_schema.HERACLES_results_dist hrd1
 inner join @cdm_database_schema.concept c1 on hrd1.stratum_1 = CAST(c1.concept_id as VARCHAR(255))
 where hrd1.analysis_id in (1803)
-and cohort_definition_id in (@cohortDefinitionId)
+and cohort_definition_id = @cohortDefinitionId

--- a/src/main/resources/resources/cohortresults/sql/cohortSpecific/distributionOfAgeAtCohortStartByGender.sql
+++ b/src/main/resources/resources/cohortresults/sql/cohortSpecific/distributionOfAgeAtCohortStartByGender.sql
@@ -11,4 +11,4 @@ hrd1.max_value as max_value,
 from @ohdsi_database_schema.HERACLES_results_dist hrd1
 inner join @cdm_database_schema.concept c1 on hrd1.stratum_1 = CAST(c1.concept_id as VARCHAR(255))
 where hrd1.analysis_id in (1802)
-and cohort_definition_id in (@cohortDefinitionId)
+and cohort_definition_id = @cohortDefinitionId

--- a/src/main/resources/resources/cohortresults/sql/cohortSpecific/drugEraPrevalenceOfDrug.sql
+++ b/src/main/resources/resources/cohortresults/sql/cohortSpecific/drugEraPrevalenceOfDrug.sql
@@ -35,7 +35,7 @@ from
 	sum(case when CAST(stratum_2 AS INT) > 0 then count_value else 0 end) as num_persons_after
 from @ohdsi_database_schema.heracles_results
 where analysis_id in (1870) --first occurrence of drug
-and cohort_definition_id in (@cohortDefinitionId)
+and cohort_definition_id = @cohortDefinitionId
 group by stratum_1
 ) hr1
 inner join
@@ -117,5 +117,5 @@ inner join
 (select count_value
 from @ohdsi_database_schema.heracles_results
 where analysis_id = 1
-and cohort_definition_id in (@cohortDefinitionId)
+and cohort_definition_id = @cohortDefinitionId
 ) denom

--- a/src/main/resources/resources/cohortresults/sql/cohortSpecific/getExposureOutcomeCohortRates.sql
+++ b/src/main/resources/resources/cohortresults/sql/cohortSpecific/getExposureOutcomeCohortRates.sql
@@ -9,16 +9,16 @@ FROM
 (
     SELECT exposure_cohort_definition_id, outcome_cohort_definition_id, count_value
     FROM @ohdsi_database_schema.penelope_results
-    WHERE exposure_cohort_definition_id in ( @exposure_cohort_definition_id )
-    AND outcome_cohort_definition_id in ( @outcome_cohort_definition_id )
+    WHERE exposure_cohort_definition_id = @exposure_cohort_definition_id
+    AND outcome_cohort_definition_id = @outcome_cohort_definition_id
     AND analysis_id = 0
 ) total
 LEFT JOIN
 (
     SELECT exposure_cohort_definition_id, outcome_cohort_definition_id, count_value
     FROM @ohdsi_database_schema.penelope_results
-    WHERE exposure_cohort_definition_id in ( @exposure_cohort_definition_id )
-    AND outcome_cohort_definition_id in ( @outcome_cohort_definition_id )
+    WHERE exposure_cohort_definition_id = @exposure_cohort_definition_id
+    AND outcome_cohort_definition_id = @outcome_cohort_definition_id
     AND analysis_id = 1
     AND stratum_1 = 'Outcome pre-exposure'
 ) outcomepreexposure
@@ -28,8 +28,8 @@ LEFT JOIN
 (
     SELECT exposure_cohort_definition_id, outcome_cohort_definition_id, count_value
     FROM @ohdsi_database_schema.penelope_results
-    WHERE exposure_cohort_definition_id in ( @exposure_cohort_definition_id )
-    AND outcome_cohort_definition_id in ( @outcome_cohort_definition_id )
+    WHERE exposure_cohort_definition_id = @exposure_cohort_definition_id
+    AND outcome_cohort_definition_id = @outcome_cohort_definition_id
     AND analysis_id = 1
     AND stratum_1 = 'Outcome post-exposure'
 ) outcomepostexposure
@@ -39,8 +39,8 @@ LEFT JOIN
 (
     SELECT exposure_cohort_definition_id, outcome_cohort_definition_id, sum(count_value) as time_at_risk
     FROM @ohdsi_database_schema.penelope_results
-    WHERE exposure_cohort_definition_id in ( @exposure_cohort_definition_id )
-    AND outcome_cohort_definition_id in ( @outcome_cohort_definition_id )
+    WHERE exposure_cohort_definition_id = @exposure_cohort_definition_id
+    AND outcome_cohort_definition_id = @outcome_cohort_definition_id
     AND analysis_id = 10
     AND stratum_1 in ('Outcome post-exposure', 'Exposure with no outcome')
     GROUP BY exposure_cohort_definition_id, outcome_cohort_definition_id

--- a/src/main/resources/resources/cohortresults/sql/cohortSpecific/getExposureOutcomePredictors.sql
+++ b/src/main/resources/resources/cohortresults/sql/cohortSpecific/getExposureOutcomePredictors.sql
@@ -1,8 +1,8 @@
 WITH total_exposed_w_outcome AS (
 	SELECT exposure_cohort_definition_id, outcome_cohort_definition_id, count_value
 	FROM @ohdsi_database_schema.penelope_results 
-	WHERE exposure_cohort_definition_id in ( @exposure_cohort_definition_id )
-		AND outcome_cohort_definition_id in ( @outcome_cohort_definition_id )
+	WHERE exposure_cohort_definition_id = @exposure_cohort_definition_id
+		AND outcome_cohort_definition_id = @outcome_cohort_definition_id
 		AND analysis_id = 1
 		AND stratum_1 = 'Outcome post-exposure'
 ),
@@ -10,8 +10,8 @@ total_exposed AS (
 	SELECT exposure_cohort_definition_id, outcome_cohort_definition_id, 
 		sum(count_value) as count_value
 	FROM @ohdsi_database_schema.penelope_results 
-	WHERE exposure_cohort_definition_id in ( @exposure_cohort_definition_id )
-		AND outcome_cohort_definition_id in ( @outcome_cohort_definition_id )
+	WHERE exposure_cohort_definition_id = @exposure_cohort_definition_id
+		AND outcome_cohort_definition_id = @outcome_cohort_definition_id
 		AND analysis_id = 1
 		AND stratum_1 IN ('Exposure with no outcome','Outcome post-exposure')
 	GROUP BY exposure_cohort_definition_id, outcome_cohort_definition_id 
@@ -21,8 +21,8 @@ concept_w_outcome AS (
 		stratum_2 as concept_id,
 		count_value as count_value
 	FROM @ohdsi_database_schema.penelope_results
-	WHERE exposure_cohort_definition_id in ( @exposure_cohort_definition_id )
-		AND outcome_cohort_definition_id in ( @outcome_cohort_definition_id )
+	WHERE exposure_cohort_definition_id = @exposure_cohort_definition_id
+		AND outcome_cohort_definition_id = @outcome_cohort_definition_id
 		AND analysis_id in (1822, 1832, 1852, 1872, 1882)
 		AND stratum_1 = 'Outcome post-exposure'
 		AND stratum_3 = '-1'
@@ -33,8 +33,8 @@ concept_total AS (
 		stratum_2 as concept_id,
 		SUM(count_value) as count_value
 	FROM @ohdsi_database_schema.penelope_results
-	WHERE exposure_cohort_definition_id in ( @exposure_cohort_definition_id )
-		AND outcome_cohort_definition_id in ( @outcome_cohort_definition_id )
+	WHERE exposure_cohort_definition_id = @exposure_cohort_definition_id
+		AND outcome_cohort_definition_id = @outcome_cohort_definition_id
 		AND analysis_id in (1822, 1832, 1852, 1872, 1882)
 		AND stratum_1 in ('Exposure with no outcome','Outcome post-exposure')
 		AND stratum_3 = '-1'

--- a/src/main/resources/resources/cohortresults/sql/cohortSpecific/getTimeToEventDrilldown.sql
+++ b/src/main/resources/resources/cohortresults/sql/cohortSpecific/getTimeToEventDrilldown.sql
@@ -12,8 +12,8 @@ WITH denominator AS (
 				outcome_cohort_definition_id,
 				ROW_NUMBER() OVER (ORDER BY analysis_id) AS stratum_1, 0 AS count_value
 			FROM @ohdsi_database_schema.penelope_results
-			WHERE exposure_cohort_definition_id in ( @exposure_cohort_definition_id )
-			AND outcome_cohort_definition_id in ( @outcome_cohort_definition_id )
+			WHERE exposure_cohort_definition_id = @exposure_cohort_definition_id
+			AND outcome_cohort_definition_id = @outcome_cohort_definition_id
 			AND analysis_id = 1805
 
 			UNION
@@ -22,8 +22,8 @@ WITH denominator AS (
 				outcome_cohort_definition_id,
 				cast(stratum_2 AS INTEGER) as stratum_1, sum(count_value) as count_value
 			FROM @ohdsi_database_schema.penelope_results
-			WHERE exposure_cohort_definition_id in ( @exposure_cohort_definition_id )
-			AND outcome_cohort_definition_id in ( @outcome_cohort_definition_id )
+			WHERE exposure_cohort_definition_id = @exposure_cohort_definition_id
+			AND outcome_cohort_definition_id = @outcome_cohort_definition_id
 			AND analysis_id = 1805
 			GROUP BY exposure_cohort_definition_id, 
 				outcome_cohort_definition_id,
@@ -49,8 +49,8 @@ WITH denominator AS (
 				outcome_cohort_definition_id,
 				ROW_NUMBER() OVER (ORDER BY analysis_id) AS stratum_1, 0 AS count_value
 			FROM @ohdsi_database_schema.penelope_results
-			WHERE exposure_cohort_definition_id in ( @exposure_cohort_definition_id )
-			AND outcome_cohort_definition_id in ( @outcome_cohort_definition_id )
+			WHERE exposure_cohort_definition_id = @exposure_cohort_definition_id
+			AND outcome_cohort_definition_id = @outcome_cohort_definition_id
 			AND analysis_id = 1806
 
 			UNION
@@ -59,8 +59,8 @@ WITH denominator AS (
 				outcome_cohort_definition_id,
 				cast(stratum_2 AS INTEGER) as stratum_1, sum(count_value) as count_value
 			FROM @ohdsi_database_schema.penelope_results
-			WHERE exposure_cohort_definition_id in ( @exposure_cohort_definition_id )
-			AND outcome_cohort_definition_id in ( @outcome_cohort_definition_id )
+			WHERE exposure_cohort_definition_id = @exposure_cohort_definition_id
+			AND outcome_cohort_definition_id = @outcome_cohort_definition_id
 			AND analysis_id = 1806
 			GROUP BY exposure_cohort_definition_id, 
 				outcome_cohort_definition_id,
@@ -75,8 +75,8 @@ WITH denominator AS (
 				outcome_cohort_definition_id,
 				sum(count_value) as count_value
 			FROM @ohdsi_database_schema.penelope_results
-			WHERE exposure_cohort_definition_id in ( @exposure_cohort_definition_id )
-			AND outcome_cohort_definition_id in ( @outcome_cohort_definition_id )
+			WHERE exposure_cohort_definition_id = @exposure_cohort_definition_id
+			AND outcome_cohort_definition_id = @outcome_cohort_definition_id
 			AND analysis_id = 1
 			GROUP BY exposure_cohort_definition_id, 
 				outcome_cohort_definition_id
@@ -91,8 +91,8 @@ numerator_first as
 		CAST(stratum_1 AS INTEGER)*30 AS duration, 
 		count_value
 	FROM @ohdsi_database_schema.penelope_results
-	WHERE exposure_cohort_definition_id in ( @exposure_cohort_definition_id )
-	AND outcome_cohort_definition_id in ( @outcome_cohort_definition_id )
+	WHERE exposure_cohort_definition_id = @exposure_cohort_definition_id
+	AND outcome_cohort_definition_id = @outcome_cohort_definition_id
 	AND analysis_id = 12
 ),
 numerator_all as
@@ -102,8 +102,8 @@ numerator_all as
 		CAST(stratum_1 AS INTEGER)*30 AS duration, 
 		count_value
 	FROM @ohdsi_database_schema.penelope_results
-	WHERE exposure_cohort_definition_id in ( @exposure_cohort_definition_id )
-	AND outcome_cohort_definition_id in ( @outcome_cohort_definition_id )
+	WHERE exposure_cohort_definition_id = @exposure_cohort_definition_id
+	AND outcome_cohort_definition_id = @outcome_cohort_definition_id
 	AND analysis_id = 13
 )
 SELECT denominator.exposure_cohort_definition_id,

--- a/src/main/resources/resources/cohortresults/sql/cohortSpecific/observationPeriodTimeRelativeToIndex.sql
+++ b/src/main/resources/resources/cohortresults/sql/cohortSpecific/observationPeriodTimeRelativeToIndex.sql
@@ -11,7 +11,7 @@ select cohort_definition_id,
 	from
 	@ohdsi_database_schema.heracles_results
 	where analysis_id in (1805)
-	and cohort_definition_id in (@cohortDefinitionId)
+	and cohort_definition_id = @cohortDefinitionId
 	and cast(stratum_1 as integer) > 0
 
 	union
@@ -25,10 +25,10 @@ select cohort_definition_id,
 	(select cohort_definition_id, sum(count_value) as count_value 
 	from @ohdsi_database_schema.heracles_results 
 	where analysis_id = 1806
-	and cohort_definition_id in (@cohortDefinitionId)
+	and cohort_definition_id = @cohortDefinitionId
 	group by cohort_definition_id) t1
 	on hr1.cohort_definition_id = t1.cohort_definition_id
 	where hr1.analysis_id in (1806)
-	and hr1.cohort_definition_id in (@cohortDefinitionId)
+	and hr1.cohort_definition_id = @cohortDefinitionId
 ) hr1,
-(select count_value from @ohdsi_database_schema.heracles_results where analysis_id = 1 and cohort_definition_id in (@cohortDefinitionId)) t1
+(select count_value from @ohdsi_database_schema.heracles_results where analysis_id = 1 and cohort_definition_id = @cohortDefinitionId) t1

--- a/src/main/resources/resources/cohortresults/sql/cohortSpecific/personsInCohortFromCohortStartToEnd.sql
+++ b/src/main/resources/resources/cohortresults/sql/cohortSpecific/personsInCohortFromCohortStartToEnd.sql
@@ -2,6 +2,6 @@
 select cast(hr1.stratum_1 as int) as month_year, 
   hr1.count_value as count_value, 
 round(1.0*hr1.count_value / denom.count_value,5) as percent_value
-from (select * from @ohdsi_database_schema.heracles_results where analysis_id = 1804 and cohort_definition_id in (@cohortDefinitionId)) hr1,
-(select count_value from @ohdsi_database_schema.heracles_results where analysis_id = 1 and cohort_definition_id in (@cohortDefinitionId)) denom
+from (select * from @ohdsi_database_schema.heracles_results where analysis_id = 1804 and cohort_definition_id = @cohortDefinitionId) hr1,
+(select count_value from @ohdsi_database_schema.heracles_results where analysis_id = 1 and cohort_definition_id = @cohortDefinitionId) denom
 order by hr1.stratum_1 asc

--- a/src/main/resources/resources/cohortresults/sql/cohortSpecific/prevalenceByMonth.sql
+++ b/src/main/resources/resources/cohortresults/sql/cohortSpecific/prevalenceByMonth.sql
@@ -4,10 +4,10 @@ select hr1.stratum_1 as x_calendar_month,
 from (select stratum_1, count_value 
 	from @ohdsi_database_schema.heracles_results
 	where analysis_id in (1815)
-	and cohort_definition_id in (@cohortDefinitionId)
+	and cohort_definition_id = @cohortDefinitionId
 ) hr1
 	inner join 
 (
-	select stratum_1, count_value from @ohdsi_database_schema.heracles_results where analysis_id = 117 and cohort_definition_id in (@cohortDefinitionId)
+	select stratum_1, count_value from @ohdsi_database_schema.heracles_results where analysis_id = 117 and cohort_definition_id = @cohortDefinitionId
 ) t1
 on hr1.stratum_1 = t1.stratum_1

--- a/src/main/resources/resources/cohortresults/sql/cohortSpecific/prevalenceByYearGenderSex.sql
+++ b/src/main/resources/resources/cohortresults/sql/cohortSpecific/prevalenceByYearGenderSex.sql
@@ -13,7 +13,7 @@ from (select cohort_definition_id,
 	count_value 
 	from @ohdsi_database_schema.heracles_results
 	where analysis_id in (1814)
-	and cohort_definition_id in (@cohortDefinitionId)
+	and cohort_definition_id = @cohortDefinitionId
 	and cast(stratum_2 as integer) in (8507,8532)
 	and cast(stratum_3 as integer) >= 0 
 ) hr1
@@ -25,7 +25,7 @@ from (select cohort_definition_id,
 	count_value 
 	from @ohdsi_database_schema.heracles_results 
 	where analysis_id = 116
-	and cohort_definition_id in (@cohortDefinitionId)
+	and cohort_definition_id = @cohortDefinitionId
 ) t1
 on hr1.index_year = t1.index_year
 and hr1.gender_concept_id = t1.gender_concept_id

--- a/src/main/resources/resources/cohortresults/sql/cohortSpecific/procedureOccurrencePrevalenceOfDrug.sql
+++ b/src/main/resources/resources/cohortresults/sql/cohortSpecific/procedureOccurrencePrevalenceOfDrug.sql
@@ -34,7 +34,7 @@ from
 	sum(case when CAST(stratum_2 AS INT) > 0 then count_value else 0 end) as num_persons_after
 from @ohdsi_database_schema.heracles_results
 where analysis_id in (1830) --first occurrence of procedure
-and cohort_definition_id in (@cohortDefinitionId)
+and cohort_definition_id = @cohortDefinitionId
 group by stratum_1
 ) hr1
 inner join
@@ -147,5 +147,5 @@ inner join
 (select count_value
 from @ohdsi_database_schema.heracles_results
 where analysis_id = 1
-and cohort_definition_id in (@cohortDefinitionId)
+and cohort_definition_id = @cohortDefinitionId
 ) denom

--- a/src/main/resources/resources/cohortresults/sql/condition/byConcept/sqlAgeAtFirstDiagnosis.sql
+++ b/src/main/resources/resources/cohortresults/sql/condition/byConcept/sqlAgeAtFirstDiagnosis.sql
@@ -15,5 +15,5 @@
   	@cdm_database_schema.concept c2
   	on CAST(hrd1.stratum_2 AS INT) = c2.concept_id
   where hrd1.analysis_id = 406
-  and hrd1.cohort_definition_id in (@cohortDefinitionId)
+  and hrd1.cohort_definition_id = @cohortDefinitionId
   and c1.concept_id = @conceptId

--- a/src/main/resources/resources/cohortresults/sql/condition/byConcept/sqlConditionsByType.sql
+++ b/src/main/resources/resources/cohortresults/sql/condition/byConcept/sqlConditionsByType.sql
@@ -32,7 +32,7 @@ from @ohdsi_database_schema.heracles_results hr1
        ) c2
        on hr1.stratum_2 = CAST(c2.concept_id as VARCHAR(255))
 where hr1.analysis_id = 405
-and hr1.cohort_definition_id in (@cohortDefinitionId)
+and hr1.cohort_definition_id = @cohortDefinitionId
   and c1.concept_id = @conceptId
 group by c1.concept_id, 
        c1.concept_name,

--- a/src/main/resources/resources/cohortresults/sql/condition/byConcept/sqlPrevalenceByGenderAgeYear.sql
+++ b/src/main/resources/resources/cohortresults/sql/condition/byConcept/sqlPrevalenceByGenderAgeYear.sql
@@ -5,33 +5,32 @@ SELECT c1.concept_id AS concept_id,
 	num_stratum_2 AS x_calendar_year, -- calendar year, note, there could be blanks
 	ROUND(1000 * (1.0 * num_count_value / denom_count_value), 5) AS y_prevalence_1000pp --prevalence, per 1000 persons
 FROM (
-	SELECT num.stratum_1 AS num_stratum_1,
+	SELECT CAST(num.stratum_1 AS BIGINT) AS num_stratum_1,
 		CAST(num.stratum_2 AS INT) AS num_stratum_2,
-		CAST(num.stratum_3 AS INT) AS num_stratum_3,
+		CAST(num.stratum_3 AS BIGINT) AS num_stratum_3,
 		CAST(num.stratum_4 AS INT) AS num_stratum_4,
 		num.count_value AS num_count_value,
 		denom.count_value AS denom_count_value
 	FROM (
-		SELECT *
+		SELECT stratum_1, stratum_2, stratum_3, stratum_4, count_value
 		FROM @ohdsi_database_schema.heracles_results
 		WHERE analysis_id = 404
 			AND stratum_3 IN ('8507', '8532')
-			AND cohort_definition_id in (@cohortDefinitionId)
-		) num
+			AND cohort_definition_id = @cohortDefinitionId
+		GROUP BY stratum_1, stratum_2, stratum_3, stratum_4, count_value
+	) num
 	INNER JOIN (
-		SELECT *
+		SELECT stratum_1, stratum_2, stratum_3, count_value
 		FROM @ohdsi_database_schema.heracles_results
 		WHERE analysis_id = 116
 			AND stratum_2 IN ('8507', '8532')
-			AND cohort_definition_id in (@cohortDefinitionId)
-		) denom
-		ON num.stratum_2 = denom.stratum_1
+			AND cohort_definition_id = @cohortDefinitionId
+		GROUP BY stratum_1, stratum_2, stratum_3, count_value
+		) denom ON num.stratum_2 = denom.stratum_1
 			AND num.stratum_3 = denom.stratum_2
 			AND num.stratum_4 = denom.stratum_3
 	) tmp
-INNER JOIN @cdm_database_schema.concept c1
-	ON num_stratum_1 = CAST(c1.concept_id as VARCHAR(255))
-INNER JOIN @cdm_database_schema.concept c2
-	ON num_stratum_3 = c2.concept_id
+INNER JOIN @cdm_database_schema.concept c1 ON num_stratum_1 = c1.concept_id
+INNER JOIN @cdm_database_schema.concept c2 ON num_stratum_3 = c2.concept_id
 WHERE c1.concept_id = '@conceptId'
 ORDER BY c1.concept_id,	num_stratum_2

--- a/src/main/resources/resources/cohortresults/sql/condition/byConcept/sqlPrevalenceByMonth.sql
+++ b/src/main/resources/resources/cohortresults/sql/condition/byConcept/sqlPrevalenceByMonth.sql
@@ -1,14 +1,18 @@
-  select c1.concept_id as concept_id,  
-    c1.concept_name as concept_name,
-  	num.stratum_2 as x_calendar_month,   -- calendar year, note, there could be blanks
-  	round(1000*(1.0*num.count_value/denom.count_value),5) as y_prevalence_1000pp  --prevalence, per 1000 persons
-  from 
-  	(select * from @ohdsi_database_schema.heracles_results where analysis_id = 402 and cohort_definition_id in (@cohortDefinitionId)) num
-  	inner join
-  	(select * from @ohdsi_database_schema.heracles_results where analysis_id = 117 and cohort_definition_id in (@cohortDefinitionId)) denom
-  	on num.stratum_2 = denom.stratum_1  --calendar year
-  	inner join
-  	@cdm_database_schema.concept c1
-  	on num.stratum_1 = CAST(c1.concept_id as VARCHAR(255))
+select c1.concept_id as concept_id,  
+	c1.concept_name as concept_name,
+	num.stratum_2 as x_calendar_month,   -- calendar year, note, there could be blanks
+	round(1000*(1.0*num.count_value/denom.count_value),5) as y_prevalence_1000pp  --prevalence, per 1000 persons
+from (
+	select stratum_1, stratum_2, count_value
+	from @ohdsi_database_schema.heracles_results 
+	where analysis_id = 402 and cohort_definition_id = @cohortDefinitionId
+	group by stratum_1, stratum_2, count_value
+) num inner join (
+	select stratum_1, count_value 
+	from @ohdsi_database_schema.heracles_results 
+	where analysis_id = 117 and cohort_definition_id = @cohortDefinitionId
+	GROUP BY stratum_1, count_value
+) denom on num.stratum_2 = denom.stratum_1  --calendar year
+inner join @cdm_database_schema.concept c1 on CAST(num.stratum_1 AS BIGINT) = c1.concept_id
 WHERE c1.concept_id = '@conceptId'
 ORDER BY CAST(num.stratum_2 as INT)

--- a/src/main/resources/resources/cohortresults/sql/condition/sqlConditionTreemap.sql
+++ b/src/main/resources/resources/cohortresults/sql/condition/sqlConditionTreemap.sql
@@ -2,9 +2,9 @@ select   concept_hierarchy.concept_id,
   CONCAT(isNull(concept_hierarchy.soc_concept_name,'NA'), '||', isNull(concept_hierarchy.hlgt_concept_name,'NA'), '||', isNull(concept_hierarchy.hlt_concept_name,'NA'), '||', isNull(concept_hierarchy.pt_concept_name,'NA'), '||', isNull(concept_hierarchy.snomed_concept_name,'NA')) concept_path,	hr1.count_value as num_persons,
 	round(1.0*hr1.count_value / denom.count_value,5) as percent_persons,
 	round(1.0*hr2.count_value / hr1.count_value,5) as records_per_person
-from (select * from @ohdsi_database_schema.heracles_results where analysis_id = 400 and cohort_definition_id in (@cohortDefinitionId)) hr1
+from (select * from @ohdsi_database_schema.heracles_results where analysis_id = 400 and cohort_definition_id = @cohortDefinitionId) hr1
 	inner join
-	(select * from @ohdsi_database_schema.heracles_results where analysis_id = 401 and cohort_definition_id in (@cohortDefinitionId)) hr2
+	(select * from @ohdsi_database_schema.heracles_results where analysis_id = 401 and cohort_definition_id = @cohortDefinitionId) hr2
 	on hr1.stratum_1 = hr2.stratum_1
 	inner join
 	(
@@ -96,6 +96,6 @@ from (select * from @ohdsi_database_schema.heracles_results where analysis_id = 
 	) concept_hierarchy
 	on hr1.stratum_1 = CAST(concept_hierarchy.concept_id as VARCHAR(255))
 	,
-	(select count_value from @ohdsi_database_schema.heracles_results where analysis_id = 1 and cohort_definition_id in (@cohortDefinitionId)) denom
+	(select count_value from @ohdsi_database_schema.heracles_results where analysis_id = 1 and cohort_definition_id = @cohortDefinitionId) denom
 
 order by hr1.count_value desc

--- a/src/main/resources/resources/cohortresults/sql/conditionera/byConcept/sqlAgeAtFirstDiagnosis.sql
+++ b/src/main/resources/resources/cohortresults/sql/conditionera/byConcept/sqlAgeAtFirstDiagnosis.sql
@@ -13,6 +13,6 @@ from @ohdsi_database_schema.heracles_results_dist hrd1
 	inner join @cdm_database_schema.concept c2
 	on CAST(hrd1.stratum_2 AS INT) = c2.concept_id
 where hrd1.analysis_id = 1006
-and cohort_definition_id in (@cohortDefinitionId)
+and cohort_definition_id = @cohortDefinitionId
 and hrd1.count_value > 0
 and c1.concept_id = @conceptId

--- a/src/main/resources/resources/cohortresults/sql/conditionera/byConcept/sqlLengthOfEra.sql
+++ b/src/main/resources/resources/cohortresults/sql/conditionera/byConcept/sqlLengthOfEra.sql
@@ -10,7 +10,7 @@ select c1.concept_id as concept_id,
 from @ohdsi_database_schema.heracles_results_dist hrd1
 	inner join @cdm_database_schema.concept c1 on CAST(hrd1.stratum_1 as INT) = c1.concept_id
 where hrd1.analysis_id = 1007 and hrd1.count_value > 0
-and cohort_definition_id in (@cohortDefinitionId)
+and cohort_definition_id = @cohortDefinitionId
 and c1.concept_id = @conceptId
 
 

--- a/src/main/resources/resources/cohortresults/sql/conditionera/byConcept/sqlPrevalenceByGenderAgeYear.sql
+++ b/src/main/resources/resources/cohortresults/sql/conditionera/byConcept/sqlPrevalenceByGenderAgeYear.sql
@@ -4,34 +4,33 @@ SELECT c1.concept_id AS concept_id,
 	num_stratum_2 AS x_calendar_year, -- calendar year, note, there could be blanks
 	ROUND(1000 * (1.0 * num_count_value / denom_count_value), 5) AS y_prevalence_1000pp --prevalence, per 1000 persons
 FROM (
-	SELECT num.stratum_1 AS num_stratum_1,
+	SELECT CAST(num.stratum_1 AS BIGINT) AS num_stratum_1,
 		num.stratum_2 AS num_stratum_2,
-		num.stratum_3 AS num_stratum_3,
+		CAST(num.stratum_3 AS BIGINT) AS num_stratum_3,
 		num.stratum_4 AS num_stratum_4,
 		num.count_value AS num_count_value,
 		denom.count_value AS denom_count_value
 	FROM (
-		SELECT *
+		SELECT stratum_1, stratum_2, stratum_3, stratum_4, count_value
 		FROM @ohdsi_database_schema.heracles_results
 		WHERE analysis_id = 1004
 			AND stratum_3 IN ('8507', '8532')
-			AND cohort_definition_id in (@cohortDefinitionId)
-		) num
+			AND cohort_definition_id = @cohortDefinitionId
+		GROUP BY stratum_1, stratum_2, stratum_3, stratum_4, count_value
+	) num
 	INNER JOIN (
-		SELECT *
+		SELECT stratum_1, stratum_2, stratum_3, count_value
 		FROM @ohdsi_database_schema.heracles_results
 		WHERE analysis_id = 116
 			AND stratum_2 IN ('8507', '8532')
-			AND cohort_definition_id in (@cohortDefinitionId)
-		) denom
-		ON num.stratum_2 = denom.stratum_1
+			AND cohort_definition_id = @cohortDefinitionId
+		GROUP BY stratum_1, stratum_2, stratum_3, count_value
+	) denom ON num.stratum_2 = denom.stratum_1
 			AND num.stratum_3 = denom.stratum_2
 			AND num.stratum_4 = denom.stratum_3
-	) tmp
-INNER JOIN @cdm_database_schema.concept c1
-	ON num_stratum_1 = CAST(c1.concept_id as VARCHAR)
-INNER JOIN @cdm_database_schema.concept c2
-	ON num_stratum_3 = CAST(c2.concept_id as VARCHAR)
+) tmp
+INNER JOIN @cdm_database_schema.concept c1 ON num_stratum_1 = c1.concept_id
+INNER JOIN @cdm_database_schema.concept c2 ON num_stratum_3 = c2.concept_id
 WHERE c1.concept_id = @conceptId
 ORDER BY c1.concept_id,	num_stratum_2
 

--- a/src/main/resources/resources/cohortresults/sql/conditionera/byConcept/sqlPrevalenceByMonth.sql
+++ b/src/main/resources/resources/cohortresults/sql/conditionera/byConcept/sqlPrevalenceByMonth.sql
@@ -1,11 +1,16 @@
 select c1.concept_id as concept_id,
 	num.stratum_2 as x_calendar_month,
 	round(1000*(1.0*num.count_value/denom.count_value),5) as y_prevalence_1000pp
-from 
-	(select * from @ohdsi_database_schema.heracles_results where analysis_id = 1002 and cohort_definition_id in (@cohortDefinitionId)) num
-	inner join
-	(select * from @ohdsi_database_schema.heracles_results where analysis_id = 117 and cohort_definition_id in (@cohortDefinitionId)) denom
-	on num.stratum_2 = denom.stratum_1  --calendar year
-	inner join
-	@cdm_database_schema.concept c1 on num.stratum_1  = CAST(c1.concept_id as VARCHAR)
+from (
+	select stratum_1, stratum_2, count_value
+	from @ohdsi_database_schema.heracles_results 
+	where analysis_id = 1002 and cohort_definition_id = @cohortDefinitionId
+	group by stratum_1, stratum_2, count_value
+) num
+inner join (
+	select stratum_1, count_value 
+	from @ohdsi_database_schema.heracles_results where analysis_id = 117 and cohort_definition_id = @cohortDefinitionId
+	group by stratum_1, count_value 
+) denom on num.stratum_2 = denom.stratum_1  --calendar year
+inner join @cdm_database_schema.concept c1 on CAST(num.stratum_1 AS BIGINT)  = c1.concept_id
 WHERE c1.concept_id = @conceptId

--- a/src/main/resources/resources/cohortresults/sql/conditionera/sqlConditionEraTreemap.sql
+++ b/src/main/resources/resources/cohortresults/sql/conditionera/sqlConditionEraTreemap.sql
@@ -3,9 +3,9 @@ select 	concept_hierarchy.concept_id,
 	hr1.count_value as num_persons, 
 	ROUND(1.0*hr1.count_value / denom.count_value,5) as percent_persons,
 	ROUND(hr2.avg_value,5) as length_of_era
-from (select * from @ohdsi_database_schema.heracles_results where analysis_id = 1000 and cohort_definition_id in (@cohortDefinitionId)) hr1
+from (select * from @ohdsi_database_schema.heracles_results where analysis_id = 1000 and cohort_definition_id = @cohortDefinitionId) hr1
 	inner join
-	(select stratum_1, avg_value from @ohdsi_database_schema.heracles_results_dist where analysis_id = 1007 and cohort_definition_id in (@cohortDefinitionId)) hr2
+	(select stratum_1, avg_value from @ohdsi_database_schema.heracles_results_dist where analysis_id = 1007 and cohort_definition_id = @cohortDefinitionId) hr2
 	on hr1.stratum_1 = hr2.stratum_1
 	inner join
   (
@@ -97,5 +97,5 @@ from (select * from @ohdsi_database_schema.heracles_results where analysis_id = 
 	) concept_hierarchy
 	on hr1.stratum_1 = CAST(concept_hierarchy.concept_id as VARCHAR(255))
 	,
-	(select count_value from @ohdsi_database_schema.heracles_results where analysis_id = 1 and cohort_definition_id in (@cohortDefinitionId)) denom
+	(select count_value from @ohdsi_database_schema.heracles_results where analysis_id = 1 and cohort_definition_id = @cohortDefinitionId) denom
 order by hr1.count_value desc

--- a/src/main/resources/resources/cohortresults/sql/datadensity/conceptsperperson.sql
+++ b/src/main/resources/resources/cohortresults/sql/datadensity/conceptsperperson.sql
@@ -9,7 +9,7 @@ select 'Condition occurrence' as Category,
 	0 as concept_id
 from @ohdsi_database_schema.heracles_results_dist hrd1
 where hrd1.analysis_id = 403
-and cohort_definition_id in (@cohortDefinitionId)
+and cohort_definition_id = @cohortDefinitionId
 
 union
 
@@ -24,7 +24,7 @@ select 'Procedure occurrence' as Category,
 	0 as concept_id
 from @ohdsi_database_schema.heracles_results_dist hrd1
 where hrd1.analysis_id = 603
-and cohort_definition_id in (@cohortDefinitionId)
+and cohort_definition_id = @cohortDefinitionId
 
 union
 
@@ -39,7 +39,7 @@ select 'Drug exposure' as Category,
 	0 as concept_id
 from @ohdsi_database_schema.heracles_results_dist hrd1
 where hrd1.analysis_id = 703
-and cohort_definition_id in (@cohortDefinitionId)
+and cohort_definition_id = @cohortDefinitionId
 
 union
 
@@ -54,7 +54,7 @@ select 'Observation' as Category,
 	0 as concept_id
 from @ohdsi_database_schema.heracles_results_dist hrd1
 where hrd1.analysis_id = 803
-and cohort_definition_id in (@cohortDefinitionId)
+and cohort_definition_id = @cohortDefinitionId
 
 union
 
@@ -69,7 +69,7 @@ select 'Drug era' as Category,
 	0 as concept_id
 from @ohdsi_database_schema.heracles_results_dist hrd1
 where hrd1.analysis_id = 903
-and cohort_definition_id in (@cohortDefinitionId)
+and cohort_definition_id = @cohortDefinitionId
 union
 
 select 'Condition era' as Category,
@@ -83,5 +83,5 @@ select 'Condition era' as Category,
 	0 as concept_id
 from @ohdsi_database_schema.heracles_results_dist hrd1
 where hrd1.analysis_id = 1003
-and cohort_definition_id in (@cohortDefinitionId)
+and cohort_definition_id = @cohortDefinitionId
 

--- a/src/main/resources/resources/cohortresults/sql/datadensity/recordsperperson.sql
+++ b/src/main/resources/resources/cohortresults/sql/datadensity/recordsperperson.sql
@@ -3,25 +3,25 @@ select t1.table_name as SERIES_NAME,
 	round(1.0*t1.count_value/denom.count_value,5) as Y_RECORD_COUNT
 from
 (
-	select 'Visit occurrence' as table_name, stratum_1, count_value from @ohdsi_database_schema.heracles_results where analysis_id = 220 and cohort_definition_id in (@cohortDefinitionId)
+	select 'Visit occurrence' as table_name, stratum_1, count_value from @ohdsi_database_schema.heracles_results where analysis_id = 220 and cohort_definition_id = @cohortDefinitionId
 	union all
-	select 'Condition occurrence' as table_name, stratum_1, count_value from @ohdsi_database_schema.heracles_results where analysis_id = 420 and cohort_definition_id in (@cohortDefinitionId)
+	select 'Condition occurrence' as table_name, stratum_1, count_value from @ohdsi_database_schema.heracles_results where analysis_id = 420 and cohort_definition_id = @cohortDefinitionId
 	union all
-	select 'Death' as table_name, stratum_1, count_value from @ohdsi_database_schema.heracles_results where analysis_id = 502 and cohort_definition_id in (@cohortDefinitionId)
+	select 'Death' as table_name, stratum_1, count_value from @ohdsi_database_schema.heracles_results where analysis_id = 502 and cohort_definition_id = @cohortDefinitionId
 	union all
-	select 'Procedure occurrence' as table_name, stratum_1, count_value from @ohdsi_database_schema.heracles_results where analysis_id = 620 and cohort_definition_id in (@cohortDefinitionId)
+	select 'Procedure occurrence' as table_name, stratum_1, count_value from @ohdsi_database_schema.heracles_results where analysis_id = 620 and cohort_definition_id = @cohortDefinitionId
 	union all
-	select 'Drug exposure' as table_name, stratum_1, count_value from @ohdsi_database_schema.heracles_results where analysis_id = 720 and cohort_definition_id in (@cohortDefinitionId)
+	select 'Drug exposure' as table_name, stratum_1, count_value from @ohdsi_database_schema.heracles_results where analysis_id = 720 and cohort_definition_id = @cohortDefinitionId
 	union all
-	select 'Observation' as table_name, stratum_1, count_value from @ohdsi_database_schema.heracles_results where analysis_id = 820 and cohort_definition_id in (@cohortDefinitionId)
+	select 'Observation' as table_name, stratum_1, count_value from @ohdsi_database_schema.heracles_results where analysis_id = 820 and cohort_definition_id = @cohortDefinitionId
 	union all
-	select 'Drug era' as table_name, stratum_1, count_value from @ohdsi_database_schema.heracles_results where analysis_id = 920 and cohort_definition_id in (@cohortDefinitionId)
+	select 'Drug era' as table_name, stratum_1, count_value from @ohdsi_database_schema.heracles_results where analysis_id = 920 and cohort_definition_id = @cohortDefinitionId
 	union all
-	select 'Condition era' as table_name, stratum_1, count_value from @ohdsi_database_schema.heracles_results where analysis_id = 1020 and cohort_definition_id in (@cohortDefinitionId)
+	select 'Condition era' as table_name, stratum_1, count_value from @ohdsi_database_schema.heracles_results where analysis_id = 1020 and cohort_definition_id = @cohortDefinitionId
 	union all
-	select 'Observation period' as table_name, stratum_1, count_value from @ohdsi_database_schema.heracles_results where analysis_id = 111 and cohort_definition_id in (@cohortDefinitionId)
+	select 'Observation period' as table_name, stratum_1, count_value from @ohdsi_database_schema.heracles_results where analysis_id = 111 and cohort_definition_id = @cohortDefinitionId
 ) t1
 inner join
-(select * from @ohdsi_database_schema.heracles_results where analysis_id = 117 and cohort_definition_id in (@cohortDefinitionId)) denom
+(select * from @ohdsi_database_schema.heracles_results where analysis_id = 117 and cohort_definition_id = @cohortDefinitionId) denom
 on t1.stratum_1 = denom.stratum_1
 ORDER BY SERIES_NAME, CAST(t1.stratum_1 as INT)

--- a/src/main/resources/resources/cohortresults/sql/datadensity/totalrecords.sql
+++ b/src/main/resources/resources/cohortresults/sql/datadensity/totalrecords.sql
@@ -3,22 +3,22 @@ select table_name as SERIES_NAME,
 	count_value as Y_RECORD_COUNT
 from
 (
-	select 'Visit occurrence' as table_name, stratum_1, count_value from @ohdsi_database_schema.heracles_results where analysis_id = 220 and cohort_definition_id in (@cohortDefinitionId)
+	select 'Visit occurrence' as table_name, stratum_1, count_value from @ohdsi_database_schema.heracles_results where analysis_id = 220 and cohort_definition_id = @cohortDefinitionId
 	union all
-	select 'Condition occurrence' as table_name, stratum_1, count_value from @ohdsi_database_schema.heracles_results where analysis_id = 420 and cohort_definition_id in (@cohortDefinitionId)
+	select 'Condition occurrence' as table_name, stratum_1, count_value from @ohdsi_database_schema.heracles_results where analysis_id = 420 and cohort_definition_id = @cohortDefinitionId
 	union all
-	select 'Death' as table_name, stratum_1, count_value from @ohdsi_database_schema.heracles_results where analysis_id = 502 and cohort_definition_id in (@cohortDefinitionId)
+	select 'Death' as table_name, stratum_1, count_value from @ohdsi_database_schema.heracles_results where analysis_id = 502 and cohort_definition_id = @cohortDefinitionId
 	union all
-	select 'Procedure occurrence' as table_name, stratum_1, count_value from @ohdsi_database_schema.heracles_results where analysis_id = 620 and cohort_definition_id in (@cohortDefinitionId)
+	select 'Procedure occurrence' as table_name, stratum_1, count_value from @ohdsi_database_schema.heracles_results where analysis_id = 620 and cohort_definition_id = @cohortDefinitionId
 	union all
-	select 'Drug exposure' as table_name, stratum_1, count_value from @ohdsi_database_schema.heracles_results where analysis_id = 720 and cohort_definition_id in (@cohortDefinitionId)
+	select 'Drug exposure' as table_name, stratum_1, count_value from @ohdsi_database_schema.heracles_results where analysis_id = 720 and cohort_definition_id = @cohortDefinitionId
 	union all
-	select 'Observation' as table_name, stratum_1, count_value from @ohdsi_database_schema.heracles_results where analysis_id = 820 and cohort_definition_id in (@cohortDefinitionId)
+	select 'Observation' as table_name, stratum_1, count_value from @ohdsi_database_schema.heracles_results where analysis_id = 820 and cohort_definition_id = @cohortDefinitionId
 	union all
-	select 'Drug era' as table_name, stratum_1, count_value from @ohdsi_database_schema.heracles_results where analysis_id = 920 and cohort_definition_id in (@cohortDefinitionId)
+	select 'Drug era' as table_name, stratum_1, count_value from @ohdsi_database_schema.heracles_results where analysis_id = 920 and cohort_definition_id = @cohortDefinitionId
 	union all
-	select 'Condition era' as table_name, stratum_1, count_value from @ohdsi_database_schema.heracles_results where analysis_id = 1020 and cohort_definition_id in (@cohortDefinitionId)
+	select 'Condition era' as table_name, stratum_1, count_value from @ohdsi_database_schema.heracles_results where analysis_id = 1020 and cohort_definition_id = @cohortDefinitionId
 	union all
-	select 'Observation period' as table_name, stratum_1, count_value from @ohdsi_database_schema.heracles_results where analysis_id = 111 and cohort_definition_id in (@cohortDefinitionId)
+	select 'Observation period' as table_name, stratum_1, count_value from @ohdsi_database_schema.heracles_results where analysis_id = 111 and cohort_definition_id = @cohortDefinitionId
 ) t1
 ORDER BY SERIES_NAME, CAST(stratum_1 as INT)

--- a/src/main/resources/resources/cohortresults/sql/death/sqlAgeAtDeath.sql
+++ b/src/main/resources/resources/cohortresults/sql/death/sqlAgeAtDeath.sql
@@ -11,4 +11,4 @@ from @ohdsi_database_schema.heracles_results_dist hrd1
 	inner join
 	@cdm_database_schema.concept c2 on hrd1.stratum_1  =  CAST(c2.concept_id as VARCHAR)
 where hrd1.analysis_id = 506
-and cohort_definition_id in (@cohortDefinitionId)
+and cohort_definition_id = @cohortDefinitionId

--- a/src/main/resources/resources/cohortresults/sql/death/sqlDeathByType.sql
+++ b/src/main/resources/resources/cohortresults/sql/death/sqlDeathByType.sql
@@ -4,4 +4,4 @@ select c2.concept_id as concept_id,
 from @ohdsi_database_schema.heracles_results hr1
 	inner join  @cdm_database_schema.concept c2 on hr1.stratum_1 = CAST(c2.concept_id as VARCHAR(255))
 where hr1.analysis_id = 505
-and cohort_definition_id in (@cohortDefinitionId)
+and cohort_definition_id = @cohortDefinitionId

--- a/src/main/resources/resources/cohortresults/sql/death/sqlPrevalenceByGenderAgeYear.sql
+++ b/src/main/resources/resources/cohortresults/sql/death/sqlPrevalenceByGenderAgeYear.sql
@@ -4,9 +4,9 @@ select CONCAT(cast(cast(num.stratum_3 as int)*10 as varchar(11)), '-', cast((cas
 	ROUND(1000*(1.0*num.count_value/denom.count_value),5) as y_prevalence_1000pp,  --prevalence, per 1000 persons,
 	num.count_value as num_persons
 from 
-	(select * from @ohdsi_database_schema.heracles_results where analysis_id = 504 and cohort_definition_id in (@cohortDefinitionId)) num
+	(select * from @ohdsi_database_schema.heracles_results where analysis_id = 504 and cohort_definition_id = @cohortDefinitionId) num
 	inner join
-	(select * from @ohdsi_database_schema.heracles_results where analysis_id = 116 and cohort_definition_id in (@cohortDefinitionId)) denom on num.stratum_1 = denom.stratum_1  --calendar year
+	(select * from @ohdsi_database_schema.heracles_results where analysis_id = 116 and cohort_definition_id = @cohortDefinitionId) denom on num.stratum_1 = denom.stratum_1  --calendar year
 		and num.stratum_2 = denom.stratum_2 --gender
 		and num.stratum_3 = denom.stratum_3 --age decile
 	inner join @cdm_database_schema.concept c2 on num.stratum_2 = CAST(c2.concept_id as VARCHAR(255))

--- a/src/main/resources/resources/cohortresults/sql/death/sqlPrevalenceByMonth.sql
+++ b/src/main/resources/resources/cohortresults/sql/death/sqlPrevalenceByMonth.sql
@@ -2,7 +2,7 @@ select num.stratum_1 as x_calendar_month,   -- calendar year, note, there could 
 	1000*(1.0*num.count_value/denom.count_value) as y_prevalence_1000pp,  --prevalence, per 1000 persons
 	0 as concept_id
 from 
-	(select * from @ohdsi_database_schema.heracles_results where analysis_id = 502 and cohort_definition_id in (@cohortDefinitionId)) num
+	(select * from @ohdsi_database_schema.heracles_results where analysis_id = 502 and cohort_definition_id = @cohortDefinitionId) num
 	inner join
-	(select * from @ohdsi_database_schema.heracles_results where analysis_id = 117 and cohort_definition_id in (@cohortDefinitionId)) denom on num.stratum_1 = denom.stratum_1  --calendar year
+	(select * from @ohdsi_database_schema.heracles_results where analysis_id = 117 and cohort_definition_id = @cohortDefinitionId) denom on num.stratum_1 = denom.stratum_1  --calendar year
 ORDER BY CAST(num.stratum_1 as INT)

--- a/src/main/resources/resources/cohortresults/sql/drug/byConcept/sqlAgeAtFirstExposure.sql
+++ b/src/main/resources/resources/cohortresults/sql/drug/byConcept/sqlAgeAtFirstExposure.sql
@@ -15,6 +15,6 @@ from @ohdsi_database_schema.heracles_results_dist hrd1
 	@cdm_database_schema.concept c2
 	on hrd1.stratum_2 = CAST(c2.concept_id AS VARCHAR)
 where hrd1.analysis_id = 706
-and cohort_definition_id in (@cohortDefinitionId)
+and cohort_definition_id = @cohortDefinitionId
 and hrd1.count_value > 0
 and c1.concept_id = @conceptId

--- a/src/main/resources/resources/cohortresults/sql/drug/byConcept/sqlDaysSupplyDistribution.sql
+++ b/src/main/resources/resources/cohortresults/sql/drug/byConcept/sqlDaysSupplyDistribution.sql
@@ -13,5 +13,5 @@ from @ohdsi_database_schema.heracles_results_dist hrd1
 	on CAST(hrd1.stratum_1 AS INT) = c1.concept_id
 where hrd1.analysis_id = 715
 and hrd1.count_value > 0
-and cohort_definition_id in (@cohortDefinitionId)
+and cohort_definition_id = @cohortDefinitionId
 and c1.concept_id = @conceptId

--- a/src/main/resources/resources/cohortresults/sql/drug/byConcept/sqlDrugsByType.sql
+++ b/src/main/resources/resources/cohortresults/sql/drug/byConcept/sqlDrugsByType.sql
@@ -10,5 +10,5 @@ from @ohdsi_database_schema.heracles_results hr1
 	@cdm_database_schema.concept c2
 	on hr1.stratum_2  = CAST(c2.concept_id AS VARCHAR)
 where hr1.analysis_id = 705
-and cohort_definition_id in (@cohortDefinitionId)
+and cohort_definition_id = @cohortDefinitionId
 and c1.concept_id = @conceptId

--- a/src/main/resources/resources/cohortresults/sql/drug/byConcept/sqlPrevalenceByGenderAgeYear.sql
+++ b/src/main/resources/resources/cohortresults/sql/drug/byConcept/sqlPrevalenceByGenderAgeYear.sql
@@ -5,34 +5,32 @@ SELECT c1.concept_id AS concept_id,
 	num_stratum_2 AS x_calendar_year, -- calendar year, note, there could be blanks
 	ROUND(1000 * (1.0 * num_count_value / denom_count_value), 5) AS y_prevalence_1000pp --prevalence, per 1000 persons
 FROM (
-	SELECT num.stratum_1 AS num_stratum_1,
+	SELECT CAST(num.stratum_1 AS BIGINT) AS num_stratum_1,
 		CAST(num.stratum_2 AS INT) AS num_stratum_2,
-		num.stratum_3 AS num_stratum_3,
+		CAST(num.stratum_3 AS BIGINT) AS num_stratum_3,
 		CAST(num.stratum_4 AS INT) AS num_stratum_4,
 		num.count_value AS num_count_value,
 		denom.count_value AS denom_count_value
 	FROM (
-		SELECT *
+		SELECT stratum_1, stratum_2, stratum_3, stratum_4, count_value
 		FROM @ohdsi_database_schema.heracles_results
 		WHERE analysis_id = 704
 			AND stratum_3 IN ('8507', '8532')
-			AND cohort_definition_id in (@cohortDefinitionId)
+			AND cohort_definition_id = @cohortDefinitionId
+		GROUP BY stratum_1, stratum_2, stratum_3, stratum_4, count_value
 		) num
 	INNER JOIN (
-		SELECT *
+		SELECT stratum_1, stratum_2, stratum_3, count_value
 		FROM @ohdsi_database_schema.heracles_results
 		WHERE analysis_id = 116
 			AND stratum_2 IN ('8507', '8532')
-			AND cohort_definition_id in (@cohortDefinitionId)
-		) denom
-		ON num.stratum_2 = denom.stratum_1
+			AND cohort_definition_id = @cohortDefinitionId
+		GROUP BY stratum_1, stratum_2, stratum_3, count_value
+	) denom ON num.stratum_2 = denom.stratum_1
 			AND num.stratum_3 = denom.stratum_2
 			AND num.stratum_4 = denom.stratum_3
 	) tmp
-INNER JOIN @cdm_database_schema.concept c1
-	ON num_stratum_1 = CAST(c1.concept_id as VARCHAR)
-INNER JOIN @cdm_database_schema.concept c2
-	ON num_stratum_3 = CAST(c2.concept_id as VARCHAR)
+INNER JOIN @cdm_database_schema.concept c1 ON num_stratum_1 = c1.concept_id
+INNER JOIN @cdm_database_schema.concept c2 ON num_stratum_3 = c2.concept_id
 WHERE c1.concept_id = @conceptId
-ORDER BY c1.concept_id,
-	num_stratum_2
+ORDER BY c1.concept_id, num_stratum_2

--- a/src/main/resources/resources/cohortresults/sql/drug/byConcept/sqlPrevalenceByMonth.sql
+++ b/src/main/resources/resources/cohortresults/sql/drug/byConcept/sqlPrevalenceByMonth.sql
@@ -2,13 +2,18 @@ select c1.concept_id as concept_id,
 	c1.concept_name as concept_name,
 	num.stratum_2 as x_calendar_month,
 	round(1000*(1.0*num.count_value/denom.count_value),5) as y_prevalence_1000pp
-from 
-	(select * from @ohdsi_database_schema.heracles_results where analysis_id = 702 and cohort_definition_id in (@cohortDefinitionId)) num
-	inner join
-	(select * from @ohdsi_database_schema.heracles_results where analysis_id = 117 and cohort_definition_id in (@cohortDefinitionId)) denom
-	on num.stratum_2 = denom.stratum_1  --calendar year
-	inner join
-	@cdm_database_schema.concept c1
-	on num.stratum_1 = CAST(c1.concept_id as VARCHAR)
+from (
+	select stratum_1, stratum_2, count_value 
+	from @ohdsi_database_schema.heracles_results 
+	where analysis_id = 702 and cohort_definition_id = @cohortDefinitionId
+	group by stratum_1, stratum_2, count_value
+) num
+inner join (
+	select stratum_1, count_value 
+	from @ohdsi_database_schema.heracles_results 
+	where analysis_id = 117 and cohort_definition_id = @cohortDefinitionId
+	group by stratum_1, count_value
+) denom on num.stratum_2 = denom.stratum_1  --calendar year
+inner join @cdm_database_schema.concept c1 on CAST(num.stratum_1 AS BIGINT) = c1.concept_id
 WHERE c1.concept_id = @conceptId
 ORDER BY CAST(num.stratum_2 as INT)

--- a/src/main/resources/resources/cohortresults/sql/drug/byConcept/sqlQuantityDistribution.sql
+++ b/src/main/resources/resources/cohortresults/sql/drug/byConcept/sqlQuantityDistribution.sql
@@ -12,6 +12,6 @@ from @ohdsi_database_schema.heracles_results_dist hrd1
 	@cdm_database_schema.concept c1
 	on CAST(hrd1.stratum_1 AS INT) = c1.concept_id
 where hrd1.analysis_id = 717
-and cohort_definition_id in (@cohortDefinitionId)
+and cohort_definition_id = @cohortDefinitionId
 and hrd1.count_value > 0
 and c1.concept_id = @conceptId

--- a/src/main/resources/resources/cohortresults/sql/drug/byConcept/sqlRefillsDistribution.sql
+++ b/src/main/resources/resources/cohortresults/sql/drug/byConcept/sqlRefillsDistribution.sql
@@ -12,6 +12,6 @@ from @ohdsi_database_schema.heracles_results_dist hrd1
 	@cdm_database_schema.concept c1
 	on hrd1.stratum_1 = CAST(c1.concept_id as VARCHAR(255))
 where hrd1.analysis_id = 716
-and cohort_definition_id in (@cohortDefinitionId)
+and cohort_definition_id = @cohortDefinitionId
 and hrd1.count_value > 0
 and c1.concept_id = @conceptId

--- a/src/main/resources/resources/cohortresults/sql/drug/sqlDrugTreemap.sql
+++ b/src/main/resources/resources/cohortresults/sql/drug/sqlDrugTreemap.sql
@@ -9,9 +9,9 @@ select 	concept_hierarchy.concept_id,
 	hr1.count_value as num_persons, 
 	round(1.0*hr1.count_value / denom.count_value,5) as percent_persons,
 	round(1.0*hr2.count_value / hr1.count_value,5) as records_per_person
-from (select * from @ohdsi_database_schema.heracles_results where analysis_id = 700 and cohort_definition_id in (@cohortDefinitionId)) hr1
+from (select * from @ohdsi_database_schema.heracles_results where analysis_id = 700 and cohort_definition_id = @cohortDefinitionId) hr1
 	inner join
-	(select * from @ohdsi_database_schema.heracles_results where analysis_id = 701 and cohort_definition_id in (@cohortDefinitionId)) hr2
+	(select * from @ohdsi_database_schema.heracles_results where analysis_id = 701 and cohort_definition_id = @cohortDefinitionId) hr2
 	on hr1.stratum_1 = hr2.stratum_1
 	inner join
 	(
@@ -95,6 +95,6 @@ from (select * from @ohdsi_database_schema.heracles_results where analysis_id = 
 	) concept_hierarchy
 	on hr1.stratum_1 = CAST(concept_hierarchy.concept_id AS VARCHAR)
 	,
-	(select count_value from @ohdsi_database_schema.heracles_results where analysis_id = 1 and cohort_definition_id in (@cohortDefinitionId)) denom
+	(select count_value from @ohdsi_database_schema.heracles_results where analysis_id = 1 and cohort_definition_id = @cohortDefinitionId) denom
 
 order by hr1.count_value desc

--- a/src/main/resources/resources/cohortresults/sql/drugera/byConcept/sqlAgeAtFirstExposure.sql
+++ b/src/main/resources/resources/cohortresults/sql/drugera/byConcept/sqlAgeAtFirstExposure.sql
@@ -15,6 +15,6 @@ from @ohdsi_database_schema.heracles_results_dist hrd1
 	@cdm_database_schema.concept c2
 	on hrd1.stratum_2 = cast(c2.concept_id as VARCHAR)
 where hrd1.analysis_id = 906
-and cohort_definition_id in (@cohortDefinitionId)
+and cohort_definition_id = @cohortDefinitionId
 and hrd1.count_value > 0
 and c1.concept_id = @conceptId

--- a/src/main/resources/resources/cohortresults/sql/drugera/byConcept/sqlLengthOfEra.sql
+++ b/src/main/resources/resources/cohortresults/sql/drugera/byConcept/sqlLengthOfEra.sql
@@ -12,6 +12,6 @@ from @ohdsi_database_schema.heracles_results_dist hrd1
 	@cdm_database_schema.concept c1
 	on hrd1.stratum_1 = CAST(c1.concept_id as VARCHAR)
 where hrd1.analysis_id = 907
-and cohort_definition_id in (@cohortDefinitionId)
+and cohort_definition_id = @cohortDefinitionId
 and hrd1.count_value > 0
 and c1.concept_id = @conceptId

--- a/src/main/resources/resources/cohortresults/sql/drugera/byConcept/sqlPrevalenceByGenderAgeYear.sql
+++ b/src/main/resources/resources/cohortresults/sql/drugera/byConcept/sqlPrevalenceByGenderAgeYear.sql
@@ -4,33 +4,33 @@ SELECT c1.concept_id AS concept_id,
 	num_stratum_2 AS x_calendar_year, -- calendar year, note, there could be blanks
 	ROUND(1000 * (1.0 * num_count_value / denom_count_value), 5) AS y_prevalence_1000pp --prevalence, per 1000 persons
 FROM (
-	SELECT num.stratum_1 num_stratum_1,
+	SELECT CAST(num.stratum_1 AS BIGINT) AS num_stratum_1,
 		CAST(num.stratum_2 AS INT) AS num_stratum_2,
-		num.stratum_3 num_stratum_3,
+		CAST(num.stratum_3 AS BIGINT) AS num_stratum_3,
 		CAST(num.stratum_4 AS INT) AS num_stratum_4,
 		num.count_value AS num_count_value,
 		denom.count_value AS denom_count_value
 	FROM (
-		SELECT *
+		SELECT stratum_1, stratum_2, stratum_3, stratum_4, count_value
 		FROM @ohdsi_database_schema.heracles_results
 		WHERE analysis_id = 904
 			AND stratum_3 IN ('8507', '8532')
-			and cohort_definition_id in (@cohortDefinitionId)
+			and cohort_definition_id = @cohortDefinitionId
+		GROUP BY stratum_1, stratum_2, stratum_3, stratum_4, count_value
 		) num
 	INNER JOIN (
-		SELECT *
+		SELECT stratum_1, stratum_2, stratum_3, count_value
 		FROM @ohdsi_database_schema.heracles_results
 		WHERE analysis_id = 116
 			AND stratum_2 IN ('8507', '8532')
-			and cohort_definition_id in (@cohortDefinitionId)
+			and cohort_definition_id = @cohortDefinitionId
+		GROUP BY stratum_1, stratum_2, stratum_3, count_value
 		) denom
 		ON num.stratum_2 = denom.stratum_1
 			AND num.stratum_3 = denom.stratum_2
 			AND num.stratum_4 = denom.stratum_3
 	) tmp
-INNER JOIN @cdm_database_schema.concept c1
-	ON num_stratum_1 = CAST(c1.concept_id as VARCHAR)
-INNER JOIN @cdm_database_schema.concept c2
-	ON num_stratum_3 = CAST(c2.concept_id as VARCHAR)
+INNER JOIN @cdm_database_schema.concept c1 ON num_stratum_1 = c1.concept_id
+INNER JOIN @cdm_database_schema.concept c2 ON num_stratum_3 = c2.concept_id
 WHERE c1.concept_id = @conceptId
 ORDER BY c1.concept_id,	num_stratum_2

--- a/src/main/resources/resources/cohortresults/sql/drugera/byConcept/sqlPrevalenceByMonth.sql
+++ b/src/main/resources/resources/cohortresults/sql/drugera/byConcept/sqlPrevalenceByMonth.sql
@@ -1,13 +1,18 @@
 select c1.concept_id as concept_id,
 	num.stratum_2 as x_calendar_month,
 	round(1000*(1.0*num.count_value/denom.count_value),5) as y_prevalence_1000pp
-from 
-	(select * from @ohdsi_database_schema.heracles_results where analysis_id = 902 and cohort_definition_id in (@cohortDefinitionId)) num
-	inner join
-	(select * from @ohdsi_database_schema.heracles_results where analysis_id = 117 and cohort_definition_id in (@cohortDefinitionId)) denom
-	on num.stratum_2 = denom.stratum_1  
-	inner join
-	@cdm_database_schema.concept c1
-	on num.stratum_1 = CAST(c1.concept_id as VARCHAR)
+from (
+	select stratum_1, stratum_2, count_value 
+	from @ohdsi_database_schema.heracles_results 
+	where analysis_id = 902 and cohort_definition_id = @cohortDefinitionId
+	group by stratum_1, stratum_2, count_value
+) num
+inner join (
+	select stratum_1, count_value 
+	from @ohdsi_database_schema.heracles_results 
+	where analysis_id = 117 and cohort_definition_id = @cohortDefinitionId
+	group by stratum_1, count_value
+) denom on num.stratum_2 = denom.stratum_1  
+inner join @cdm_database_schema.concept c1 on CAST(num.stratum_1 AS BIGINT) = c1.concept_id
 WHERE c1.concept_id = @conceptId
 ORDER BY CAST(num.stratum_2 as INT)

--- a/src/main/resources/resources/cohortresults/sql/drugera/sqlDrugEraTreemap.sql
+++ b/src/main/resources/resources/cohortresults/sql/drugera/sqlDrugEraTreemap.sql
@@ -8,9 +8,9 @@ select concept_hierarchy.rxnorm_ingredient_concept_id concept_id,
 	hr1.count_value as num_persons, 
 	1.0*hr1.count_value / denom.count_value as percent_persons,
 	hr2.avg_value as length_of_era
-from (select * from @ohdsi_database_schema.heracles_results where analysis_id = 900 and cohort_definition_id in (@cohortDefinitionId)) hr1
+from (select * from @ohdsi_database_schema.heracles_results where analysis_id = 900 and cohort_definition_id = @cohortDefinitionId) hr1
 	inner join
-	(select stratum_1, avg_value from @ohdsi_database_schema.heracles_results_dist where analysis_id = 907 and cohort_definition_id in (@cohortDefinitionId)) hr2
+	(select stratum_1, avg_value from @ohdsi_database_schema.heracles_results_dist where analysis_id = 907 and cohort_definition_id = @cohortDefinitionId) hr2
 	on hr1.stratum_1 = hr2.stratum_1
 	inner join
 	(
@@ -88,5 +88,5 @@ from (select * from @ohdsi_database_schema.heracles_results where analysis_id = 
 	) concept_hierarchy
 	on hr1.stratum_1 = CAST(concept_hierarchy.rxnorm_ingredient_concept_id AS VARCHAR)
 	,
-	(select count_value from @ohdsi_database_schema.heracles_results where analysis_id = 1 and cohort_definition_id in (@cohortDefinitionId)) denom
+	(select count_value from @ohdsi_database_schema.heracles_results where analysis_id = 1 and cohort_definition_id = @cohortDefinitionId) denom
 order by hr1.count_value desc

--- a/src/main/resources/resources/cohortresults/sql/heraclesHeel/sqlHeraclesHeel.sql
+++ b/src/main/resources/resources/cohortresults/sql/heraclesHeel/sqlHeraclesHeel.sql
@@ -1,4 +1,4 @@
 select analysis_id as ATTRIBUTE_NAME, HERACLES_HEEL_warning as ATTRIBUTE_VALUE
 from @ohdsi_database_schema.HERACLES_HEEL_results
-where cohort_definition_id in (@cohortDefinitionId)
+where cohort_definition_id = @cohortDefinitionId
 order by case when left(HERACLES_HEEL_warning,5) = 'Error' then 1 else 2 end, analysis_id

--- a/src/main/resources/resources/cohortresults/sql/measurement/byConcept/sqlAgeAtFirstOccurrence.sql
+++ b/src/main/resources/resources/cohortresults/sql/measurement/byConcept/sqlAgeAtFirstOccurrence.sql
@@ -12,4 +12,4 @@ from @ohdsi_database_schema.heracles_results_dist hrd1
 	inner join @cdm_database_schema.concept c2 on hrd1.stratum_2 = CAST(c2.concept_id as VARCHAR)
 where hrd1.analysis_id = 1306
   and c1.concept_id = @conceptId
-and cohort_definition_id in (@cohortDefinitionId)
+and cohort_definition_id = @cohortDefinitionId

--- a/src/main/resources/resources/cohortresults/sql/measurement/byConcept/sqlLowerLimitDistribution.sql
+++ b/src/main/resources/resources/cohortresults/sql/measurement/byConcept/sqlLowerLimitDistribution.sql
@@ -13,4 +13,4 @@ from @ohdsi_database_schema.heracles_results_dist hrd1
 where hrd1.analysis_id = 1316
 and hrd1.count_value > 0
   and c1.concept_id = @conceptId
-and cohort_definition_id in (@cohortDefinitionId)
+and cohort_definition_id = @cohortDefinitionId

--- a/src/main/resources/resources/cohortresults/sql/measurement/byConcept/sqlMeasurementValueDistribution.sql
+++ b/src/main/resources/resources/cohortresults/sql/measurement/byConcept/sqlMeasurementValueDistribution.sql
@@ -13,5 +13,5 @@ from @ohdsi_database_schema.heracles_results_dist hrd1
 where hrd1.analysis_id = 1315
 and hrd1.count_value > 0
   and c1.concept_id = @conceptId
-and cohort_definition_id in (@cohortDefinitionId)
+and cohort_definition_id = @cohortDefinitionId
 

--- a/src/main/resources/resources/cohortresults/sql/measurement/byConcept/sqlMeasurementssByType.sql
+++ b/src/main/resources/resources/cohortresults/sql/measurement/byConcept/sqlMeasurementssByType.sql
@@ -8,4 +8,4 @@ from @ohdsi_database_schema.heracles_results hr1
 	inner join @cdm_database_schema.concept c2 on hr1.stratum_2 = CAST(c2.concept_id as VARCHAR)
 where hr1.analysis_id = 1305
   and c1.concept_id = @conceptId
-and cohort_definition_id in (@cohortDefinitionId)
+and cohort_definition_id = @cohortDefinitionId

--- a/src/main/resources/resources/cohortresults/sql/measurement/byConcept/sqlPrevalenceByGenderAgeYear.sql
+++ b/src/main/resources/resources/cohortresults/sql/measurement/byConcept/sqlPrevalenceByGenderAgeYear.sql
@@ -5,34 +5,32 @@ SELECT c1.concept_id AS concept_id,
 	num_stratum_2 AS x_calendar_year, -- calendar year, note, there could be blanks
 	ROUND(1000 * (1.0 * num_count_value / denom_count_value), 5) AS y_prevalence_1000pp --prevalence, per 1000 persons
 FROM (
-	SELECT CAST(num.stratum_1 AS INT) AS num_stratum_1,
+	SELECT CAST(num.stratum_1 AS BIGINT) AS num_stratum_1,
 		CAST(num.stratum_2 AS INT) AS num_stratum_2,
-		CAST(num.stratum_3 AS INT) AS num_stratum_3,
+		CAST(num.stratum_3 AS BIGINT) AS num_stratum_3,
 		CAST(num.stratum_4 AS INT) AS num_stratum_4,
 		num.count_value AS num_count_value,
 		denom.count_value AS denom_count_value
 	FROM (
-		SELECT *
+		SELECT stratum_1, stratum_2, statum_3, stratum_4, count_value
 		FROM @ohdsi_database_schema.heracles_results
 		WHERE analysis_id = 1304
 			AND stratum_3 IN ('8507', '8532')
-			and cohort_definition_id in (@cohortDefinitionId)
+			and cohort_definition_id = @cohortDefinitionId
+		GROUP BY stratum_1, stratum_2, statum_3, stratum_4, count_value
 		) num
 	INNER JOIN (
-		SELECT *
+		SELECT stratum_1, stratum_2, statum_3, count_value
 		FROM @ohdsi_database_schema.heracles_results
 		WHERE analysis_id = 116
 			AND stratum_2 IN ('8507', '8532')
-			and cohort_definition_id in (@cohortDefinitionId)
-		) denom
-		ON num.stratum_2 = denom.stratum_1
+			and cohort_definition_id = @cohortDefinitionId
+		GROUP BY stratum_1, stratum_2, statum_3, count_value
+		) denom ON num.stratum_2 = denom.stratum_1
 			AND num.stratum_3 = denom.stratum_2
 			AND num.stratum_4 = denom.stratum_3
 	) tmp
-INNER JOIN @cdm_database_schema.concept c1
-	ON num_stratum_1 = c1.concept_id
-INNER JOIN @cdm_database_schema.concept c2
-	ON num_stratum_3 = c2.concept_id
+INNER JOIN @cdm_database_schema.concept c1 ON num_stratum_1 = c1.concept_id
+INNER JOIN @cdm_database_schema.concept c2 ON num_stratum_3 = c2.concept_id
 WHERE c1.concept_id = @conceptId
-ORDER BY c1.concept_id,
-	num_stratum_2
+ORDER BY c1.concept_id, num_stratum_2

--- a/src/main/resources/resources/cohortresults/sql/measurement/byConcept/sqlPrevalenceByMonth.sql
+++ b/src/main/resources/resources/cohortresults/sql/measurement/byConcept/sqlPrevalenceByMonth.sql
@@ -2,10 +2,18 @@ select c1.concept_id as CONCEPT_ID,  --all rows for all concepts, but you may sp
 	c1.concept_name as CONCEPT_NAME,
 	num.stratum_2 as X_CALENDAR_MONTH,   -- calendar year, note, there could be blanks
 	round(1000*(1.0*num.count_value/denom.count_value),5) as Y_PREVALENCE_1000PP  --prevalence, per 1000 persons
-from 
-	(select * from @ohdsi_database_schema.heracles_results where analysis_id = 1302 and cohort_definition_id in (@cohortDefinitionId)) num
-	inner join
-	(select * from @ohdsi_database_schema.heracles_results where analysis_id = 117 and cohort_definition_id in (@cohortDefinitionId)) denom on num.stratum_2 = denom.stratum_1  --calendar year
-	inner join @cdm_database_schema.concept c1 on num.stratum_1 = CAST(c1.concept_id as VARCHAR)
+from (
+	select stratum_1, stratum_2, count_value 
+	from @ohdsi_database_schema.heracles_results 
+	where analysis_id = 1302 and cohort_definition_id = @cohortDefinitionId
+	group by stratum_1, stratum_2, count_value 
+) num
+inner join (
+	select stratum_1, count_value 
+	from @ohdsi_database_schema.heracles_results 
+	where analysis_id = 117 and cohort_definition_id = @cohortDefinitionId
+	group by stratum_1, count_value 
+) denom on num.stratum_2 = denom.stratum_1  --calendar year
+inner join @cdm_database_schema.concept c1 on CAST(num.stratum_1 AS BIGINT) = c1.concept_id
 WHERE c1.concept_id = @conceptId
 ORDER BY CAST(num.stratum_2 as INT)

--- a/src/main/resources/resources/cohortresults/sql/measurement/byConcept/sqlRecordsByUnit.sql
+++ b/src/main/resources/resources/cohortresults/sql/measurement/byConcept/sqlRecordsByUnit.sql
@@ -8,4 +8,4 @@ from @ohdsi_database_schema.heracles_results hr1
 	inner join @cdm_database_schema.concept c2 on hr1.stratum_2 = CAST(c2.concept_id as VARCHAR)
 where hr1.analysis_id = 1307
   and c1.concept_id = @conceptId
-and cohort_definition_id in (@cohortDefinitionId)
+and cohort_definition_id = @cohortDefinitionId

--- a/src/main/resources/resources/cohortresults/sql/measurement/byConcept/sqlUpperLimitDistribution.sql
+++ b/src/main/resources/resources/cohortresults/sql/measurement/byConcept/sqlUpperLimitDistribution.sql
@@ -13,4 +13,4 @@ from @ohdsi_database_schema.heracles_results_dist hrd1
 where hrd1.analysis_id = 1317
 and hrd1.count_value > 0
   and c1.concept_id = @conceptId
-and cohort_definition_id in (@cohortDefinitionId)
+and cohort_definition_id = @cohortDefinitionId

--- a/src/main/resources/resources/cohortresults/sql/measurement/byConcept/sqlValuesRelativeToNorm.sql
+++ b/src/main/resources/resources/cohortresults/sql/measurement/byConcept/sqlValuesRelativeToNorm.sql
@@ -8,4 +8,4 @@ from @ohdsi_database_schema.heracles_results hr1
 	inner join @cdm_database_schema.concept c2 on hr1.stratum_2 = CAST(c2.concept_id as VARCHAR)
 where hr1.analysis_id = 1318
   and c1.concept_id = @conceptId
-and cohort_definition_id in (@cohortDefinitionId)
+and cohort_definition_id = @cohortDefinitionId

--- a/src/main/resources/resources/cohortresults/sql/measurement/sqlMeasurementTreemap.sql
+++ b/src/main/resources/resources/cohortresults/sql/measurement/sqlMeasurementTreemap.sql
@@ -8,9 +8,9 @@ select 	concept_hierarchy.concept_id,
 	hr1.count_value as num_persons, 
 	1.0*hr1.count_value / denom.count_value as percent_persons,
 	1.0*hr2.count_value / hr1.count_value as records_per_person
-from (select * from @ohdsi_database_schema.heracles_results where analysis_id = 1300 and cohort_definition_id in (@cohortDefinitionId)) hr1
+from (select * from @ohdsi_database_schema.heracles_results where analysis_id = 1300 and cohort_definition_id = @cohortDefinitionId) hr1
 	inner join
-	(select * from @ohdsi_database_schema.heracles_results where analysis_id = 1301 and cohort_definition_id in (@cohortDefinitionId)) hr2
+	(select * from @ohdsi_database_schema.heracles_results where analysis_id = 1301 and cohort_definition_id = @cohortDefinitionId) hr2
 	on hr1.stratum_1 = hr2.stratum_1
 	inner join
 	(
@@ -28,5 +28,5 @@ from (select * from @ohdsi_database_schema.heracles_results where analysis_id = 
 		left join @cdm_database_schema.concept c3 on ca3.ANCESTOR_CONCEPT_ID = c3.concept_id
 		group by obs.concept_id, obs.concept_name
 	) concept_hierarchy on hr1.stratum_1 = CAST(concept_hierarchy.concept_id as VARCHAR),
-	(select count_value from @ohdsi_database_schema.heracles_results where analysis_id = 1 and cohort_definition_id in (@cohortDefinitionId)) denom
+	(select count_value from @ohdsi_database_schema.heracles_results where analysis_id = 1 and cohort_definition_id = @cohortDefinitionId) denom
 order by hr1.count_value desc

--- a/src/main/resources/resources/cohortresults/sql/observation/byConcept/sqlAgeAtFirstOccurrence.sql
+++ b/src/main/resources/resources/cohortresults/sql/observation/byConcept/sqlAgeAtFirstOccurrence.sql
@@ -12,4 +12,4 @@ from @ohdsi_database_schema.heracles_results_dist hrd1
 	inner join @cdm_database_schema.concept c2 on hrd1.stratum_2 = CAST(c2.concept_id as VARCHAR)
 where hrd1.analysis_id = 806
   and c1.concept_id = @conceptId
-and cohort_definition_id in (@cohortDefinitionId)
+and cohort_definition_id = @cohortDefinitionId

--- a/src/main/resources/resources/cohortresults/sql/observation/byConcept/sqlObservationValueDistribution.sql
+++ b/src/main/resources/resources/cohortresults/sql/observation/byConcept/sqlObservationValueDistribution.sql
@@ -13,5 +13,5 @@ from @ohdsi_database_schema.heracles_results_dist hrd1
 where hrd1.analysis_id = 815
 and hrd1.count_value > 0
   and c1.concept_id = @conceptId
-and cohort_definition_id in (@cohortDefinitionId)
+and cohort_definition_id = @cohortDefinitionId
 

--- a/src/main/resources/resources/cohortresults/sql/observation/byConcept/sqlObservationsByType.sql
+++ b/src/main/resources/resources/cohortresults/sql/observation/byConcept/sqlObservationsByType.sql
@@ -8,4 +8,4 @@ from @ohdsi_database_schema.heracles_results hr1
 	inner join @cdm_database_schema.concept c2 on hr1.stratum_2 = CAST(c2.concept_id as VARCHAR)
 where hr1.analysis_id = 805
   and c1.concept_id = @conceptId
-and cohort_definition_id in (@cohortDefinitionId)
+and cohort_definition_id = @cohortDefinitionId

--- a/src/main/resources/resources/cohortresults/sql/observation/byConcept/sqlPrevalenceByGenderAgeYear.sql
+++ b/src/main/resources/resources/cohortresults/sql/observation/byConcept/sqlPrevalenceByGenderAgeYear.sql
@@ -5,34 +5,32 @@ SELECT c1.concept_id AS concept_id,
 	num_stratum_2 AS x_calendar_year, -- calendar year, note, there could be blanks
 	ROUND(1000 * (1.0 * num_count_value / denom_count_value), 5) AS y_prevalence_1000pp --prevalence, per 1000 persons
 FROM (
-	SELECT num.stratum_1 AS num_stratum_1,
+	SELECT CAST(num.stratum_1 AS BIGINT) AS num_stratum_1,
 		CAST(num.stratum_2 AS INT) AS num_stratum_2,
-		num.stratum_3 AS num_stratum_3,
+		CAST(num.stratum_3 AS BIGINT) AS num_stratum_3,
 		CAST(num.stratum_4 AS INT) AS num_stratum_4,
 		num.count_value AS num_count_value,
 		denom.count_value AS denom_count_value
 	FROM (
-		SELECT *
+		SELECT stratum_1, stratum_2, stratum_3, stratum_4, count_value
 		FROM @ohdsi_database_schema.heracles_results
 		WHERE analysis_id = 804
 			AND stratum_3 IN ('8507', '8532')
-			and cohort_definition_id in (@cohortDefinitionId)
+			and cohort_definition_id = @cohortDefinitionId
+		GROUP BY stratum_1, stratum_2, stratum_3, stratum_4, count_value
 		) num
 	INNER JOIN (
-		SELECT *
+		SELECT stratum_1, stratum_2, stratum_3, count_value
 		FROM @ohdsi_database_schema.heracles_results
 		WHERE analysis_id = 116
 			AND stratum_2 IN ('8507', '8532')
-			and cohort_definition_id in (@cohortDefinitionId)
-		) denom
-		ON num.stratum_2 = denom.stratum_1
+			and cohort_definition_id = @cohortDefinitionId
+		GROUP BY stratum_1, stratum_2, stratum_3, count_value
+		) denom ON num.stratum_2 = denom.stratum_1
 			AND num.stratum_3 = denom.stratum_2
 			AND num.stratum_4 = denom.stratum_3
 	) tmp
-INNER JOIN @cdm_database_schema.concept c1
-	ON num_stratum_1 = CAST(c1.concept_id as VARCHAR)
-INNER JOIN @cdm_database_schema.concept c2
-	ON num_stratum_3 = CAST(c2.concept_id as VARCHAR)
+INNER JOIN @cdm_database_schema.concept c1 ON num_stratum_1 = c1.concept_id
+INNER JOIN @cdm_database_schema.concept c2 ON num_stratum_3 = c2.concept_id
 WHERE c1.concept_id = @conceptId
-ORDER BY c1.concept_id,
-	num_stratum_2
+ORDER BY c1.concept_id, num_stratum_2

--- a/src/main/resources/resources/cohortresults/sql/observation/byConcept/sqlPrevalenceByMonth.sql
+++ b/src/main/resources/resources/cohortresults/sql/observation/byConcept/sqlPrevalenceByMonth.sql
@@ -2,10 +2,18 @@ select c1.concept_id as CONCEPT_ID,  --all rows for all concepts, but you may sp
 	c1.concept_name as CONCEPT_NAME,
 	num.stratum_2 as X_CALENDAR_MONTH,   -- calendar year, note, there could be blanks
 	round(1000*(1.0*num.count_value/denom.count_value),5) as Y_PREVALENCE_1000PP  --prevalence, per 1000 persons
-from 
-	(select * from @ohdsi_database_schema.heracles_results where analysis_id = 802 and cohort_definition_id in (@cohortDefinitionId)) num
-	inner join
-	(select * from @ohdsi_database_schema.heracles_results where analysis_id = 117 and cohort_definition_id in (@cohortDefinitionId)) denom on num.stratum_2 = denom.stratum_1  --calendar year
-	inner join @cdm_database_schema.concept c1 on num.stratum_1 = CAST(c1.concept_id as VARCHAR)
+from (
+	select stratum_1, stratum_2, count_value 
+	from @ohdsi_database_schema.heracles_results 
+	where analysis_id = 802 and cohort_definition_id = @cohortDefinitionId
+	group by stratum_1, stratum_2, count_value 
+) num
+inner join (
+	select stratum_1, count_value 
+	from @ohdsi_database_schema.heracles_results 
+	where analysis_id = 117 and cohort_definition_id = @cohortDefinitionId
+	group by stratum_1, count_value 
+) denom on num.stratum_2 = denom.stratum_1  --calendar year
+inner join @cdm_database_schema.concept c1 on CAST(num.stratum_1 AS BIGINT) = c1.concept_id
 WHERE c1.concept_id = @conceptId
 ORDER BY CAST(num.stratum_2 as INT)

--- a/src/main/resources/resources/cohortresults/sql/observation/byConcept/sqlRecordsByUnit.sql
+++ b/src/main/resources/resources/cohortresults/sql/observation/byConcept/sqlRecordsByUnit.sql
@@ -8,4 +8,4 @@ from @ohdsi_database_schema.heracles_results hr1
 	inner join @cdm_database_schema.concept c2 on hr1.stratum_2 = CAST(c2.concept_id as VARCHAR)
 where hr1.analysis_id = 807
   and c1.concept_id = @conceptId
-and cohort_definition_id in (@cohortDefinitionId)
+and cohort_definition_id = @cohortDefinitionId

--- a/src/main/resources/resources/cohortresults/sql/observation/sqlObservationTreemap.sql
+++ b/src/main/resources/resources/cohortresults/sql/observation/sqlObservationTreemap.sql
@@ -8,9 +8,9 @@ select 	concept_hierarchy.concept_id,
 	hr1.count_value as num_persons, 
 	1.0*hr1.count_value / denom.count_value as percent_persons,
 	1.0*hr2.count_value / hr1.count_value as records_per_person
-from (select * from @ohdsi_database_schema.heracles_results where analysis_id = 800 and cohort_definition_id in (@cohortDefinitionId)) hr1
+from (select * from @ohdsi_database_schema.heracles_results where analysis_id = 800 and cohort_definition_id = @cohortDefinitionId) hr1
 	inner join
-	(select * from @ohdsi_database_schema.heracles_results where analysis_id = 801 and cohort_definition_id in (@cohortDefinitionId)) hr2
+	(select * from @ohdsi_database_schema.heracles_results where analysis_id = 801 and cohort_definition_id = @cohortDefinitionId) hr2
 	on hr1.stratum_1 = hr2.stratum_1
 	inner join
 	(
@@ -28,5 +28,5 @@ from (select * from @ohdsi_database_schema.heracles_results where analysis_id = 
 		left join @cdm_database_schema.concept c3 on ca3.ANCESTOR_CONCEPT_ID = c3.concept_id
 		group by obs.concept_id, obs.concept_name
 	) concept_hierarchy on hr1.stratum_1 = CAST(concept_hierarchy.concept_id as VARCHAR),
-	(select count_value from @ohdsi_database_schema.heracles_results where analysis_id = 1 and cohort_definition_id in (@cohortDefinitionId)) denom
+	(select count_value from @ohdsi_database_schema.heracles_results where analysis_id = 1 and cohort_definition_id = @cohortDefinitionId) denom
 order by hr1.count_value desc

--- a/src/main/resources/resources/cohortresults/sql/observationperiod/ageatfirst.sql
+++ b/src/main/resources/resources/cohortresults/sql/observationperiod/ageatfirst.sql
@@ -3,9 +3,9 @@ select cast(hr1.stratum_1 as int) as interval_index,
 	round(1.0*hr1.count_value / denom.count_value,5) as percent_value
 from 
 (
-	select * from @ohdsi_database_schema.heracles_results where analysis_id = 101 and cohort_definition_id in (@cohortDefinitionId)
+	select * from @ohdsi_database_schema.heracles_results where analysis_id = 101 and cohort_definition_id = @cohortDefinitionId
 ) hr1,
 (
-	select count_value from @ohdsi_database_schema.heracles_results where analysis_id = 1 and cohort_definition_id in (@cohortDefinitionId)
+	select count_value from @ohdsi_database_schema.heracles_results where analysis_id = 1 and cohort_definition_id = @cohortDefinitionId
 ) denom
 order by cast(hr1.stratum_1 as int) asc

--- a/src/main/resources/resources/cohortresults/sql/observationperiod/agebygender.sql
+++ b/src/main/resources/resources/cohortresults/sql/observationperiod/agebygender.sql
@@ -10,4 +10,4 @@ select c1.concept_name as Category,
 from @ohdsi_database_schema.heracles_results_dist hrd1
 inner join @cdm_database_schema.concept c1 on hrd1.stratum_1 = CAST(c1.concept_id as VARCHAR)
 where hrd1.analysis_id = 104
-and cohort_definition_id in (@cohortDefinitionId)
+and cohort_definition_id = @cohortDefinitionId

--- a/src/main/resources/resources/cohortresults/sql/observationperiod/cumulativeduration.sql
+++ b/src/main/resources/resources/cohortresults/sql/observationperiod/cumulativeduration.sql
@@ -1,13 +1,13 @@
 select 'Length of observation' as series_name, 
 	cast(hr1.stratum_1 as int)*30 as x_length_of_observation, 
 	round(1.0*sum(ar2.count_value) / denom.count_value,5) as y_percent_persons
-from (select * from @ohdsi_database_schema.heracles_results where analysis_id = 108 and cohort_definition_id in (@cohortDefinitionId)) hr1
+from (select * from @ohdsi_database_schema.heracles_results where analysis_id = 108 and cohort_definition_id = @cohortDefinitionId) hr1
 inner join
 (
-	select * from @ohdsi_database_schema.heracles_results where analysis_id = 108 and cohort_definition_id in (@cohortDefinitionId)
+	select * from @ohdsi_database_schema.heracles_results where analysis_id = 108 and cohort_definition_id = @cohortDefinitionId
 ) ar2 on hr1.analysis_id = ar2.analysis_id and cast(hr1.stratum_1 as int) <= cast(ar2.stratum_1 as int),
 (
-	select count_value from @ohdsi_database_schema.heracles_results where analysis_id = 1 and cohort_definition_id in (@cohortDefinitionId)
+	select count_value from @ohdsi_database_schema.heracles_results where analysis_id = 1 and cohort_definition_id = @cohortDefinitionId
 ) denom
 group by cast(hr1.stratum_1 as int)*30, denom.count_value
 order by cast(hr1.stratum_1 as int)*30 asc

--- a/src/main/resources/resources/cohortresults/sql/observationperiod/observationlength_data.sql
+++ b/src/main/resources/resources/cohortresults/sql/observationperiod/observationlength_data.sql
@@ -3,8 +3,8 @@ select cast(hr1.stratum_1 as int) as interval_index,
 	round(1.0*hr1.count_value / denom.count_value,5) as percent_value
 from @ohdsi_database_schema.heracles_results hr1,
 (
-	select count_value from @ohdsi_database_schema.heracles_results where analysis_id = 1 and cohort_definition_id in (@cohortDefinitionId)
+	select count_value from @ohdsi_database_schema.heracles_results where analysis_id = 1 and cohort_definition_id = @cohortDefinitionId
 ) denom
 where hr1.analysis_id = 108
-and hr1.cohort_definition_id in (@cohortDefinitionId)
+and hr1.cohort_definition_id = @cohortDefinitionId
 order by cast(hr1.stratum_1 as int) asc

--- a/src/main/resources/resources/cohortresults/sql/observationperiod/observationlength_stats.sql
+++ b/src/main/resources/resources/cohortresults/sql/observationperiod/observationlength_stats.sql
@@ -3,7 +3,7 @@ select  min(cast(hr1.stratum_1 as int)) * 30 as min_value,
 	30 as interval_size
 from @ohdsi_database_schema.heracles_results hr1,
 (
-	select count_value from @ohdsi_database_schema.heracles_results where analysis_id = 1 and cohort_definition_id in (@cohortDefinitionId)
+	select count_value from @ohdsi_database_schema.heracles_results where analysis_id = 1 and cohort_definition_id = @cohortDefinitionId
 ) denom
 where hr1.analysis_id = 108
-and hr1.cohort_definition_id in (@cohortDefinitionId)
+and hr1.cohort_definition_id = @cohortDefinitionId

--- a/src/main/resources/resources/cohortresults/sql/observationperiod/observationlengthbyage.sql
+++ b/src/main/resources/resources/cohortresults/sql/observationperiod/observationlengthbyage.sql
@@ -9,5 +9,5 @@
   0 as concept_id
 from @ohdsi_database_schema.heracles_results_dist hrd1
 where hrd1.analysis_id = 107
-and cohort_definition_id in (@cohortDefinitionId)
+and cohort_definition_id = @cohortDefinitionId
 order by cast(hrd1.stratum_1 as int) asc

--- a/src/main/resources/resources/cohortresults/sql/observationperiod/observationlengthbygender.sql
+++ b/src/main/resources/resources/cohortresults/sql/observationperiod/observationlengthbygender.sql
@@ -10,4 +10,4 @@ select c1.concept_name as category,
 from @ohdsi_database_schema.heracles_results_dist hrd1
 inner join @cdm_database_schema.concept c1 on hrd1.stratum_1 = CAST(c1.concept_id as VARCHAR)
 where hrd1.analysis_id = 106
-and cohort_definition_id in (@cohortDefinitionId)
+and cohort_definition_id = @cohortDefinitionId

--- a/src/main/resources/resources/cohortresults/sql/observationperiod/observedbymonth.sql
+++ b/src/main/resources/resources/cohortresults/sql/observationperiod/observedbymonth.sql
@@ -1,7 +1,7 @@
 select cast(hr1.stratum_1 as int) as month_year, 
   hr1.count_value as count_value, 
 	round(1.0*hr1.count_value / denom.count_value,5) as percent_value
-from (select * from @ohdsi_database_schema.heracles_results where analysis_id = 110 and cohort_definition_id in (@cohortDefinitionId)) hr1,
-	(select count_value from @ohdsi_database_schema.heracles_results where analysis_id = 1 and cohort_definition_id in (@cohortDefinitionId)) denom
+from (select * from @ohdsi_database_schema.heracles_results where analysis_id = 110 and cohort_definition_id = @cohortDefinitionId) hr1,
+	(select count_value from @ohdsi_database_schema.heracles_results where analysis_id = 1 and cohort_definition_id = @cohortDefinitionId) denom
 order by hr1.stratum_1 asc
   

--- a/src/main/resources/resources/cohortresults/sql/observationperiod/observedbyyear_data.sql
+++ b/src/main/resources/resources/cohortresults/sql/observationperiod/observedbyyear_data.sql
@@ -3,13 +3,13 @@ select cast(hr1.stratum_1 as int) - MinValue.MinValue as interval_index,
   round(1.0*hr1.count_value / denom.count_value,5) as percent_value
 from 
 (
-	select * from @ohdsi_database_schema.heracles_results where analysis_id = 109 and cohort_definition_id in (@cohortDefinitionId)
+	select * from @ohdsi_database_schema.heracles_results where analysis_id = 109 and cohort_definition_id = @cohortDefinitionId
 ) hr1,
 (
 	select min(cast(stratum_1 as int)) as MinValue 
-	from @ohdsi_database_schema.heracles_results where analysis_id = 109 and cohort_definition_id in (@cohortDefinitionId)
+	from @ohdsi_database_schema.heracles_results where analysis_id = 109 and cohort_definition_id = @cohortDefinitionId
 ) MinValue,
 (
-	select count_value from @ohdsi_database_schema.heracles_results where analysis_id = 1 and cohort_definition_id in (@cohortDefinitionId)
+	select count_value from @ohdsi_database_schema.heracles_results where analysis_id = 1 and cohort_definition_id = @cohortDefinitionId
 ) denom
 order by hr1.stratum_1 asc

--- a/src/main/resources/resources/cohortresults/sql/observationperiod/observedbyyear_stats.sql
+++ b/src/main/resources/resources/cohortresults/sql/observationperiod/observedbyyear_stats.sql
@@ -3,4 +3,4 @@ select min(cast(hr1.stratum_1 as int)) as min_value,
   1 as interval_size
 from @ohdsi_database_schema.heracles_results hr1
 where hr1.analysis_id = 109
-and cohort_definition_id in (@cohortDefinitionId)
+and cohort_definition_id = @cohortDefinitionId

--- a/src/main/resources/resources/cohortresults/sql/observationperiod/periodsperperson.sql
+++ b/src/main/resources/resources/cohortresults/sql/observationperiod/periodsperperson.sql
@@ -3,4 +3,4 @@ select row_number() over (order by hr1.stratum_1) as concept_id,
 	hr1.count_value as count_value
 from @ohdsi_database_schema.heracles_results hr1
 where hr1.analysis_id = 113
-and cohort_definition_id in (@cohortDefinitionId)
+and cohort_definition_id = @cohortDefinitionId

--- a/src/main/resources/resources/cohortresults/sql/person/ethnicity.sql
+++ b/src/main/resources/resources/cohortresults/sql/person/ethnicity.sql
@@ -6,4 +6,4 @@ from @ohdsi_database_schema.heracles_results hr1
 	@cdm_database_schema.concept c1
 	on hr1.stratum_1 = CAST(c1.concept_id as VARCHAR(255))
 where hr1.analysis_id = 5
-and cohort_definition_id in (@cohortDefinitionId)
+and cohort_definition_id = @cohortDefinitionId

--- a/src/main/resources/resources/cohortresults/sql/person/gender.sql
+++ b/src/main/resources/resources/cohortresults/sql/person/gender.sql
@@ -7,4 +7,4 @@ from @ohdsi_database_schema.heracles_results hr1
 	on hr1.stratum_1 = CAST(c1.concept_id as VARCHAR(255))
 where hr1.analysis_id = 2
 and c1.concept_id in (8507, 8532)
-and cohort_definition_id in (@cohortDefinitionId)
+and cohort_definition_id = @cohortDefinitionId

--- a/src/main/resources/resources/cohortresults/sql/person/population.sql
+++ b/src/main/resources/resources/cohortresults/sql/person/population.sql
@@ -5,7 +5,7 @@ inner join
 @ohdsi_database_schema.heracles_results hr1
 on ha1.analysis_id = hr1.analysis_id
 where ha1.analysis_id = 0
-and cohort_definition_id in (@cohortDefinitionId)
+and cohort_definition_id = @cohortDefinitionId
 union
 
 select ha1.analysis_name as attribute_name, 
@@ -15,6 +15,6 @@ inner join
 @ohdsi_database_schema.heracles_results hr1
 on ha1.analysis_id = hr1.analysis_id
 where ha1.analysis_id = 1
-and cohort_definition_id in (@cohortDefinitionId)
+and cohort_definition_id = @cohortDefinitionId
 )
 order by attribute_name desc

--- a/src/main/resources/resources/cohortresults/sql/person/race.sql
+++ b/src/main/resources/resources/cohortresults/sql/person/race.sql
@@ -6,4 +6,4 @@ from @ohdsi_database_schema.heracles_results hr1
 	@cdm_database_schema.concept c1
 	on hr1.stratum_1 = CAST(c1.concept_id as VARCHAR(255))
 where hr1.analysis_id = 4
-and cohort_definition_id in (@cohortDefinitionId)
+and cohort_definition_id = @cohortDefinitionId

--- a/src/main/resources/resources/cohortresults/sql/person/yearofbirth_data.sql
+++ b/src/main/resources/resources/cohortresults/sql/person/yearofbirth_data.sql
@@ -1,7 +1,7 @@
 select cast(hr1.stratum_1 as int) - MinValue.MinValue as interval_index, 
   hr1.count_value as count_value, 
 	round(1.0*hr1.count_value / denom.count_value,5) as percent_value
-from (select * from @ohdsi_database_schema.heracles_results where analysis_id = 3 and cohort_definition_id in (@cohortDefinitionId)) hr1,
-	(select min(cast(stratum_1 as int)) as MinValue from @ohdsi_database_schema.heracles_results where analysis_id = 3 and cohort_definition_id in (@cohortDefinitionId)) MinValue,
-	(select count_value from @ohdsi_database_schema.heracles_results where analysis_id = 1 and cohort_definition_id in (@cohortDefinitionId)) denom
+from (select * from @ohdsi_database_schema.heracles_results where analysis_id = 3 and cohort_definition_id = @cohortDefinitionId) hr1,
+	(select min(cast(stratum_1 as int)) as MinValue from @ohdsi_database_schema.heracles_results where analysis_id = 3 and cohort_definition_id = @cohortDefinitionId) MinValue,
+	(select count_value from @ohdsi_database_schema.heracles_results where analysis_id = 1 and cohort_definition_id = @cohortDefinitionId) denom
 order by hr1.stratum_1 asc

--- a/src/main/resources/resources/cohortresults/sql/person/yearofbirth_stats.sql
+++ b/src/main/resources/resources/cohortresults/sql/person/yearofbirth_stats.sql
@@ -3,4 +3,4 @@ select min(cast(hr1.stratum_1 as int)) as min_value,
 	1 as interval_size
 from @ohdsi_database_schema.heracles_results hr1
 where hr1.analysis_id = 3
-and cohort_definition_id in (@cohortDefinitionId)
+and cohort_definition_id = @cohortDefinitionId

--- a/src/main/resources/resources/cohortresults/sql/procedure/byConcept/sqlAgeAtFirstOccurrence.sql
+++ b/src/main/resources/resources/cohortresults/sql/procedure/byConcept/sqlAgeAtFirstOccurrence.sql
@@ -16,4 +16,4 @@ from @ohdsi_database_schema.heracles_results_dist hrd1
 	on hrd1.stratum_2 = CAST(c2.concept_id as VARCHAR)
 where hrd1.analysis_id = 606
  and c1.concept_id = @conceptId
-and cohort_definition_id in (@cohortDefinitionId)
+and cohort_definition_id = @cohortDefinitionId

--- a/src/main/resources/resources/cohortresults/sql/procedure/byConcept/sqlPrevalenceByGenderAgeYear.sql
+++ b/src/main/resources/resources/cohortresults/sql/procedure/byConcept/sqlPrevalenceByGenderAgeYear.sql
@@ -5,33 +5,32 @@ SELECT c1.concept_id AS concept_id,
 	num_stratum_2 AS x_calendar_year, -- calendar year, note, there could be blanks
 	ROUND(1000 * (1.0 * num_count_value / denom_count_value), 5) AS y_prevalence_1000pp --prevalence, per 1000 persons
 FROM (
-	SELECT num.stratum_1 AS num_stratum_1,
-		num.stratum_2 AS num_stratum_2,
-		CAST(num.stratum_3 AS INT) AS num_stratum_3,
+	SELECT CAST(num.stratum_1 AS BIGINT) AS num_stratum_1,
+		CAST(num.stratum_2 AS INT) AS num_stratum_2,
+		CAST(num.stratum_3 AS BIGINT) AS num_stratum_3,
 		CAST(num.stratum_4 AS INT) AS num_stratum_4,
 		num.count_value AS num_count_value,
 		denom.count_value AS denom_count_value
 	FROM (
-		SELECT *
+		SELECT stratum_1, stratum_2, stratum_3, stratum_4, count_value
 		FROM @ohdsi_database_schema.heracles_results
 		WHERE analysis_id = 604
 			AND stratum_3 IN ('8507', '8532')
-			and cohort_definition_id in (@cohortDefinitionId)
+			and cohort_definition_id = @cohortDefinitionId
+		GROUP BY stratum_1, stratum_2, stratum_3, stratum_4, count_value
 		) num
 	INNER JOIN (
-		SELECT *
+		SELECT stratum_1, stratum_2, stratum_3, count_value
 		FROM @ohdsi_database_schema.heracles_results
 		WHERE analysis_id = 116
 			AND stratum_2 IN ('8507', '8532')
-			and cohort_definition_id in (@cohortDefinitionId)
-		) denom
-		ON num.stratum_2 = denom.stratum_1
+			and cohort_definition_id = @cohortDefinitionId
+		GROUP BY stratum_1, stratum_2, stratum_3, count_value
+		) denom ON num.stratum_2 = denom.stratum_1
 			AND num.stratum_3 = denom.stratum_2
 			AND num.stratum_4 = denom.stratum_3
 	) tmp
-INNER JOIN @cdm_database_schema.concept c1
-	ON num_stratum_1 = CAST(c1.concept_id as VARCHAR)
-INNER JOIN @cdm_database_schema.concept c2
-	ON num_stratum_3 = c2.concept_id
+INNER JOIN @cdm_database_schema.concept c1 ON num_stratum_1 = c1.concept_id
+INNER JOIN @cdm_database_schema.concept c2 ON num_stratum_3 = c2.concept_id
 where  c1.concept_id = @conceptId
 ORDER BY c1.concept_id,	num_stratum_2

--- a/src/main/resources/resources/cohortresults/sql/procedure/byConcept/sqlPrevalenceByMonth.sql
+++ b/src/main/resources/resources/cohortresults/sql/procedure/byConcept/sqlPrevalenceByMonth.sql
@@ -2,11 +2,18 @@
     c1.concept_name as concept_name,
   	num.stratum_2 as x_calendar_month,   -- calendar year, note, there could be blanks
   	round(1000*(1.0*num.count_value/denom.count_value),5) as y_prevalence_1000pp  --prevalence, per 1000 persons
-from 
-	(select * from @ohdsi_database_schema.heracles_results where analysis_id = 602 and cohort_definition_id in (@cohortDefinitionId)) num
-	inner join
-	(select * from @ohdsi_database_schema.heracles_results where analysis_id = 117 and cohort_definition_id in (@cohortDefinitionId)) 
-	denom on num.stratum_2 = denom.stratum_1  --calendar year
-	inner join @cdm_database_schema.concept c1 on num.stratum_1 = CAST(c1.concept_id as VARCHAR)
+from (
+	select stratum_1, stratum_2, count_value 
+	from @ohdsi_database_schema.heracles_results 
+	where analysis_id = 602 and cohort_definition_id = @cohortDefinitionId
+	group by stratum_1, stratum_2, count_value 
+) num
+inner join (
+	select stratum_1, count_value 
+	from @ohdsi_database_schema.heracles_results 
+	where analysis_id = 117 and cohort_definition_id = @cohortDefinitionId
+	group by stratum_1, count_value 
+) denom on num.stratum_2 = denom.stratum_1  --calendar year
+inner join @cdm_database_schema.concept c1 on CAST(num.stratum_1 AS BIGINT) = c1.concept_id
 where c1.concept_id = @conceptId
 ORDER BY CAST(num.stratum_2 as INT)

--- a/src/main/resources/resources/cohortresults/sql/procedure/byConcept/sqlProceduresByType.sql
+++ b/src/main/resources/resources/cohortresults/sql/procedure/byConcept/sqlProceduresByType.sql
@@ -7,5 +7,5 @@ from @ohdsi_database_schema.heracles_results hr1
 	inner join @cdm_database_schema.concept c1 on hr1.stratum_1 = CAST(c1.concept_id as VARCHAR)
 	inner join @cdm_database_schema.concept c2 on hr1.stratum_2 = CAST(c2.concept_id as VARCHAR)
 where hr1.analysis_id = 605
-and cohort_definition_id in (@cohortDefinitionId)
+and cohort_definition_id = @cohortDefinitionId
  and c1.concept_id = @conceptId

--- a/src/main/resources/resources/cohortresults/sql/procedure/sqlProcedureTreemap.sql
+++ b/src/main/resources/resources/cohortresults/sql/procedure/sqlProcedureTreemap.sql
@@ -8,9 +8,9 @@ select 	concept_hierarchy.concept_id,
 	hr1.count_value as num_persons, 
 	1.0*hr1.count_value / denom.count_value as percent_persons,
 	1.0*hr2.count_value / hr1.count_value as records_per_person
-from (select * from @ohdsi_database_schema.heracles_results where analysis_id = 600 and cohort_definition_id in (@cohortDefinitionId)) hr1
+from (select * from @ohdsi_database_schema.heracles_results where analysis_id = 600 and cohort_definition_id = @cohortDefinitionId) hr1
 	inner join
-	(select * from @ohdsi_database_schema.heracles_results where analysis_id = 601 and cohort_definition_id in (@cohortDefinitionId)) hr2
+	(select * from @ohdsi_database_schema.heracles_results where analysis_id = 601 and cohort_definition_id = @cohortDefinitionId) hr2
 	on hr1.stratum_1 = hr2.stratum_1
 	inner join
 	(
@@ -119,6 +119,6 @@ from (select * from @ohdsi_database_schema.heracles_results where analysis_id = 
 	) concept_hierarchy
 	on hr1.stratum_1 = CAST(concept_hierarchy.concept_id as VARCHAR)
 	,
-	(select count_value from @ohdsi_database_schema.heracles_results where analysis_id = 1 and cohort_definition_id in (@cohortDefinitionId)) denom
+	(select count_value from @ohdsi_database_schema.heracles_results where analysis_id = 1 and cohort_definition_id = @cohortDefinitionId) denom
 
 order by hr1.count_value desc

--- a/src/main/resources/resources/cohortresults/sql/visit/byConcept/sqlAgeAtFirstOccurrence.sql
+++ b/src/main/resources/resources/cohortresults/sql/visit/byConcept/sqlAgeAtFirstOccurrence.sql
@@ -12,4 +12,4 @@ from @ohdsi_database_schema.heracles_results_dist hrd1
 	inner join @cdm_database_schema.concept c2 on hrd1.stratum_2 = CAST(c2.concept_id as VARCHAR)
 where hrd1.analysis_id = 206
 and  c1.concept_id = @conceptId
-and cohort_definition_id in (@cohortDefinitionId)
+and cohort_definition_id = @cohortDefinitionId

--- a/src/main/resources/resources/cohortresults/sql/visit/byConcept/sqlPrevalenceByGenderAgeYear.sql
+++ b/src/main/resources/resources/cohortresults/sql/visit/byConcept/sqlPrevalenceByGenderAgeYear.sql
@@ -5,35 +5,33 @@ SELECT c1.concept_id AS concept_id,
 	num_stratum_2 AS x_calendar_year, -- calendar year, note, there could be blanks
 	ROUND(1000 * (1.0 * num_count_value / denom_count_value), 5) AS y_prevalence_1000pp --prevalence, per 1000 persons
 FROM (
-	SELECT num.stratum_1 AS num_stratum_1,
+	SELECT CAST(num.stratum_1 AS BIGINT) AS num_stratum_1,
 		CAST(num.stratum_2 AS INT) AS num_stratum_2,
-		num.stratum_3 AS num_stratum_3,
+		CAST(num.stratum_3 AS BIGINT) AS num_stratum_3,
 		CAST(num.stratum_4 AS INT) AS num_stratum_4,
 		num.count_value AS num_count_value,
 		denom.count_value AS denom_count_value
 	FROM (
-		SELECT *
+		SELECT stratum_1. stratum_2, stratum_3, stratum_4, count_value
 		FROM @ohdsi_database_schema.heracles_results
 		WHERE analysis_id = 204
 			AND stratum_3 IN ('8507', '8532')
-			and cohort_definition_id in (@cohortDefinitionId)
+			and cohort_definition_id = @cohortDefinitionId
+		GROUP BY stratum_1. stratum_2, stratum_3, stratum_4, count_value
 		) num
 	INNER JOIN (
-		SELECT *
+		SELECT stratum_1. stratum_2, stratum_3, count_value
 		FROM @ohdsi_database_schema.heracles_results
 		WHERE analysis_id = 116
 			AND stratum_2 IN ('8507', '8532')
-			and cohort_definition_id in (@cohortDefinitionId)
-		) denom
-		ON num.stratum_2 = denom.stratum_1
+			and cohort_definition_id = @cohortDefinitionId
+		GROUP BY stratum_1. stratum_2, stratum_3, count_value
+		) denom ON num.stratum_2 = denom.stratum_1
 			AND num.stratum_3 = denom.stratum_2
 			AND num.stratum_4 = denom.stratum_3
 	) tmp
-INNER JOIN @cdm_database_schema.concept c1
-	ON num_stratum_1 = CAST(c1.concept_id as VARCHAR)
-INNER JOIN @cdm_database_schema.concept c2
-	ON num_stratum_3 = CAST(c2.concept_id as VARCHAR)
+INNER JOIN @cdm_database_schema.concept c1 ON num_stratum_1 = c1.concept_id
+INNER JOIN @cdm_database_schema.concept c2 ON num_stratum_3 = c2.concept_id
 where  c1.concept_id = @conceptId
-ORDER BY c1.concept_id,
-	num_stratum_2
+ORDER BY c1.concept_id, num_stratum_2
 

--- a/src/main/resources/resources/cohortresults/sql/visit/byConcept/sqlPrevalenceByMonth.sql
+++ b/src/main/resources/resources/cohortresults/sql/visit/byConcept/sqlPrevalenceByMonth.sql
@@ -2,10 +2,18 @@ select c1.concept_id as concept_id,  --all rows for all concepts, but you may sp
 	c1.concept_name as concept_name,
 	num.stratum_2 as x_calendar_month,   -- calendar year, note, there could be blanks
 	1000*(1.0*num.count_value/denom.count_value) as y_prevalence_1000pp  --prevalence, per 1000 persons
-from 
-	(select * from @ohdsi_database_schema.heracles_results where analysis_id = 202 and cohort_definition_id in (@cohortDefinitionId)) num
-	inner join
-		(select * from @ohdsi_database_schema.heracles_results where analysis_id = 117 and cohort_definition_id in (@cohortDefinitionId)) denom on num.stratum_2 = denom.stratum_1  --calendar year
-	inner join @cdm_database_schema.concept c1 on num.stratum_1 = CAST(c1.concept_id as VARCHAR(255))
+from (
+	select stratum_1, stratum_2, count_value 
+	from @ohdsi_database_schema.heracles_results 
+	where analysis_id = 202 and cohort_definition_id = @cohortDefinitionId
+	group by stratum_1, stratum_2, count_value 
+) num
+inner join (
+	select stratum_1, count_value 
+	from @ohdsi_database_schema.heracles_results 
+	where analysis_id = 117 and cohort_definition_id = @cohortDefinitionId
+	group by stratum_1, count_value 
+) denom on num.stratum_2 = denom.stratum_1  --calendar year
+inner join @cdm_database_schema.concept c1 on CAST(num.stratum_1 AS BIGINT) = c1.concept_id
 where  c1.concept_id = @conceptId
 ORDER BY CAST(num.stratum_2 as INT)

--- a/src/main/resources/resources/cohortresults/sql/visit/byConcept/sqlVisitDurationByType.sql
+++ b/src/main/resources/resources/cohortresults/sql/visit/byConcept/sqlVisitDurationByType.sql
@@ -12,4 +12,4 @@ from @ohdsi_database_schema.heracles_results_dist hrd1
 	@cdm_database_schema.concept c1 on hrd1.stratum_1 = CAST(c1.concept_id as VARCHAR)
 where hrd1.analysis_id = 211
 and  c1.concept_id = @conceptId
-and cohort_definition_id in (@cohortDefinitionId)
+and cohort_definition_id = @cohortDefinitionId

--- a/src/main/resources/resources/cohortresults/sql/visit/sqlVisitTreemap.sql
+++ b/src/main/resources/resources/cohortresults/sql/visit/sqlVisitTreemap.sql
@@ -3,9 +3,9 @@ select 	c1.concept_id,
 	hr1.count_value as num_persons, 
 	1.0*hr1.count_value / denom.count_value as percent_persons,
 	1.0*hr2.count_value / hr1.count_value as records_per_person
-from (select * from @ohdsi_database_schema.heracles_results where analysis_id = 200 and cohort_definition_id in (@cohortDefinitionId)) hr1
+from (select * from @ohdsi_database_schema.heracles_results where analysis_id = 200 and cohort_definition_id = @cohortDefinitionId) hr1
 	inner join
-	(select * from @ohdsi_database_schema.heracles_results where analysis_id = 201 and cohort_definition_id in (@cohortDefinitionId)) hr2 on hr1.stratum_1 = hr2.stratum_1
+	(select * from @ohdsi_database_schema.heracles_results where analysis_id = 201 and cohort_definition_id = @cohortDefinitionId) hr2 on hr1.stratum_1 = hr2.stratum_1
 	inner join @cdm_database_schema.concept c1 on hr1.stratum_1 = CAST(c1.concept_id as VARCHAR(255)),
-	(select count_value from @ohdsi_database_schema.heracles_results where analysis_id = 1 and cohort_definition_id in (@cohortDefinitionId)) denom
+	(select count_value from @ohdsi_database_schema.heracles_results where analysis_id = 1 and cohort_definition_id = @cohortDefinitionId) denom
 order by hr1.count_value desc


### PR DESCRIPTION
Fixed casting for concept stratums to BIGINT.
Switched cohort_defintion_id from IN to =.
Applied GROUP BY to subqueries to avoid MPP optimizations that fetch all rows and risk casting non-numerics to BIGINT.
