### PR TITLE
Raised hibernate version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -449,12 +449,12 @@
     <dependency>
       <groupId>org.hibernate</groupId>
       <artifactId>hibernate-core</artifactId>
-      <version>5.2.13.Final</version>
+      <version>5.2.14.Final</version>
     </dependency>
     <dependency>
       <groupId>org.hibernate</groupId>
       <artifactId>hibernate-entitymanager</artifactId>
-      <version>5.2.13.Final</version>
+      <version>5.2.14.Final</version>
     </dependency>
     <dependency>
       <groupId>javax.servlet</groupId>

--- a/src/main/java/org/ohdsi/webapi/cohortdefinition/CleanupCohortTasklet.java
+++ b/src/main/java/org/ohdsi/webapi/cohortdefinition/CleanupCohortTasklet.java
@@ -85,7 +85,7 @@ public class CleanupCohortTasklet implements Tasklet {
 				getSourceJdbcTemplate(source).batchUpdate(deleteSql.split(";")); // use batch update since SQL translation may produce multiple statements
 				sourcesUpdated++;
 			} catch (Exception e) {
-				log.error("Error deleting results for cohort: {}", cohortId);
+				log.error("Error deleting results for cohort: {}, cause: {}", cohortId, e.getMessage());
 			}
 		}
     return sourcesUpdated;


### PR DESCRIPTION
Fixes https://github.com/OHDSI/WebAPI/issues/1076

Due to hibernate bug in v.5.2.13.Final https://hibernate.atlassian.net/browse/HHH-9460 the order of deletion 'owner' and 'dependent' entities in 1-1 relation with `@OneToOne(optional = false)`  is incorrect: firstly 'owner' entity is deleted and only then the 'dependent' one. It was fixed in v.5.2.14