### PR TITLE
Fixed status update of IR generation info when Spring Batch job is cancelled

### DIFF
--- a/src/main/java/org/ohdsi/webapi/cohortcharacterization/CcServiceImpl.java
+++ b/src/main/java/org/ohdsi/webapi/cohortcharacterization/CcServiceImpl.java
@@ -35,11 +35,10 @@ import org.ohdsi.webapi.util.SessionUtils;
 import org.ohdsi.webapi.util.SourceUtils;
 import org.springframework.batch.core.BatchStatus;
 import org.springframework.batch.core.ExitStatus;
-import org.springframework.batch.core.Job;
 import org.springframework.batch.core.JobExecution;
 import org.springframework.batch.core.JobParameters;
 import org.springframework.batch.core.JobParametersBuilder;
-import org.springframework.batch.core.explore.JobExplorer;
+import org.springframework.batch.core.job.builder.SimpleJobBuilder;
 import org.springframework.batch.core.repository.JobRepository;
 import org.springframework.context.annotation.DependsOn;
 import org.springframework.core.convert.ConversionService;
@@ -362,7 +361,7 @@ public class CcServiceImpl extends AbstractDaoService implements CcService, Gene
 
         CancelableJdbcTemplate jdbcTemplate = getSourceJdbcTemplate(source);
 
