### PR TITLE
Remove non-OHDSI nexus references from pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -373,32 +373,6 @@
       <id>redshift</id>
       <url>http://redshift-maven-repository.s3-website-us-east-1.amazonaws.com/release</url>
     </repository>
-    <repository>
-      <id>odysseus.community.snapshots</id>
-      <name>Odysseus community snapshots</name>
-      <releases>
-        <enabled>false</enabled>
-        <updatePolicy>always</updatePolicy>
-      </releases>
-      <snapshots>
-        <enabled>true</enabled>
-        <updatePolicy>always</updatePolicy>
-      </snapshots>
-      <url>http://repo.odysseusinc.com/artifactory/community-libs-snapshot-local</url>
-    </repository>
-    <repository>
-      <id>odysseus.community.releases</id>
-      <name>Odysseus community releases</name>
-      <releases>
-        <enabled>true</enabled>
-        <updatePolicy>always</updatePolicy>
-      </releases>
-      <snapshots>
-        <enabled>false</enabled>
-        <updatePolicy>always</updatePolicy>
-      </snapshots>
-      <url>http://repo.odysseusinc.com/artifactory/community-libs-release-local</url>
-    </repository>
   </repositories>
 
   <pluginRepositories>

--- a/pom.xml
+++ b/pom.xml
@@ -618,7 +618,7 @@
     <dependency>
       <groupId>org.ohdsi</groupId>
       <artifactId>featureExtraction</artifactId>
-      <version>2.2.0-SNAPSHOT</version>
+      <version>2.2.0</version>
     </dependency>
     <dependency>
       <groupId>com.amazon.redshift</groupId>


### PR DESCRIPTION
Per #1034, I'm removing the references to 3rd party repositories in favor of using the OHDSI nexus repo for all OHDSI references. 