### PR TITLE
Fix to overlap logic

### DIFF
--- a/src/main/resources/resources/pathway/runPathwayAnalysis.sql
+++ b/src/main/resources/resources/pathway/runPathwayAnalysis.sql
@@ -19,9 +19,9 @@ FROM (
 	  e.subject_id,
 	  e.cohort_start_date,
 	  e.cohort_end_date
-	FROM @target_database_schema.@target_cohort_table e
+	FROM @target_cohort_table e
 	  JOIN ( @event_cohort_id_index_map ) ec ON e.cohort_definition_id = ec.cohort_definition_id
-	  JOIN @target_database_schema.@target_cohort_table t ON t.cohort_start_date <= e.cohort_start_date AND e.cohort_end_date <= t.cohort_end_date AND t.subject_id = e.subject_id
+	  JOIN @target_cohort_table t ON t.cohort_start_date <= e.cohort_start_date AND e.cohort_end_date <= t.cohort_end_date AND t.subject_id = e.subject_id
 	WHERE t.cohort_definition_id = @pathway_target_cohort_id
 ) RE;
 
@@ -168,7 +168,7 @@ SELECT
   pathway_count.cnt AS pathways_count
 FROM (
   SELECT COUNT(*) cnt
-  FROM @target_database_schema.@target_cohort_table
+  FROM @target_cohort_table
   WHERE cohort_definition_id = @pathway_target_cohort_id
 ) target_count,
 (


### PR DESCRIPTION
Implements the changes discussed in [https://github.com/OHDSI/WebAPI/issues/779](url) .

It is important to note that the new overlap logic will recognise a one day overlap between two cohorts where `cohort1.cohort_end_date = cohort2.cohort_start_date`. On its own, this is probably technically correct given the OMOP convention for cohort dates to be inclusive.

However, there is an interaction with the collapse window functionality. If one `cohort_end_date` is within `collapse_window` of another `cohort_start_date`, a one day overlap will be artificially created. While I'm guessing these scenarios are very much edge cases, I doubt it's the behaviour we want. 

[mick-iqvia](/mick-iqvia) and I have been discussing some alternative ways that closely related event windows could be collapsed. We may want to consider incorporating into the same release as this PR. 