-        Job generateCohortJob = generationUtils.buildJobForCohortBasedAnalysisTasklet(
+        SimpleJobBuilder generateCohortJob = generationUtils.buildJobForCohortBasedAnalysisTasklet(
                 GENERATE_COHORT_CHARACTERIZATION,
                 source,
                 builder,
@@ -384,7 +383,7 @@ public class CcServiceImpl extends AbstractDaoService implements CcService, Gene
 
         final JobParameters jobParameters = builder.toJobParameters();
 
-        return jobService.runJob(generateCohortJob, jobParameters);
+        return jobService.runJob(generateCohortJob.build(), jobParameters);
     }
 
     @Override

--- a/src/main/java/org/ohdsi/webapi/common/generation/GenerationUtils.java
+++ b/src/main/java/org/ohdsi/webapi/common/generation/GenerationUtils.java
@@ -67,7 +67,7 @@ public class GenerationUtils extends AbstractDaoService {
         return Constants.TEMP_COHORT_TABLE_PREFIX + sessionId;
     }
 
-    public Job buildJobForCohortBasedAnalysisTasklet(
+    public SimpleJobBuilder buildJobForCohortBasedAnalysisTasklet(
             String analysisTypeName,
             Source source,
             JobParametersBuilder builder,
@@ -120,6 +120,6 @@ public class GenerationUtils extends AbstractDaoService {
                 .listener(dropCohortTableListener)
                 .listener(new AutoremoveJobListener(jobService));
 
-        return generateJobBuilder.build();
+        return generateJobBuilder;
     }
 }

--- a/src/main/java/org/ohdsi/webapi/ircalc/IRAnalysisInfoListener.java
+++ b/src/main/java/org/ohdsi/webapi/ircalc/IRAnalysisInfoListener.java
@@ -73,7 +73,7 @@ public class IRAnalysisInfoListener implements JobExecutionListener {
 
         findExecutionInfoBySourceId(analysis.getExecutionInfoList(), sourceId).ifPresent(analysisInfo -> {
             analysisInfo.setIsValid(isValid);
-			analysisInfo.setCanceled(je.getStepExecutions().stream().anyMatch(se -> Objects.equals(Constants.CANCELED, se.getExitStatus().getExitCode())));
+			analysisInfo.setCanceled(je.getStatus() == BatchStatus.STOPPED || je.getStepExecutions().stream().anyMatch(se -> Objects.equals(Constants.CANCELED, se.getExitStatus().getExitCode())));
             analysisInfo.setExecutionDuration((int) (endTime.getTime() - startTime.getTime()));
             analysisInfo.setStatus(GenerationStatus.COMPLETE);
             analysisInfo.setMessage(statusMessage.substring(0, Math.min(MAX_MESSAGE_LENGTH, statusMessage.length())));

--- a/src/main/java/org/ohdsi/webapi/ircalc/IRAnalysisInfoListener.java
+++ b/src/main/java/org/ohdsi/webapi/ircalc/IRAnalysisInfoListener.java
@@ -1,0 +1,92 @@
+package org.ohdsi.webapi.ircalc;
+
+import org.ohdsi.webapi.Constants;
+import org.ohdsi.webapi.GenerationStatus;
+import org.springframework.batch.core.BatchStatus;
+import org.springframework.batch.core.JobExecution;
+import org.springframework.batch.core.JobExecutionListener;
+import org.springframework.batch.core.JobParameters;
+import org.springframework.transaction.TransactionDefinition;
+import org.springframework.transaction.TransactionStatus;
+import org.springframework.transaction.support.DefaultTransactionDefinition;
+import org.springframework.transaction.support.TransactionTemplate;
+
+import java.util.Calendar;
+import java.util.Collection;
+import java.util.Date;
+import java.util.Objects;
+import java.util.Optional;
+
+public class IRAnalysisInfoListener implements JobExecutionListener {
+
+    private static final int MAX_MESSAGE_LENGTH = 2000;
+
+    private final TransactionTemplate transactionTemplate;
+    private final IncidenceRateAnalysisRepository incidenceRateAnalysisRepository;
+    private Date startTime;
+
+    public IRAnalysisInfoListener(TransactionTemplate transactionTemplate, IncidenceRateAnalysisRepository incidenceRateAnalysisRepository) {
+
+        this.transactionTemplate = transactionTemplate;
+        this.incidenceRateAnalysisRepository = incidenceRateAnalysisRepository;
+    }
+
+    @Override
+    public void beforeJob(JobExecution je) {
+
+        startTime = Calendar.getInstance().getTime();
+        JobParameters jobParams = je.getJobParameters();
+        Integer analysisId = Integer.valueOf(jobParams.getString("analysis_id"));
+        Integer sourceId = Integer.valueOf(jobParams.getString("source_id"));
+
+        DefaultTransactionDefinition requresNewTx = new DefaultTransactionDefinition();
+        requresNewTx.setPropagationBehavior(TransactionDefinition.PROPAGATION_REQUIRES_NEW);
+
+        TransactionStatus initStatus = this.transactionTemplate.getTransactionManager().getTransaction(requresNewTx);
+        IncidenceRateAnalysis analysis = this.incidenceRateAnalysisRepository.findOne(analysisId);
+
+        findExecutionInfoBySourceId(analysis.getExecutionInfoList(), sourceId).ifPresent(analysisInfo -> {
+            analysisInfo.setIsValid(false);
+            analysisInfo.setStartTime(startTime);
+            analysisInfo.setStatus(GenerationStatus.RUNNING);
+        });
+
+        this.incidenceRateAnalysisRepository.save(analysis);
+        this.transactionTemplate.getTransactionManager().commit(initStatus);
+    }
+
+    @Override
+    public void afterJob(JobExecution je) {
+
+        boolean isValid = !(je.getStatus() == BatchStatus.FAILED || je.getStatus() == BatchStatus.STOPPED);
+        String statusMessage = je.getExitStatus().getExitDescription();
+
+        JobParameters jobParams = je.getJobParameters();
+        Integer analysisId = Integer.valueOf(jobParams.getString("analysis_id"));
+        Integer sourceId = Integer.valueOf(jobParams.getString("source_id"));
+
+        DefaultTransactionDefinition requresNewTx = new DefaultTransactionDefinition();
+        requresNewTx.setPropagationBehavior(TransactionDefinition.PROPAGATION_REQUIRES_NEW);
+        TransactionStatus completeStatus = this.transactionTemplate.getTransactionManager().getTransaction(requresNewTx);
+        Date endTime = Calendar.getInstance().getTime();
+        IncidenceRateAnalysis analysis = this.incidenceRateAnalysisRepository.findOne(analysisId);
+
+        findExecutionInfoBySourceId(analysis.getExecutionInfoList(), sourceId).ifPresent(analysisInfo -> {
+            analysisInfo.setIsValid(isValid);
+			analysisInfo.setCanceled(je.getStepExecutions().stream().anyMatch(se -> Objects.equals(Constants.CANCELED, se.getExitStatus().getExitCode())));
+            analysisInfo.setExecutionDuration((int) (endTime.getTime() - startTime.getTime()));
+            analysisInfo.setStatus(GenerationStatus.COMPLETE);
+            analysisInfo.setMessage(statusMessage.substring(0, Math.min(MAX_MESSAGE_LENGTH, statusMessage.length())));
+        });
+
+        this.incidenceRateAnalysisRepository.save(analysis);
+        this.transactionTemplate.getTransactionManager().commit(completeStatus);
+    }
+
+    private Optional<ExecutionInfo> findExecutionInfoBySourceId(Collection<ExecutionInfo> infoList, Integer sourceId) {
+
+        return infoList.stream()
+                .filter(info -> Objects.equals(info.getId().getSourceId(), sourceId))
+                .findFirst();
+    }
+}

--- a/src/main/java/org/ohdsi/webapi/pathway/PathwayServiceImpl.java
+++ b/src/main/java/org/ohdsi/webapi/pathway/PathwayServiceImpl.java
@@ -40,6 +40,7 @@ import org.ohdsi.webapi.util.SourceUtils;
 import org.springframework.batch.core.Job;
 import org.springframework.batch.core.JobParameters;
 import org.springframework.batch.core.JobParametersBuilder;
+import org.springframework.batch.core.job.builder.SimpleJobBuilder;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.convert.ConversionService;
 import org.springframework.data.domain.Page;
@@ -325,7 +326,7 @@ public class PathwayServiceImpl extends AbstractDaoService implements PathwaySer
 
         JdbcTemplate jdbcTemplate = getSourceJdbcTemplate(source);
 
-        Job generateAnalysisJob = generationUtils.buildJobForCohortBasedAnalysisTasklet(
+        SimpleJobBuilder generateAnalysisJob = generationUtils.buildJobForCohortBasedAnalysisTasklet(
                 GENERATE_PATHWAY_ANALYSIS,
                 source,
                 builder,
@@ -349,7 +350,7 @@ public class PathwayServiceImpl extends AbstractDaoService implements PathwaySer
 
         final JobParameters jobParameters = builder.toJobParameters();
 
-        jobService.runJob(generateAnalysisJob, jobParameters);
+        jobService.runJob(generateAnalysisJob.build(), jobParameters);
     }
 
     @Override


### PR DESCRIPTION
On job cancel the `doAfter` wasn't called and the generation info was stuck in PENDING state. Therefore, the approach similar to the cohort definition's one was applied.

Related to https://github.com/OHDSI/WebAPI/pull/801 and https://github.com/OHDSI/Atlas/issues/1099