### PR TITLE
Modified sequence query in sql server

### DIFF
--- a/src/main/java/org/ohdsi/webapi/cohortresults/VisualizationData.java
+++ b/src/main/java/org/ohdsi/webapi/cohortresults/VisualizationData.java
@@ -22,6 +22,7 @@ public class VisualizationData implements Serializable {
         name = "visualization_generator",
         strategy = "org.hibernate.id.enhanced.SequenceStyleGenerator",
         parameters = {
+            @Parameter(name = "sequence_name", value = "HERACLES_VIZ_DATA_SEQUENCE"),
             @Parameter(name = "increment_size", value = "1")
         }
     )

--- a/src/main/java/org/ohdsi/webapi/source/Source.java
+++ b/src/main/java/org/ohdsi/webapi/source/Source.java
@@ -57,6 +57,7 @@ public class Source implements Serializable {
     name = "source_generator",
     strategy = "org.hibernate.id.enhanced.SequenceStyleGenerator",
     parameters = {
+      @Parameter(name = "sequence_name", value = "source_sequence"),
       @Parameter(name = "increment_size", value = "1")
     }
   )

--- a/src/main/java/org/ohdsi/webapi/source/SourceDaimon.java
+++ b/src/main/java/org/ohdsi/webapi/source/SourceDaimon.java
@@ -57,6 +57,7 @@ public class SourceDaimon implements Serializable {
     name = "source_daimon_generator",
     strategy = "org.hibernate.id.enhanced.SequenceStyleGenerator",
     parameters = {
+      @Parameter(name = "sequence_name", value = "source_daimon_sequence"),
       @Parameter(name = "increment_size", value = "1")
     }
   )

--- a/src/main/resources/db/migration/sqlserver/V2.7.0.20190201140945__sources-created-modified-fix.sql
+++ b/src/main/resources/db/migration/sqlserver/V2.7.0.20190201140945__sources-created-modified-fix.sql
@@ -1,3 +1,7 @@
+-- DECLARE current id
+DECLARE @cur_id_val INT;
+DECLARE @sql NVARCHAR(MAX);
+
 -- RENAME source table
 ALTER TABLE ${ohdsiSchema}.source DROP CONSTRAINT DF_source_SOURCE_DIALECT;
 ALTER TABLE ${ohdsiSchema}.source DROP CONSTRAINT source_key_unique;
@@ -7,9 +11,16 @@ EXEC sp_rename '[${ohdsiSchema}].[source]', 'source_bak';
 
 CREATE SEQUENCE ${ohdsiSchema}.source_sequence
   AS BIGINT
-  MINVALUE 0
+  MINVALUE 1
   NO CYCLE
   CACHE 1;
