### PR TITLE
Update table target in SQL Server migration. Fixes #906

### DIFF
--- a/src/main/resources/db/migration/sqlserver/V2.7.0.20190304220500__role-moderator.sql
+++ b/src/main/resources/db/migration/sqlserver/V2.7.0.20190304220500__role-moderator.sql
@@ -1,4 +1,4 @@
-INSERT INTO ${ohdsiSchema}.sec_permission(id, name, system_role) VALUES
+INSERT INTO ${ohdsiSchema}.sec_role(id, name, system_role) VALUES
   (NEXT VALUE FOR ${ohdsiSchema}.sec_role_sequence, 'Moderator', TRUE);
 
 insert into ${ohdsiSchema}.sec_permission(id, value, description)


### PR DESCRIPTION
Updates SQL Server migration to use the proper table which is based off of the corresponding PostgreSQL migration: [V2.7.0.20190304220500__role-moderator.sql](https://github.com/OHDSI/WebAPI/blob/master/src/main/resources/db/migration/postgresql/V2.7.0.20190304220500__role-moderator.sql)