### PR TITLE
Add posixGroup...

### DIFF
--- a/src/main/java/org/ohdsi/webapi/user/importer/providers/DefaultLdapProvider.java
+++ b/src/main/java/org/ohdsi/webapi/user/importer/providers/DefaultLdapProvider.java
@@ -48,7 +48,7 @@ public class DefaultLdapProvider extends AbstractLdapProvider {
   @Value("${security.ldap.system.password}")
   private String systemPassword;
 
-  private static final Set<String> GROUP_CLASSES = ImmutableSet.of("groupOfUniqueNames", "groupOfNames");
+  private static final Set<String> GROUP_CLASSES = ImmutableSet.of("groupOfUniqueNames", "groupOfNames", "posixGroup");
 
   private static final Set<String> USER_CLASSES = ImmutableSet.of("account", "person");
 


### PR DESCRIPTION
Fixed #875 
In OpenLDAP, the name of the default group is used as posixGroup, which requires code that includes it in the WebAPI.