### PR TITLE
Record count retrieval fixes

### DIFF
--- a/src/main/resources/resources/cdmresults/sql/getConceptRecordCount.sql
+++ b/src/main/resources/resources/cdmresults/sql/getConceptRecordCount.sql
@@ -7,7 +7,7 @@ WITH concepts AS (
 ), counts AS (
 SELECT stratum_1 concept_id, MAX (count_value) agg_count_value
 FROM @resultTableQualifier.achilles_results
-WHERE analysis_id IN (2, 4, 5, 201, 301, 401, 501, 505, 601, 701, 801, 901, 1001, 1201, 1801)
+WHERE analysis_id IN (2, 4, 5, 201, 301, 401, 501, 505, 601, 701, 801, 901, 1001, 1201, 1801, 2101)
 		/* analyses:
  			 Number of persons by gender
 			 Number of persons by race
@@ -24,12 +24,13 @@ WHERE analysis_id IN (2, 4, 5, 201, 301, 401, 501, 505, 601, 701, 801, 901, 1001
 			 Number of condition era records, by condition_concept_id
 			 Number of visits by place of service
 			 Number of measurement occurrence records, by observation_concept_id
+			 Number of device exposure records, by device_concept_id
 		*/
 GROUP BY stratum_1
 UNION
 SELECT stratum_2 AS concept_id, SUM (count_value) AS agg_count_value
 FROM @resultTableQualifier.achilles_results
-WHERE analysis_id IN (405, 605, 705, 805, 807, 1805, 1807)
+WHERE analysis_id IN (405, 605, 705, 805, 807, 1805, 1807, 2105)
 		/* analyses:
 			 Number of condition occurrence records, by condition_concept_id by condition_type_concept_id
 			 Number of procedure occurrence records, by procedure_concept_id by procedure_type_concept_id
@@ -38,6 +39,7 @@ WHERE analysis_id IN (405, 605, 705, 805, 807, 1805, 1807)
 			 Number of observation occurrence records, by observation_concept_id and unit_concept_id
 			 Number of observation occurrence records, by measurement_concept_id by measurement_type_concept_id
 			 Number of measurement occurrence records, by measurement_concept_id and unit_concept_id
+			 Number of device exposure records, by device_concept_id by device_type_concept_id
 		    but this subquery only gets the type or unit concept_ids, i.e., stratum_2
 		*/
 GROUP BY stratum_2

--- a/src/main/resources/resources/cdmresults/sql/loadConceptRecordCountCache.sql
+++ b/src/main/resources/resources/cdmresults/sql/loadConceptRecordCountCache.sql
@@ -55,5 +55,4 @@ FROM concepts
   LEFT JOIN counts c1 ON concepts.ancestor_id = c1.concept_id
   LEFT JOIN counts c2 ON concepts.descendant_id = c2.concept_id
 GROUP BY concepts.ancestor_id
-HAVING isnull(max(c1.agg_count_value), 0) > 0 OR isnull(sum(c2.agg_count_value), 0) > 0
 ;

--- a/src/main/resources/resources/cdmresults/sql/loadConceptRecordCountCache.sql
+++ b/src/main/resources/resources/cdmresults/sql/loadConceptRecordCountCache.sql
@@ -6,7 +6,7 @@ WITH concepts AS (
 ), counts AS (
 SELECT stratum_1 concept_id, MAX (count_value) agg_count_value
 FROM @resultTableQualifier.achilles_results
-WHERE analysis_id IN (2, 4, 5, 201, 301, 401, 501, 505, 601, 701, 801, 901, 1001, 1201, 1801)
+WHERE analysis_id IN (2, 4, 5, 201, 301, 401, 501, 505, 601, 701, 801, 901, 1001, 1201, 1801, 2101)
 		/* analyses:
  			 Number of persons by gender
 			 Number of persons by race
@@ -23,12 +23,13 @@ WHERE analysis_id IN (2, 4, 5, 201, 301, 401, 501, 505, 601, 701, 801, 901, 1001
 			 Number of condition era records, by condition_concept_id
 			 Number of visits by place of service
 			 Number of measurement occurrence records, by observation_concept_id
+			 Number of device exposure records, by device_concept_id
 		*/
 GROUP BY stratum_1
 UNION
 SELECT stratum_2 AS concept_id, SUM (count_value) AS agg_count_value
 FROM @resultTableQualifier.achilles_results
-WHERE analysis_id IN (405, 605, 705, 805, 807, 1805, 1807)
+WHERE analysis_id IN (405, 605, 705, 805, 807, 1805, 1807, 2105)
 		/* analyses:
 			 Number of condition occurrence records, by condition_concept_id by condition_type_concept_id
 			 Number of procedure occurrence records, by procedure_concept_id by procedure_type_concept_id
@@ -37,6 +38,7 @@ WHERE analysis_id IN (405, 605, 705, 805, 807, 1805, 1807)
 			 Number of observation occurrence records, by observation_concept_id and unit_concept_id
 			 Number of observation occurrence records, by measurement_concept_id by measurement_type_concept_id
 			 Number of measurement occurrence records, by measurement_concept_id and unit_concept_id
+			 Number of device exposure records, by device_concept_id by device_type_concept_id
 		    but this subquery only gets the type or unit concept_ids, i.e., stratum_2
 		*/
 GROUP BY stratum_2

--- a/src/main/resources/resources/cdmresults/sql/loadConceptRecordCountCache.sql
+++ b/src/main/resources/resources/cdmresults/sql/loadConceptRecordCountCache.sql
@@ -53,3 +53,5 @@ FROM concepts
   LEFT JOIN counts c1 ON concepts.ancestor_id = c1.concept_id
   LEFT JOIN counts c2 ON concepts.descendant_id = c2.concept_id
 GROUP BY concepts.ancestor_id
+HAVING isnull(max(c1.agg_count_value), 0) > 0 OR isnull(sum(c2.agg_count_value), 0) > 0
+;


### PR DESCRIPTION
- Per this discussion: https://github.com/OHDSI/WebAPI/commit/c11f1425c27f7301aaede2922120afd37bd7558b#comments: In reviewing the code that was part of this commit, I'm unsure how the new caching mechanism requires the need for concept ID's with 0 records (RC) and 0 descendant record counts (DRC). To that end, I've reverted back the HAVING clause to the query used to retrieve the concept counts. My thinking here is that if a concept ID does not exist in the cache _after it has been warmed_ then it is assumed to have no RC/DRC. Furthermore, I've revised the CDMResultsService to check the status of the cache and if it has not been warmed, it will attempt to query the Achilles results table for the record counts. In addition, I revised the function to chunk up the concept IDs that are passed into the PreparedStatementRenderer to respect the limits imposed by the RDBMS hosting the CDM's results schema.

Tagging @pavgra for thoughts and comments since I could be mis-understanding his revised implementation in this area.

- Fixes #714 by adding in device related Achilles results analysis IDs.