+
+-- GET current ID for source table
+-- and resetting number
+SELECT @cur_id_val = coalesce(MAX(SOURCE_ID), 1) FROM ${ohdsiSchema}.source_bak;
+SET @sql = N'ALTER SEQUENCE ${ohdsiSchema}.source_sequence RESTART WITH ' + CAST(@cur_id_val as NVARCHAR(20)) + ';';
+
+EXEC sp_executesql @sql;
 
 CREATE TABLE ${ohdsiSchema}.source
 (
@@ -35,9 +46,16 @@ EXEC sp_rename '[${ohdsiSchema}].[source_daimon]', 'source_daimon_bak';
 
 CREATE SEQUENCE ${ohdsiSchema}.source_daimon_sequence
   AS BIGINT
-  MINVALUE 0
+  MINVALUE 1
   NO CYCLE
   CACHE 1;
+
+-- GET current id for previous source_daimon table
+-- and resetting number
+SELECT @cur_id_val = coalesce(MAX(source_daimon_id), 1) FROM ${ohdsiSchema}.source_daimon_bak;
+SET @sql = N'ALTER SEQUENCE ${ohdsiSchema}.source_daimon_sequence RESTART WITH ' + CAST(@cur_id_val as NVARCHAR(20)) + ';';
+
+EXEC sp_executesql @sql;
 
 CREATE TABLE ${ohdsiSchema}.source_daimon
 (

--- a/src/main/resources/db/migration/sqlserver/V2.7.0.20190201140945__sources-created-modified-fix.sql
+++ b/src/main/resources/db/migration/sqlserver/V2.7.0.20190201140945__sources-created-modified-fix.sql
@@ -1,71 +1,95 @@
+CREATE SEQUENCE ${ohdsiSchema}.source_sequence
+  AS BIGINT
+  START WITH 1
+  NO CYCLE;
+GO
+
+-- Create sid,,
+ALTER TABLE ${ohdsiSchema}.source ADD sid INT;
+GO
+
+UPDATE ${ohdsiSchema}.source SET sid = SOURCE_ID;
+GO
+
+-- DROP constraints and columns,,
+ALTER TABLE ${ohdsiSchema}.source DROP CONSTRAINT PK_source;
+GO
+
+ALTER TABLE ${ohdsiSchema}.source DROP COLUMN SOURCE_ID;
+GO
+
+-- sid is column,,
+EXEC sp_rename '[${ohdsiSchema}].source.sid', 'SOURCE_ID', 'COLUMN';
+GO
+
+ALTER TABLE ${ohdsiSchema}.source ALTER COLUMN SOURCE_ID INT NOT NULL;
+GO
+
+
+ALTER TABLE ${ohdsiSchema}.source ADD CONSTRAINT DF_source_id DEFAULT (NEXT VALUE FOR ${ohdsiSchema}.source_sequence) FOR SOURCE_ID;
+GO
+
+ALTER TABLE ${ohdsiSchema}.source ADD CONSTRAINT PK_source PRIMARY KEY clustered(SOURCE_ID asc);
+GO
+
 -- DECLARE current id
 DECLARE @cur_id_val INT;
 DECLARE @sql NVARCHAR(MAX);
 
--- RENAME source table
-ALTER TABLE ${ohdsiSchema}.source DROP CONSTRAINT DF_source_SOURCE_DIALECT;
-ALTER TABLE ${ohdsiSchema}.source DROP CONSTRAINT source_key_unique;
-ALTER TABLE ${ohdsiSchema}.source DROP CONSTRAINT PK_source;
-
-EXEC sp_rename '[${ohdsiSchema}].[source]', 'source_bak';
-
-CREATE SEQUENCE ${ohdsiSchema}.source_sequence
-  AS BIGINT
-  MINVALUE 1
-  NO CYCLE
-  CACHE 1;
-
 -- GET current ID for source table
 -- and resetting number
-SELECT @cur_id_val = coalesce(MAX(SOURCE_ID), 1) FROM ${ohdsiSchema}.source_bak;
+SELECT @cur_id_val = coalesce(MAX(SOURCE_ID), 1) FROM ${ohdsiSchema}.source;
 SET @sql = N'ALTER SEQUENCE ${ohdsiSchema}.source_sequence RESTART WITH ' + CAST(@cur_id_val as NVARCHAR(20)) + ';';
 
 EXEC sp_executesql @sql;
+GO
 
-CREATE TABLE ${ohdsiSchema}.source
-(
-  SOURCE_ID         int not null constraint PK_source default NEXT VALUE FOR ${ohdsiSchema}.source_sequence primary key clustered,
-  SOURCE_NAME       varchar(255)                   not null,
-  SOURCE_KEY        varchar(50)                    not null constraint [source_key_unique] unique,
-  SOURCE_CONNECTION varchar(8000)                  not null,
-  SOURCE_DIALECT    varchar(255) CONSTRAINT [DF_source_SOURCE_DIALECT] DEFAULT ('sql server') not null,
-  username          nvarchar(255),
-  password          nvarchar(255),
-  krb_auth_method   varchar(10) default 'PASSWORD' not null,
-  keytab_name       varchar(50),
-  krb_keytab        varbinary(max),
-  krb_admin_server  varchar(50),
-  deleted_date      datetime
-) ON [PRIMARY];
-
--- Copy previous source configuration and drop table
-INSERT INTO ${ohdsiSchema}.source SELECT * from ${ohdsiSchema}.source_bak;
-DROP TABLE ${ohdsiSchema}.source_bak;
-
-EXEC sp_rename '[${ohdsiSchema}].[source_daimon]', 'source_daimon_bak';
 
 CREATE SEQUENCE ${ohdsiSchema}.source_daimon_sequence
   AS BIGINT
-  MINVALUE 1
-  NO CYCLE
-  CACHE 1;
+  START WITH 1
+  NO CYCLE;
+GO
+
+-- Create source diamon id,,
+ALTER TABLE ${ohdsiSchema}.source_daimon ADD sd_id INT;
+GO
+
+UPDATE ${ohdsiSchema}.source_daimon SET sd_id = source_daimon_id;
+GO
+
+-- DROP previous column
+DECLARE @pk nvarchar(512);
+SELECT @pk = Name FROM SYS.KEY_CONSTRAINTS WHERE [type] = 'PK' AND PARENT_OBJECT_ID = OBJECT_ID('${ohdsiSchema}.source_daimon')
+
+IF @pk IS NOT NULL
+EXEC('ALTER TABLE ${ohdsiSchema}.source_daimon DROP CONSTRAINT ' + @pk);
+GO
+
+ALTER TABLE ${ohdsiSchema}.source_daimon DROP COLUMN source_daimon_id;
+GO
+
+-- sd_id is column,,
+EXEC sp_rename '[${ohdsiSchema}].source_daimon.sd_id', 'source_daimon_id', 'COLUMN';
+GO
+
+ALTER TABLE ${ohdsiSchema}.source_daimon ALTER COLUMN source_daimon_id INT NOT NULL;
+GO
+
+ALTER TABLE ${ohdsiSchema}.source_daimon ADD CONSTRAINT DF_source_daimon_id DEFAULT (NEXT VALUE FOR ${ohdsiSchema}.source_daimon_sequence) FOR source_daimon_id;
+GO
+
+ALTER TABLE ${ohdsiSchema}.source_daimon ADD CONSTRAINT PK_source_daimon PRIMARY KEY clustered(source_daimon_id asc);
+GO
+
+-- DECLARE current id
+DECLARE @cur_id_val INT;
+DECLARE @sql NVARCHAR(MAX);
 
 -- GET current id for previous source_daimon table
 -- and resetting number
-SELECT @cur_id_val = coalesce(MAX(source_daimon_id), 1) FROM ${ohdsiSchema}.source_daimon_bak;
+SELECT @cur_id_val = coalesce(MAX(source_daimon_id), 1) FROM ${ohdsiSchema}.source_daimon;
 SET @sql = N'ALTER SEQUENCE ${ohdsiSchema}.source_daimon_sequence RESTART WITH ' + CAST(@cur_id_val as NVARCHAR(20)) + ';';
 
 EXEC sp_executesql @sql;
-
-CREATE TABLE ${ohdsiSchema}.source_daimon
-(
-  source_daimon_id int not null constraint PK_source_daimon default NEXT VALUE FOR ${ohdsiSchema}.source_sequence primary key clustered,
-  source_id        int           not null,
-  daimon_type      int           not null,
-  table_qualifier  varchar(255)  not null,
-  priority         int default 0 not null
-) ON [PRIMARY];
-
--- Copy previous source configuration and drop table
-INSERT INTO ${ohdsiSchema}.source_daimon SELECT * from ${ohdsiSchema}.source_daimon_bak;
-DROP TABLE ${ohdsiSchema}.source_daimon_bak;
+GO

--- a/src/main/resources/db/migration/sqlserver/V2.7.0.20190201140945__sources-created-modified-fix.sql
+++ b/src/main/resources/db/migration/sqlserver/V2.7.0.20190201140945__sources-created-modified-fix.sql
@@ -1,0 +1,53 @@
+-- RENAME source table
+ALTER TABLE ${ohdsiSchema}.source DROP CONSTRAINT DF_source_SOURCE_DIALECT;
+ALTER TABLE ${ohdsiSchema}.source DROP CONSTRAINT source_key_unique;
+ALTER TABLE ${ohdsiSchema}.source DROP CONSTRAINT PK_source;
+
+EXEC sp_rename '[${ohdsiSchema}].[source]', 'source_bak';
+
+CREATE SEQUENCE ${ohdsiSchema}.source_sequence
+  AS BIGINT
+  MINVALUE 0
+  NO CYCLE
+  CACHE 1;
+
+CREATE TABLE ${ohdsiSchema}.source
+(
+  SOURCE_ID         int default NEXT VALUE FOR ${ohdsiSchema}.source_sequence not null constraint PK_source primary key nonclustered,
+  SOURCE_NAME       varchar(255)                   not null,
+  SOURCE_KEY        varchar(50)                    not null constraint [source_key_unique] unique,
+  SOURCE_CONNECTION varchar(8000)                  not null,
+  SOURCE_DIALECT    varchar(255) CONSTRAINT [DF_source_SOURCE_DIALECT] DEFAULT ('sql server') not null,
+  username          nvarchar(255),
+  password          nvarchar(255),
+  krb_auth_method   varchar(10) default 'PASSWORD' not null,
+  keytab_name       varchar(50),
+  krb_keytab        varbinary(max),
+  krb_admin_server  varchar(50),
+  deleted_date      datetime
+)
+
+-- Copy previous source configuration and drop table
+INSERT INTO ${ohdsiSchema}.source SELECT * from ${ohdsiSchema}.source_bak;
+DROP TABLE ${ohdsiSchema}.source_bak;
+
+EXEC sp_rename '[${ohdsiSchema}].[source_daimon]', 'source_daimon_bak';
+
+CREATE SEQUENCE ${ohdsiSchema}.source_daimon_sequence
+  AS BIGINT
+  MINVALUE 0
+  NO CYCLE
+  CACHE 1;
+
+CREATE TABLE ${ohdsiSchema}.source_daimon
+(
+  source_daimon_id int default NEXT VALUE FOR ${ohdsiSchema}.source_sequence not null primary key,
+  source_id        int           not null,
+  daimon_type      int           not null,
+  table_qualifier  varchar(255)  not null,
+  priority         int default 0 not null
+)
+
+-- Copy previous source configuration and drop table
+INSERT INTO ${ohdsiSchema}.source_daimon SELECT * from ${ohdsiSchema}.source_daimon_bak;
+DROP TABLE ${ohdsiSchema}.source_daimon_bak;

--- a/src/main/resources/db/migration/sqlserver/V2.7.0.20190201140945__sources-created-modified-fix.sql
+++ b/src/main/resources/db/migration/sqlserver/V2.7.0.20190201140945__sources-created-modified-fix.sql
@@ -24,7 +24,7 @@ EXEC sp_executesql @sql;
 
 CREATE TABLE ${ohdsiSchema}.source
 (
-  SOURCE_ID         int default NEXT VALUE FOR ${ohdsiSchema}.source_sequence not null constraint PK_source primary key nonclustered,
+  SOURCE_ID         int not null constraint PK_source default NEXT VALUE FOR ${ohdsiSchema}.source_sequence primary key clustered,
   SOURCE_NAME       varchar(255)                   not null,
   SOURCE_KEY        varchar(50)                    not null constraint [source_key_unique] unique,
   SOURCE_CONNECTION varchar(8000)                  not null,
@@ -36,7 +36,7 @@ CREATE TABLE ${ohdsiSchema}.source
   krb_keytab        varbinary(max),
   krb_admin_server  varchar(50),
   deleted_date      datetime
-)
+) ON [PRIMARY];
 
 -- Copy previous source configuration and drop table
 INSERT INTO ${ohdsiSchema}.source SELECT * from ${ohdsiSchema}.source_bak;
@@ -59,12 +59,12 @@ EXEC sp_executesql @sql;
 
 CREATE TABLE ${ohdsiSchema}.source_daimon
 (
-  source_daimon_id int default NEXT VALUE FOR ${ohdsiSchema}.source_sequence not null primary key,
+  source_daimon_id int not null constraint PK_source_daimon default NEXT VALUE FOR ${ohdsiSchema}.source_sequence primary key clustered,
   source_id        int           not null,
   daimon_type      int           not null,
   table_qualifier  varchar(255)  not null,
   priority         int default 0 not null
-)
+) ON [PRIMARY];
 
 -- Copy previous source configuration and drop table
 INSERT INTO ${ohdsiSchema}.source_daimon SELECT * from ${ohdsiSchema}.source_daimon_bak;

