### PR TITLE
Revert "Raised hibernate version"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -449,12 +449,12 @@
     <dependency>
       <groupId>org.hibernate</groupId>
       <artifactId>hibernate-core</artifactId>
-      <version>5.2.14.Final</version>
+      <version>5.2.13.Final</version>
     </dependency>
     <dependency>
       <groupId>org.hibernate</groupId>
       <artifactId>hibernate-entitymanager</artifactId>
-      <version>5.2.14.Final</version>
+      <version>5.2.13.Final</version>
     </dependency>
     <dependency>
       <groupId>javax.servlet</groupId>

--- a/src/main/java/org/ohdsi/webapi/cohortdefinition/CleanupCohortTasklet.java
+++ b/src/main/java/org/ohdsi/webapi/cohortdefinition/CleanupCohortTasklet.java
@@ -85,7 +85,7 @@ public class CleanupCohortTasklet implements Tasklet {
 				getSourceJdbcTemplate(source).batchUpdate(deleteSql.split(";")); // use batch update since SQL translation may produce multiple statements
 				sourcesUpdated++;
 			} catch (Exception e) {
-				log.error("Error deleting results for cohort: {}, cause: {}", cohortId, e.getMessage());
+				log.error("Error deleting results for cohort: {}", cohortId);
 			}
 		}
     return sourcesUpdated;


### PR DESCRIPTION
Reverts OHDSI/WebAPI#1080.

Due to an issue in 5.2.14, describerd here: https://hibernate.atlassian.net/browse/HHH-12436

There is a problem persisting One-To-One mappings (there is a one-to-one mapping between CohortDefinition and CohortDefinitionDetails.

If we go with a newer version of Hibernate, we will need to take appropriate steps to handle the persistence of these one-to-one relationships.

As an aside, I'll work on reviewing hibernate 5.4.2.FINAL as an option, which I believe addresses this issue.

Fixes #1081.

