### PR TITLE
Ensure ResultsCache.getCache() always returns a non-null. Fixes #901

### DIFF
--- a/src/main/java/org/ohdsi/webapi/cache/ResultsCache.java
+++ b/src/main/java/org/ohdsi/webapi/cache/ResultsCache.java
@@ -16,7 +16,6 @@
 package org.ohdsi.webapi.cache;
 
 import java.util.HashMap;
-import java.util.Objects;
 import org.ohdsi.webapi.cdmresults.CDMResultsCache;
 
 /**
@@ -31,7 +30,7 @@ public class ResultsCache {
     }
     
     public CDMResultsCache getCache(String sourceKey) {
-        CDMResultsCache returnVal = this.getCaches().putIfAbsent(sourceKey, new CDMResultsCache());
-        return Objects.isNull(returnVal) ? this.getCaches().get(sourceKey) : returnVal;
+        this.getCaches().putIfAbsent(sourceKey, new CDMResultsCache());
+        return this.getCaches().get(sourceKey);
     }
 }

--- a/src/main/java/org/ohdsi/webapi/cache/ResultsCache.java
+++ b/src/main/java/org/ohdsi/webapi/cache/ResultsCache.java
@@ -16,6 +16,7 @@
 package org.ohdsi.webapi.cache;
 
 import java.util.HashMap;
+import java.util.Objects;
 import org.ohdsi.webapi.cdmresults.CDMResultsCache;
 
 /**
@@ -30,6 +31,7 @@ public class ResultsCache {
     }
     
     public CDMResultsCache getCache(String sourceKey) {
-        return this.getCaches().putIfAbsent(sourceKey, new CDMResultsCache());
+        CDMResultsCache returnVal = this.getCaches().putIfAbsent(sourceKey, new CDMResultsCache());
+        return Objects.isNull(returnVal) ? this.getCaches().get(sourceKey) : returnVal;
     }
 }


### PR DESCRIPTION
fixes #901