### PR TITLE
Updates pom to use newer StdApi and Hydra

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -631,7 +631,7 @@
     <dependency>
       <groupId>org.ohdsi</groupId>
       <artifactId>hydra</artifactId>
-      <version>0.0.4</version>
+      <version>0.0.4-SNAPSHOT</version>
     </dependency>
     <dependency>
       <groupId>org.json</groupId>
@@ -704,7 +704,7 @@
     <dependency>
       <groupId>org.ohdsi</groupId>
       <artifactId>standardized-analysis-api</artifactId>
-      <version>1.1.0</version>
+      <version>1.1.1-SNAPSHOT</version>
     </dependency>
     <dependency>
       <groupId>com.cosium.spring.data</groupId>


### PR DESCRIPTION
Updates pom.xml to use newer version of StandardizedAnalysisApi as referenced in this PR: OHDSI/StandardizedAnalysisApi#20. Also uses a newer version of Hydra to include fixes from @jreps on the PLP skeletons. 

Aims to fix #976.