### PR TITLE
Set daimon default to null when not found

### DIFF
--- a/src/main/java/org/ohdsi/webapi/util/DataSourceDTOParser.java
+++ b/src/main/java/org/ohdsi/webapi/util/DataSourceDTOParser.java
@@ -27,9 +27,9 @@ public final class DataSourceDTOParser {
             KerberosUtils.setKerberosParams(source, params, dto);
         }
 
-        dto.setCdmSchema(source.getTableQualifier(SourceDaimon.DaimonType.CDM));
-        dto.setVocabularySchema(source.getTableQualifier(SourceDaimon.DaimonType.Vocabulary));
-        dto.setResultSchema(source.getTableQualifier(SourceDaimon.DaimonType.Results));
+        dto.setCdmSchema(source.getTableQualifierOrNull(SourceDaimon.DaimonType.CDM));
+        dto.setVocabularySchema(source.getTableQualifierOrNull(SourceDaimon.DaimonType.Vocabulary));
+        dto.setResultSchema(source.getTableQualifierOrNull(SourceDaimon.DaimonType.Results));
 
         return dto;
     }


### PR DESCRIPTION
It is not required that a data source have a vocabulary, CDM and results daimon configured. This is left to the administrator to decide since it is possible that you may want to have a separate vocabulary data source separate from the CDM(s) in the environment. 

This change allows for that flexibility in the DTO parser used to retrieve data sources. Please let me know if you have any questions.