--- a/src/main/resources/db/migration/sqlserver/V2.7.0.20190201154512__heracles-visualization-data-fix.sql
+++ b/src/main/resources/db/migration/sqlserver/V2.7.0.20190201154512__heracles-visualization-data-fix.sql
@@ -10,7 +10,7 @@ CREATE SEQUENCE ${ohdsiSchema}.HERACLES_VIZ_DATA_SEQUENCE
 
 DECLARE @cur_id_val INT;
 DECLARE @sql NVARCHAR(MAX);
-SELECT @cur_id_val =  coalesce(MAX(id), 1) FROM ${ohdsiSchema}.HERACLES_VISUALIZATION_DATA_bak;
+SELECT @cur_id_val = coalesce(MAX(id), 1) FROM ${ohdsiSchema}.HERACLES_VISUALIZATION_DATA_bak;
 SET @sql = N'ALTER SEQUENCE ${ohdsiSchema}.HERACLES_VIZ_DATA_SEQUENCE RESTART WITH ' + CAST(@cur_id_val as NVARCHAR(20)) + ';';
 
 EXEC sp_executesql @sql;
@@ -21,10 +21,10 @@ create table ${ohdsiSchema}.HERACLES_VISUALIZATION_DATA
   source_id            int          not null,
   visualization_key    varchar(300) not null,
   drilldown_id         int,
