### PR TITLE
fixes failed MSSQL migration

### DIFF
--- a/src/main/resources/db/migration/sqlserver/V2.7.0.20190129083000__fe-analysis-created-modified-fix.sql
+++ b/src/main/resources/db/migration/sqlserver/V2.7.0.20190129083000__fe-analysis-created-modified-fix.sql
@@ -1,3 +1,15 @@
+DECLARE @ConstraintName nvarchar(200);
+
+SELECT @ConstraintName = Name FROM SYS.DEFAULT_CONSTRAINTS
+WHERE PARENT_OBJECT_ID = OBJECT_ID('${ohdsiSchema}.fe_analysis_criteria')
+      AND PARENT_COLUMN_ID = (SELECT column_id FROM sys.columns
+WHERE NAME = 'created_date'
+      AND object_id = OBJECT_ID('${ohdsiSchema}.fe_analysis_criteria'));
+
+IF @ConstraintName IS NOT NULL
+  EXEC('ALTER TABLE ${ohdsiSchema}.fe_analysis_criteria DROP CONSTRAINT ' + @ConstraintName);
+ALTER TABLE ${ohdsiSchema}.fe_analysis_criteria DROP CONSTRAINT FK_fac_su_cid;
+ALTER TABLE ${ohdsiSchema}.fe_analysis_criteria DROP CONSTRAINT FK_fac_su_mid;
 ALTER TABLE ${ohdsiSchema}.fe_analysis_criteria DROP COLUMN created_by_id;
 ALTER TABLE ${ohdsiSchema}.fe_analysis_criteria DROP COLUMN created_date;
 ALTER TABLE ${ohdsiSchema}.fe_analysis_criteria DROP COLUMN modified_by_id;


### PR DESCRIPTION
This fixes failed migration for MS Sql Server.
Migration fails due to column constraints that prevents deletion of columns.