-  id                   int default NEXT VALUE FOR ${ohdsiSchema}.HERACLES_VIZ_DATA_SEQUENCE,
+  id                   int not null constraint PK_heracles_viz_data default NEXT VALUE FOR ${ohdsiSchema}.HERACLES_VIZ_DATA_SEQUENCE,
   end_time             datetime,
   data                 varchar(max)
-);
+) ON [PRIMARY];
 
-INSERT INTO ${ohdsiSchema}.HERACLES_VISUALIZATION_DATA SELECT * FROM HERACLES_VISUALIZATION_DATA_bak;
+INSERT INTO ${ohdsiSchema}.HERACLES_VISUALIZATION_DATA SELECT * FROM ${ohdsiSchema}.HERACLES_VISUALIZATION_DATA_bak;
 DROP TABLE ${ohdsiSchema}.HERACLES_VISUALIZATION_DATA_bak;

--- a/src/main/resources/db/migration/sqlserver/V2.7.0.20190201154512__heracles-visualization-data-fix.sql
+++ b/src/main/resources/db/migration/sqlserver/V2.7.0.20190201154512__heracles-visualization-data-fix.sql
@@ -1,0 +1,20 @@
+ALTER TABLE ${ohdsiSchema}.HERACLES_VISUALIZATION_DATA DROP CONSTRAINT PK_heracles_viz_data;
+
+EXEC sp_rename '[${ohdsiSchema}].[HERACLES_VISUALIZATION_DATA]', 'HERACLES_VISUALIZATION_DATA_bak';
+
+CREATE SEQUENCE ${ohdsiSchema}.HERACLES_VIZ_DATA_SEQUENCE
+  AS BIGINT
+  START WITH 0
+  NO CYCLE
+  CACHE 1;
+
+create table ${ohdsiSchema}.HERACLES_VISUALIZATION_DATA
+(
+  cohort_definition_id int          not null,
+  source_id            int          not null,
+  visualization_key    varchar(300) not null,
+  drilldown_id         int,
+  id                   int default NEXT VALUE FOR ${ohdsiSchema}.HERACLES_VIZ_DATA_SEQUENCE,
+  end_time             datetime,
+  data                 varchar(max)
+);

--- a/src/main/resources/db/migration/sqlserver/V2.7.0.20190201154512__heracles-visualization-data-fix.sql
+++ b/src/main/resources/db/migration/sqlserver/V2.7.0.20190201154512__heracles-visualization-data-fix.sql
@@ -18,3 +18,6 @@ create table ${ohdsiSchema}.HERACLES_VISUALIZATION_DATA
   end_time             datetime,
   data                 varchar(max)
 );
+
+INSERT INTO ${ohdsiSchema}.HERACLES_VISUALIZATION_DATA SELECT * FROM HERACLES_VISUALIZATION_DATA_bak;
+DROP TABLE ${ohdsiSchema}.HERACLES_VISUALIZATION_DATA_bak;

--- a/src/main/resources/db/migration/sqlserver/V2.7.0.20190201154512__heracles-visualization-data-fix.sql
+++ b/src/main/resources/db/migration/sqlserver/V2.7.0.20190201154512__heracles-visualization-data-fix.sql
@@ -4,9 +4,16 @@ EXEC sp_rename '[${ohdsiSchema}].[HERACLES_VISUALIZATION_DATA]', 'HERACLES_VISUA
 
 CREATE SEQUENCE ${ohdsiSchema}.HERACLES_VIZ_DATA_SEQUENCE
   AS BIGINT
-  START WITH 0
+  START WITH 1
   NO CYCLE
   CACHE 1;
+
+DECLARE @cur_id_val INT;
+DECLARE @sql NVARCHAR(MAX);
+SELECT @cur_id_val =  coalesce(MAX(id), 1) FROM ${ohdsiSchema}.HERACLES_VISUALIZATION_DATA_bak;
+SET @sql = N'ALTER SEQUENCE ${ohdsiSchema}.HERACLES_VIZ_DATA_SEQUENCE RESTART WITH ' + CAST(@cur_id_val as NVARCHAR(20)) + ';';
+
+EXEC sp_executesql @sql;
 
 create table ${ohdsiSchema}.HERACLES_VISUALIZATION_DATA
 (


### PR DESCRIPTION
Fixed #753 
@chrisknoll I have migrated to SQL Server with reference to PostgreSQL query.

In addition, regardless of this issue, we have verified that the data type of the data column in the Heracles visualization data table is ```TEXT```. However, when use ```select``` query in JPA, exception is caused by using ```distinct```. I think it would be right to use ```union all```. However, for compatibility with other RDBMS, I changed it to ```VARCHAR``` instead of TEXT and set the length to MAX.