### PR TITLE
Update SQL migration - fixes #1105

### DIFF
--- a/src/main/resources/db/migration/sqlserver/V2.8.0.20190424150601__add-unique-name-constraint-to-entities.sql
+++ b/src/main/resources/db/migration/sqlserver/V2.8.0.20190424150601__add-unique-name-constraint-to-entities.sql
@@ -1,198 +1,553 @@
 -- Alter Concept Set table
 
-UPDATE ${ohdsiSchema}.concept_set
-SET concept_set_name = u.concept_set_name + ' (' + CAST(u.rn AS varchar(15)) + ')'
-FROM 
-  ${ohdsiSchema}.concept_set, 
-  (
-    SELECT d.concept_set_id, d.concept_set_name, d.rn
-    FROM
-    (
-      select a.concept_set_name, cd.concept_set_id, ROW_NUMBER() OVER(PARTITION BY a.concept_set_name ORDER BY cd.concept_set_id ASC) rn
-      FROM
-      (
-        select concept_set_name, COUNT(*) cnt
-        FROM ${ohdsiSchema}.concept_set
-        group by concept_set_name having COUNT(*) > 1
-      ) a
-      INNER JOIN ${ohdsiSchema}.concept_set cd ON a.concept_set_name = cd.concept_set_name
-    ) d 
-  ) u
- WHERE u.concept_set_id = ${ohdsiSchema}.concept_set.concept_set_id 
-;
+CREATE PROCEDURE ${ohdsiSchema}.rename_cs_names AS
+BEGIN
+    DECLARE @duplicate_names TABLE(id int IDENTITY (1, 1), duplicate_name varchar(100));
+    DECLARE @name_repeats TABLE (id int IDENTITY (1, 1), repeat_number int);
+    DECLARE @amount_of_duplicate_names int;
+    DECLARE @amount_of_constraints int;
+    DECLARE @constraint_title varchar(100);
+    DECLARE @schema_title varchar(100);
+    DECLARE @k int;
+    
+    SET @k = (SELECT COUNT(*) FROM (SELECT concept_set_name FROM ${ohdsiSchema}.concept_set
+                                    GROUP BY concept_set_name
+                                    HAVING COUNT(*) > 1) AS temp);
 
-ALTER TABLE ${ohdsiSchema}.concept_set ADD CONSTRAINT uq_cs_name UNIQUE (concept_set_name);
+    WHILE @k > 0
+        BEGIN
+            INSERT INTO @duplicate_names
+            SELECT concept_set_name FROM ${ohdsiSchema}.concept_set
+            GROUP BY concept_set_name
+            HAVING COUNT(*) > 1;
+        
+            INSERT INTO @name_repeats
+            SELECT COUNT(*) FROM ${ohdsiSchema}.concept_set
+            GROUP BY concept_set_name
+            HAVING COUNT(*) > 1;
+        
+            SET @amount_of_duplicate_names = (SELECT COUNT(*) FROM @duplicate_names);
+        
+            DECLARE @i int = 1;
+            DECLARE @j int = 1;
+            DECLARE @name_repeat int = 0;
+            DECLARE @dupl_name varchar(100);
+        
+            WHILE @i <= coalesce(@amount_of_duplicate_names, 0)
+            BEGIN
+                SET @name_repeat = (SELECT repeat_number FROM @name_repeats WHERE id = @i);
+                WHILE @j <= coalesce(@name_repeat, 0)
+                BEGIN
+                    SET @dupl_name = (SELECT duplicate_name FROM @duplicate_names WHERE id = @i);
+        
+                    UPDATE ${ohdsiSchema}.concept_set
+                    SET concept_set_name = concept_set_name + ' (' + CAST(@j AS varchar(15)) + ')'
+                    WHERE concept_set_id =
+                          (SELECT TOP (1) concept_set_id FROM ${ohdsiSchema}.concept_set
+                           WHERE concept_set_name = @dupl_name
+                          );
+                    SET @j = @j + 1;
+                END;
+                SET @i = @i + 1;
+                SET @j = 1;
+            END;
+            
+            DELETE FROM @duplicate_names WHERE id = id;
+            DELETE FROM @name_repeats WHERE id = id;
+            SET @k = (SELECT COUNT(*) FROM (SELECT concept_set_name FROM ${ohdsiSchema}.concept_set
+                                            GROUP BY concept_set_name
+                                            HAVING COUNT(*) > 1) AS temp);
+        END;
+    
+    ALTER TABLE ${ohdsiSchema}.concept_set ADD CONSTRAINT uq_cs_name UNIQUE (concept_set_name);
+END;
+GO
+
+EXEC ${ohdsiSchema}.rename_cs_names;
+GO
 
 -- Alter Cohort Definition table
 
-UPDATE ${ohdsiSchema}.cohort_definition
-SET name = u.name + ' (' + CAST(u.rn AS varchar(15)) + ')'
-FROM 
-  ${ohdsiSchema}.cohort_definition, 
-  (
-    SELECT d.id, d.name, d.rn
-    FROM
-    (
-      select a.name, cd.id, ROW_NUMBER() OVER(PARTITION BY a.name ORDER BY cd.id ASC) rn
-      FROM
-      (
-        select name, COUNT(*) cnt
-        FROM ${ohdsiSchema}.cohort_definition
-        group by name having COUNT(*) > 1
-      ) a
-      INNER JOIN ${ohdsiSchema}.cohort_definition cd ON a.name = cd.name
-    ) d 
-  ) u
- WHERE u.id = ${ohdsiSchema}.cohort_definition.id 
-;
+CREATE PROCEDURE ${ohdsiSchema}.rename_cd_names AS
+BEGIN
+    DECLARE @duplicate_names TABLE(id int IDENTITY (1, 1), duplicate_name varchar(100));
+    DECLARE @name_repeats TABLE (id int IDENTITY (1, 1), repeat_number int);
+    DECLARE @amount_of_duplicate_names int;
+    DECLARE @amount_of_constraints int;
+    DECLARE @constraint_title varchar(100);
+    DECLARE @schema_title varchar(100);
+    DECLARE @k int;
 
-ALTER TABLE ${ohdsiSchema}.cohort_definition ADD CONSTRAINT uq_cd_name UNIQUE (name);
+    SET @k = (SELECT COUNT(*) FROM (SELECT name FROM ${ohdsiSchema}.cohort_definition
+                                    GROUP BY name
+                                    HAVING COUNT(*) > 1) AS temp);
+                                    
+    WHILE @k > 0
+        BEGIN
+            INSERT INTO @duplicate_names
+            SELECT name FROM ${ohdsiSchema}.cohort_definition
+            GROUP BY name
+            HAVING COUNT(*) > 1;
+        
+            INSERT INTO @name_repeats
+            SELECT COUNT(*) FROM ${ohdsiSchema}.cohort_definition
+            GROUP BY name
+            HAVING COUNT(*) > 1;
+        
+            SET @amount_of_duplicate_names = (SELECT COUNT(*) FROM @duplicate_names);
+        
+            DECLARE @i int = 1;
+            DECLARE @j int = 1;
+            DECLARE @name_repeat int = 0;
+            DECLARE @dupl_name varchar(100);
+        
+            WHILE @i <= coalesce(@amount_of_duplicate_names, 0)
+            BEGIN
+                SET @name_repeat = (SELECT repeat_number FROM @name_repeats WHERE id = @i);
+                WHILE @j <= coalesce(@name_repeat, 0)
+                BEGIN
+                    SET @dupl_name = (SELECT duplicate_name FROM @duplicate_names WHERE id = @i);
+        
+                    UPDATE ${ohdsiSchema}.cohort_definition
+                    SET name = name + ' (' + CAST(@j AS varchar(15)) + ')'
+                    WHERE id =
+                          (SELECT TOP (1) id FROM ${ohdsiSchema}.cohort_definition
+                           WHERE name = @dupl_name
+                          );
+                    SET @j = @j + 1;
+                END;
+                SET @i = @i + 1;
+                SET @j = 1;
+            END;
+            
+            DELETE FROM @duplicate_names WHERE id = id;
+            DELETE FROM @name_repeats WHERE id = id;
+            SET @k = (SELECT COUNT(*) FROM (SELECT name FROM ${ohdsiSchema}.cohort_definition
+                                            GROUP BY name
+                                            HAVING COUNT(*) > 1) AS temp);
+        END;
+
+    ALTER TABLE ${ohdsiSchema}.cohort_definition ADD CONSTRAINT uq_cd_name UNIQUE (name);
+END;
+GO
+
+EXEC ${ohdsiSchema}.rename_cd_names;
+GO
 
 -- Alter Cohort Characterization table
-UPDATE ${ohdsiSchema}.cohort_characterization
-SET name = u.name + ' (' + CAST(u.rn AS varchar(15)) + ')'
-FROM 
-  ${ohdsiSchema}.cohort_characterization, 
-  (
-    SELECT d.id, d.name, d.rn
-    FROM
-    (
-      select a.name, cd.id, ROW_NUMBER() OVER(PARTITION BY a.name ORDER BY cd.id ASC) rn
-      FROM
-      (
-        select name, COUNT(*) cnt
-        FROM ${ohdsiSchema}.cohort_characterization
-        group by name having COUNT(*) > 1
-      ) a
-      INNER JOIN ${ohdsiSchema}.cohort_characterization cd ON a.name = cd.name
-    ) d 
-  ) u
- WHERE u.id = ${ohdsiSchema}.cohort_characterization.id 
-;
 
-ALTER TABLE ${ohdsiSchema}.cohort_characterization ADD CONSTRAINT uq_cc_name UNIQUE (name);
+CREATE PROCEDURE ${ohdsiSchema}.rename_cc_names AS
+BEGIN
+    DECLARE @duplicate_names TABLE(id int IDENTITY (1, 1), duplicate_name varchar(100));
+    DECLARE @name_repeats TABLE (id int IDENTITY (1, 1), repeat_number int);
+    DECLARE @amount_of_duplicate_names int;
+    DECLARE @amount_of_constraints int;
+    DECLARE @constraint_title varchar(100);
+    DECLARE @schema_title varchar(100);
+    DECLARE @k int;
+    
+    SET @k = (SELECT COUNT(*) FROM (SELECT name FROM ${ohdsiSchema}.cohort_characterization
+                                    GROUP BY name
+                                    HAVING COUNT(*) > 1) AS temp);
+                                    
+    WHILE @k > 0
+        BEGIN
+            INSERT INTO @duplicate_names
+            SELECT name FROM ${ohdsiSchema}.cohort_characterization
+            GROUP BY name
+            HAVING COUNT(*) > 1;
+        
+            INSERT INTO @name_repeats
+            SELECT COUNT(*) FROM ${ohdsiSchema}.cohort_characterization
+            GROUP BY name
+            HAVING COUNT(*) > 1;
+        
+            SET @amount_of_duplicate_names = (SELECT COUNT(*) FROM @duplicate_names);
+        
+            DECLARE @i int = 1;
+            DECLARE @j int = 1;
+            DECLARE @name_repeat int = 0;
+            DECLARE @dupl_name varchar(100);
+        
+            WHILE @i <= coalesce(@amount_of_duplicate_names, 0)
+            BEGIN
+                SET @name_repeat = (SELECT repeat_number FROM @name_repeats WHERE id = @i);
+                WHILE @j <= coalesce(@name_repeat, 0)
+                BEGIN
+                    SET @dupl_name = (SELECT duplicate_name FROM @duplicate_names WHERE id = @i);
+        
+                    UPDATE ${ohdsiSchema}.cohort_characterization
+                    SET name = name + ' (' + CAST(@j AS varchar(15)) + ')'
+                    WHERE id =
+                          (SELECT TOP (1) id FROM ${ohdsiSchema}.cohort_characterization
+                           WHERE name = @dupl_name
+                          );
+                    SET @j = @j + 1;
+                END;
+                SET @i = @i + 1;
+                SET @j = 1;
+            END;
+        
+            DELETE FROM @duplicate_names WHERE id = id;
+            DELETE FROM @name_repeats WHERE id = id;
+            SET @k = (SELECT COUNT(*) FROM (SELECT name FROM ${ohdsiSchema}.cohort_characterization
+                                            GROUP BY name
+                                            HAVING COUNT(*) > 1) AS temp);
+        END;
+    
+    ALTER TABLE ${ohdsiSchema}.cohort_characterization ADD CONSTRAINT uq_cc_name UNIQUE (name);
+END;
+GO
+
+EXEC ${ohdsiSchema}.rename_cc_names;
+GO
 
 -- Alter Fe Analysis Table
 
-UPDATE ${ohdsiSchema}.fe_analysis
-SET name = u.name + ' (' + CAST(u.rn AS varchar(15)) + ')'
-FROM 
-  ${ohdsiSchema}.fe_analysis, 
-  (
-    SELECT d.id, d.name, d.rn
-    FROM
-    (
-      select a.name, cd.id, ROW_NUMBER() OVER(PARTITION BY a.name ORDER BY cd.id ASC) rn
-      FROM
-      (
-        select name, COUNT(*) cnt
-        FROM ${ohdsiSchema}.fe_analysis
-        group by name having COUNT(*) > 1
-      ) a
-      INNER JOIN ${ohdsiSchema}.fe_analysis cd ON a.name = cd.name
-    ) d 
-  ) u
- WHERE u.id = ${ohdsiSchema}.fe_analysis.id 
-;
+CREATE PROCEDURE ${ohdsiSchema}.rename_fe_names AS
+BEGIN
+    DECLARE @duplicate_names TABLE(id int IDENTITY (1, 1), duplicate_name varchar(100));
+    DECLARE @name_repeats TABLE (id int IDENTITY (1, 1), repeat_number int);
+    DECLARE @amount_of_duplicate_names int;
+    DECLARE @amount_of_constraints int;
+    DECLARE @constraint_title varchar(100);
+    DECLARE @schema_title varchar(100);
+    DECLARE @k int;
 
-ALTER TABLE ${ohdsiSchema}.fe_analysis ADD CONSTRAINT uq_fe_name UNIQUE (name);
+    SET @k = (SELECT COUNT(*) FROM (SELECT name FROM ${ohdsiSchema}.fe_analysis
+                                    GROUP BY name
+                                    HAVING COUNT(*) > 1) AS temp);
+                                    
+    WHILE @k > 0
+        BEGIN
+            INSERT INTO @duplicate_names
+            SELECT name FROM ${ohdsiSchema}.fe_analysis
+            GROUP BY name
+            HAVING COUNT(*) > 1;
+        
+            INSERT INTO @name_repeats
+            SELECT COUNT(*) FROM ${ohdsiSchema}.fe_analysis
+            GROUP BY name
+            HAVING COUNT(*) > 1;
+        
+            SET @amount_of_duplicate_names = (SELECT COUNT(*) FROM @duplicate_names);
+        
+            DECLARE @i int = 1;
+            DECLARE @j int = 1;
+            DECLARE @name_repeat int = 0;
+            DECLARE @dupl_name varchar(100);
+        
+            WHILE @i <= coalesce(@amount_of_duplicate_names, 0)
+            BEGIN
+                SET @name_repeat = (SELECT repeat_number FROM @name_repeats WHERE id = @i);
+                WHILE @j <= coalesce(@name_repeat, 0)
+                BEGIN
+                    SET @dupl_name = (SELECT duplicate_name FROM @duplicate_names WHERE id = @i);
+        
+                    UPDATE ${ohdsiSchema}.fe_analysis
+                    SET name = name + ' (' + CAST(@j AS varchar(15)) + ')'
+                    WHERE id =
+                          (SELECT TOP (1) id FROM ${ohdsiSchema}.fe_analysis
+                           WHERE name = @dupl_name
+                          );
+                    SET @j = @j + 1;
+                END;
+                SET @i = @i + 1;
+                SET @j = 1;
+            END;
+        
+            DELETE FROM @duplicate_names WHERE id = id;
+            DELETE FROM @name_repeats WHERE id = id;
+
+            SET @k = (SELECT COUNT(*) FROM (SELECT name FROM ${ohdsiSchema}.fe_analysis
+                                            GROUP BY name
+                                            HAVING COUNT(*) > 1) AS temp);
+        END;
+    
+    ALTER TABLE ${ohdsiSchema}.fe_analysis ADD CONSTRAINT uq_fe_name UNIQUE (name);
+END;
+GO
+
+EXEC ${ohdsiSchema}.rename_fe_names;
+GO
 
 -- Alter Pathway Analysis Table
 
-UPDATE ${ohdsiSchema}.pathway_analysis
-SET name = u.name + ' (' + CAST(u.rn AS varchar(15)) + ')'
-FROM 
-  ${ohdsiSchema}.pathway_analysis, 
-  (
-    SELECT d.id, d.name, d.rn
-    FROM
-    (
-      select a.name, cd.id, ROW_NUMBER() OVER(PARTITION BY a.name ORDER BY cd.id ASC) rn
-      FROM
-      (
-        select name, COUNT(*) cnt
-        FROM ${ohdsiSchema}.pathway_analysis
-        group by name having COUNT(*) > 1
-      ) a
-      INNER JOIN ${ohdsiSchema}.pathway_analysis cd ON a.name = cd.name
-    ) d 
-  ) u
- WHERE u.id = ${ohdsiSchema}.pathway_analysis.id 
-;
+CREATE PROCEDURE ${ohdsiSchema}.rename_pw_names AS
+BEGIN
+    DECLARE @duplicate_names TABLE(id int IDENTITY (1, 1), duplicate_name varchar(100));
+    DECLARE @name_repeats TABLE (id int IDENTITY (1, 1), repeat_number int);
+    DECLARE @amount_of_duplicate_names int;
+    DECLARE @amount_of_constraints int;
+    DECLARE @constraint_title varchar(100);
+    DECLARE @schema_title varchar(100);
+    DECLARE @k int;
 
-ALTER TABLE ${ohdsiSchema}.pathway_analysis ADD CONSTRAINT uq_pw_name UNIQUE (name);
+    SET @k = (SELECT COUNT(*) FROM (SELECT name FROM ${ohdsiSchema}.pathway_analysis
+                                    GROUP BY name
+                                    HAVING COUNT(*) > 1) AS temp);
+
+    WHILE @k > 0
+        BEGIN
+            INSERT INTO @duplicate_names
+            SELECT name FROM ${ohdsiSchema}.pathway_analysis
+            GROUP BY name
+            HAVING COUNT(*) > 1;
+        
+            INSERT INTO @name_repeats
+            SELECT COUNT(*) FROM ${ohdsiSchema}.pathway_analysis
+            GROUP BY name
+            HAVING COUNT(*) > 1;
+        
+            SET @amount_of_duplicate_names = (SELECT COUNT(*) FROM @duplicate_names);
+        
+            DECLARE @i int = 1;
+            DECLARE @j int = 1;
+            DECLARE @name_repeat int = 0;
+            DECLARE @dupl_name varchar(100);
+        
+            WHILE @i <= coalesce(@amount_of_duplicate_names, 0)
+            BEGIN
+                SET @name_repeat = (SELECT repeat_number FROM @name_repeats WHERE id = @i);
+                WHILE @j <= coalesce(@name_repeat, 0)
+                BEGIN
+                    SET @dupl_name = (SELECT duplicate_name FROM @duplicate_names WHERE id = @i);
+        
+                    UPDATE ${ohdsiSchema}.pathway_analysis
+                    SET name = name + ' (' + CAST(@j AS varchar(15)) + ')'
+                    WHERE id =
+                          (SELECT TOP (1) id FROM ${ohdsiSchema}.pathway_analysis
+                           WHERE name = @dupl_name
+                          );
+                    SET @j = @j + 1;
+                END;
+                SET @i = @i + 1;
+                SET @j = 1;
+            END;
+        
+            DELETE FROM @duplicate_names WHERE id = id;
+            DELETE FROM @name_repeats WHERE id = id;
+            SET @k = (SELECT COUNT(*) FROM (SELECT name FROM ${ohdsiSchema}.pathway_analysis
+                                            GROUP BY name
+                                            HAVING COUNT(*) > 1) AS temp);
+        END;
+
+    ALTER TABLE ${ohdsiSchema}.pathway_analysis ADD CONSTRAINT uq_pw_name UNIQUE (name);
+END;
+GO
+
+EXEC ${ohdsiSchema}.rename_pw_names;
+GO
 
 -- Alter IR Analysis Table
 
-UPDATE ${ohdsiSchema}.ir_analysis
-SET name = u.name + ' (' + CAST(u.rn AS varchar(15)) + ')'
-FROM 
-  ${ohdsiSchema}.ir_analysis, 
-  (
-    SELECT d.id, d.name, d.rn
-    FROM
-    (
-      select a.name, cd.id, ROW_NUMBER() OVER(PARTITION BY a.name ORDER BY cd.id ASC) rn
-      FROM
-      (
-        select name, COUNT(*) cnt
-        FROM ${ohdsiSchema}.ir_analysis
-        group by name having COUNT(*) > 1
-      ) a
-      INNER JOIN ${ohdsiSchema}.ir_analysis cd ON a.name = cd.name
-    ) d 
-  ) u
- WHERE u.id = ${ohdsiSchema}.ir_analysis.id 
-;
+CREATE PROCEDURE ${ohdsiSchema}.rename_ir_names AS
+BEGIN
+    DECLARE @duplicate_names TABLE(id int IDENTITY (1, 1), duplicate_name varchar(100));
+    DECLARE @name_repeats TABLE (id int IDENTITY (1, 1), repeat_number int);
+    DECLARE @amount_of_duplicate_names int;
+    DECLARE @amount_of_constraints int;
+    DECLARE @constraint_title varchar(100);
+    DECLARE @schema_title varchar(100);
+    DECLARE @k int;
 
-ALTER TABLE ${ohdsiSchema}.ir_analysis ADD CONSTRAINT uq_ir_name UNIQUE (name);
+    SET @k = (SELECT COUNT(*) FROM (SELECT name FROM ${ohdsiSchema}.ir_analysis
+                                    GROUP BY name
+                                    HAVING COUNT(*) > 1) AS temp);
+                                    
+    WHILE @k > 0
+        BEGIN
+            INSERT INTO @duplicate_names
+            SELECT name FROM ${ohdsiSchema}.ir_analysis
+            GROUP BY name
+            HAVING COUNT(*) > 1;
+        
+            INSERT INTO @name_repeats
+            SELECT COUNT(*) FROM ${ohdsiSchema}.ir_analysis
+            GROUP BY name
+            HAVING COUNT(*) > 1;
+        
+            SET @amount_of_duplicate_names = (SELECT COUNT(*) FROM @duplicate_names);
+        
+            DECLARE @i int = 1;
+            DECLARE @j int = 1;
+            DECLARE @name_repeat int = 0;
+            DECLARE @dupl_name varchar(100);
+        
+            WHILE @i <= coalesce(@amount_of_duplicate_names, 0)
+            BEGIN
+                SET @name_repeat = (SELECT repeat_number FROM @name_repeats WHERE id = @i);
+                WHILE @j <= coalesce(@name_repeat, 0)
+                BEGIN
+                    SET @dupl_name = (SELECT duplicate_name FROM @duplicate_names WHERE id = @i);
+        
+                    UPDATE ${ohdsiSchema}.ir_analysis
+                    SET name = name + ' (' + CAST(@j AS varchar(15)) + ')'
+                    WHERE id =
+                          (SELECT TOP (1) id FROM ${ohdsiSchema}.ir_analysis
+                           WHERE name = @dupl_name
+                          );
+                    SET @j = @j + 1;
+                END;
+                SET @i = @i + 1;
+                SET @j = 1;
+            END;
+        
+            DELETE FROM @duplicate_names WHERE id = id;
+            DELETE FROM @name_repeats WHERE id = id;
+            SET @k = (SELECT COUNT(*) FROM (SELECT name FROM ${ohdsiSchema}.ir_analysis
+                                            GROUP BY name
+                                            HAVING COUNT(*) > 1) AS temp);
+        END;
+    
+    ALTER TABLE ${ohdsiSchema}.ir_analysis ADD CONSTRAINT uq_ir_name UNIQUE (name);
+END;
+GO
+
+EXEC ${ohdsiSchema}.rename_ir_names;
+GO
 
 -- Alter Estimation table
 
-UPDATE ${ohdsiSchema}.estimation
-SET name = u.name + ' (' + CAST(u.rn AS varchar(15)) + ')'
-FROM 
-  ${ohdsiSchema}.estimation, 
-  (
-    SELECT d.estimation_id, d.name, d.rn
-    FROM
-    (
-      select a.name, cd.estimation_id, ROW_NUMBER() OVER(PARTITION BY a.name ORDER BY cd.estimation_id ASC) rn
-      FROM
-      (
-        select name, COUNT(*) cnt
-        FROM ${ohdsiSchema}.estimation
-        group by name having COUNT(*) > 1
-      ) a
-      INNER JOIN ${ohdsiSchema}.estimation cd ON a.name = cd.name
-    ) d 
-  ) u
- WHERE u.estimation_id = ${ohdsiSchema}.estimation.estimation_id 
-;
+CREATE PROCEDURE ${ohdsiSchema}.rename_estimation_names AS
+BEGIN
+    DECLARE @duplicate_names TABLE(id int IDENTITY (1, 1), duplicate_name varchar(100));
+    DECLARE @name_repeats TABLE (id int IDENTITY (1, 1), repeat_number int);
+    DECLARE @amount_of_duplicate_names int;
+    DECLARE @amount_of_constraints int;
+    DECLARE @constraint_title varchar(100);
+    DECLARE @schema_title varchar(100);
+    DECLARE @k int;
 
-ALTER TABLE ${ohdsiSchema}.estimation ADD CONSTRAINT uq_es_name UNIQUE (name);
+    SET @k = (SELECT COUNT(*) FROM (SELECT name FROM ${ohdsiSchema}.estimation
+                                    GROUP BY name
+                                    HAVING COUNT(*) > 1) AS temp);
+                                    
+    WHILE @k > 0
+        BEGIN
+            INSERT INTO @duplicate_names
+            SELECT name FROM ${ohdsiSchema}.estimation
+            GROUP BY name
+            HAVING COUNT(*) > 1;
+        
+            INSERT INTO @name_repeats
+            SELECT COUNT(*) FROM ${ohdsiSchema}.estimation
+            GROUP BY name
+            HAVING COUNT(*) > 1;
+        
+            SET @amount_of_duplicate_names = (SELECT COUNT(*) FROM @duplicate_names);
+        
+            DECLARE @i int = 1;
+            DECLARE @j int = 1;
+            DECLARE @name_repeat int = 0;
+            DECLARE @dupl_name varchar(100);
+        
+            WHILE @i <= coalesce(@amount_of_duplicate_names, 0)
+            BEGIN
+                SET @name_repeat = (SELECT repeat_number FROM @name_repeats WHERE id = @i);
+                WHILE @j <= coalesce(@name_repeat, 0)
+                BEGIN
+                    SET @dupl_name = (SELECT duplicate_name FROM @duplicate_names WHERE id = @i);
+        
+                    UPDATE ${ohdsiSchema}.estimation
+                    SET name = name + ' (' + CAST(@j AS varchar(15)) + ')'
+                    WHERE estimation_id =
+                          (SELECT TOP (1) estimation_id FROM ${ohdsiSchema}.estimation
+                           WHERE name = @dupl_name
+                          );
+                    SET @j = @j + 1;
+                END;
+                SET @i = @i + 1;
+                SET @j = 1;
+            END;
+        
+            SET @k = (SELECT COUNT(*) FROM (SELECT name FROM ${ohdsiSchema}.estimation
+                                            GROUP BY name
+                                            HAVING COUNT(*) > 1) AS temp);
+            DELETE FROM @duplicate_names WHERE id = id;
+            DELETE FROM @name_repeats WHERE id = id;
+        END;
+
+    ALTER TABLE ${ohdsiSchema}.estimation ADD CONSTRAINT uq_es_name UNIQUE (name);
+END;
+GO
+
+EXEC ${ohdsiSchema}.rename_estimation_names;
+GO
 
 -- Alter Prediction table
 
-UPDATE ${ohdsiSchema}.prediction
-SET name = u.name + ' (' + CAST(u.rn AS varchar(15)) + ')'
-FROM 
-  ${ohdsiSchema}.prediction, 
-  (
-    SELECT d.prediction_id, d.name, d.rn
-    FROM
-    (
-      select a.name, cd.prediction_id, ROW_NUMBER() OVER(PARTITION BY a.name ORDER BY cd.prediction_id ASC) rn
-      FROM
-      (
-        select name, COUNT(*) cnt
-        FROM ${ohdsiSchema}.prediction
-        group by name having COUNT(*) > 1
-      ) a
-      INNER JOIN ${ohdsiSchema}.prediction cd ON a.name = cd.name
-    ) d 
-  ) u
- WHERE u.prediction_id = ${ohdsiSchema}.prediction.prediction_id 
-;
+CREATE PROCEDURE ${ohdsiSchema}.rename_prediction_names AS
+BEGIN
+    DECLARE @duplicate_names TABLE(id int IDENTITY (1, 1), duplicate_name varchar(100));
+    DECLARE @name_repeats TABLE (id int IDENTITY (1, 1), repeat_number int);
+    DECLARE @amount_of_duplicate_names int;
+    DECLARE @amount_of_constraints int;
+    DECLARE @constraint_title varchar(100);
+    DECLARE @schema_title varchar(100);
+    DECLARE @k int;
 
-ALTER TABLE ${ohdsiSchema}.prediction ADD CONSTRAINT uq_pd_name UNIQUE (name);
+    SET @k = (SELECT COUNT(*) FROM (SELECT name FROM ${ohdsiSchema}.prediction
+                                    GROUP BY name
+                                    HAVING COUNT(*) > 1) AS temp);
+    
+    WHILE @k > 0
+        BEGIN
+            INSERT INTO @duplicate_names
+            SELECT name FROM ${ohdsiSchema}.prediction
+            GROUP BY name
+            HAVING COUNT(*) > 1;
+        
+            INSERT INTO @name_repeats
+            SELECT COUNT(*) FROM ${ohdsiSchema}.prediction
+            GROUP BY name
+            HAVING COUNT(*) > 1;
+        
+            SET @amount_of_duplicate_names = (SELECT COUNT(*) FROM @duplicate_names);
+        
+            DECLARE @i int = 1;
+            DECLARE @j int = 1;
+            DECLARE @name_repeat int = 0;
+            DECLARE @dupl_name varchar(100);
+        
+            WHILE @i <= coalesce(@amount_of_duplicate_names, 0)
+            BEGIN
+                SET @name_repeat = (SELECT repeat_number FROM @name_repeats WHERE id = @i);
+                WHILE @j <= coalesce(@name_repeat, 0)
+                BEGIN
+                    SET @dupl_name = (SELECT duplicate_name FROM @duplicate_names WHERE id = @i);
+        
+                    UPDATE ${ohdsiSchema}.prediction
+                    SET name = name + ' (' + CAST(@j AS varchar(15)) + ')'
+                    WHERE prediction_id =
+                          (SELECT TOP (1) prediction_id FROM ${ohdsiSchema}.prediction
+                           WHERE name = @dupl_name
+                          );
+                    SET @j = @j + 1;
+                END;
+                SET @i = @i + 1;
+                SET @j = 1;
+            END;
+            
+            SET @k = (SELECT COUNT(*) FROM (SELECT name FROM ${ohdsiSchema}.prediction
+                                            GROUP BY name
+                                            HAVING COUNT(*) > 1) AS temp);
+            DELETE FROM @duplicate_names WHERE id = id;
+            DELETE FROM @name_repeats WHERE id = id;
+        END;
+    
+    ALTER TABLE ${ohdsiSchema}.prediction ADD CONSTRAINT uq_pd_name UNIQUE (name);
+END;
+GO
+
+EXEC ${ohdsiSchema}.rename_prediction_names;
+GO
+
+DROP PROCEDURE ${ohdsiSchema}.rename_cs_names;
+DROP PROCEDURE ${ohdsiSchema}.rename_cd_names;
+DROP PROCEDURE ${ohdsiSchema}.rename_cc_names;
+DROP PROCEDURE ${ohdsiSchema}.rename_fe_names;
+DROP PROCEDURE ${ohdsiSchema}.rename_pw_names;
+DROP PROCEDURE ${ohdsiSchema}.rename_ir_names;
+DROP PROCEDURE ${ohdsiSchema}.rename_estimation_names;
+DROP PROCEDURE ${ohdsiSchema}.rename_prediction_names;

--- a/src/main/resources/db/migration/sqlserver/V2.8.0.20190424150601__add-unique-name-constraint-to-entities.sql
+++ b/src/main/resources/db/migration/sqlserver/V2.8.0.20190424150601__add-unique-name-constraint-to-entities.sql
@@ -5,9 +5,6 @@ BEGIN
     DECLARE @duplicate_names TABLE(id int IDENTITY (1, 1), duplicate_name varchar(100));
     DECLARE @name_repeats TABLE (id int IDENTITY (1, 1), repeat_number int);
     DECLARE @amount_of_duplicate_names int;
-    DECLARE @amount_of_constraints int;
-    DECLARE @constraint_title varchar(100);
-    DECLARE @schema_title varchar(100);
     DECLARE @k int;
     
     SET @k = (SELECT COUNT(*) FROM (SELECT concept_set_name FROM ${ohdsiSchema}.concept_set
@@ -73,9 +70,6 @@ BEGIN
     DECLARE @duplicate_names TABLE(id int IDENTITY (1, 1), duplicate_name varchar(100));
     DECLARE @name_repeats TABLE (id int IDENTITY (1, 1), repeat_number int);
     DECLARE @amount_of_duplicate_names int;
-    DECLARE @amount_of_constraints int;
-    DECLARE @constraint_title varchar(100);
-    DECLARE @schema_title varchar(100);
     DECLARE @k int;
 
     SET @k = (SELECT COUNT(*) FROM (SELECT name FROM ${ohdsiSchema}.cohort_definition
@@ -141,9 +135,6 @@ BEGIN
     DECLARE @duplicate_names TABLE(id int IDENTITY (1, 1), duplicate_name varchar(100));
     DECLARE @name_repeats TABLE (id int IDENTITY (1, 1), repeat_number int);
     DECLARE @amount_of_duplicate_names int;
-    DECLARE @amount_of_constraints int;
-    DECLARE @constraint_title varchar(100);
-    DECLARE @schema_title varchar(100);
     DECLARE @k int;
     
     SET @k = (SELECT COUNT(*) FROM (SELECT name FROM ${ohdsiSchema}.cohort_characterization
@@ -209,9 +200,6 @@ BEGIN
     DECLARE @duplicate_names TABLE(id int IDENTITY (1, 1), duplicate_name varchar(100));
     DECLARE @name_repeats TABLE (id int IDENTITY (1, 1), repeat_number int);
     DECLARE @amount_of_duplicate_names int;
-    DECLARE @amount_of_constraints int;
-    DECLARE @constraint_title varchar(100);
-    DECLARE @schema_title varchar(100);
     DECLARE @k int;
 
     SET @k = (SELECT COUNT(*) FROM (SELECT name FROM ${ohdsiSchema}.fe_analysis
@@ -278,9 +266,6 @@ BEGIN
     DECLARE @duplicate_names TABLE(id int IDENTITY (1, 1), duplicate_name varchar(100));
     DECLARE @name_repeats TABLE (id int IDENTITY (1, 1), repeat_number int);
     DECLARE @amount_of_duplicate_names int;
-    DECLARE @amount_of_constraints int;
-    DECLARE @constraint_title varchar(100);
-    DECLARE @schema_title varchar(100);
     DECLARE @k int;
 
     SET @k = (SELECT COUNT(*) FROM (SELECT name FROM ${ohdsiSchema}.pathway_analysis
@@ -346,9 +331,6 @@ BEGIN
     DECLARE @duplicate_names TABLE(id int IDENTITY (1, 1), duplicate_name varchar(100));
     DECLARE @name_repeats TABLE (id int IDENTITY (1, 1), repeat_number int);
     DECLARE @amount_of_duplicate_names int;
-    DECLARE @amount_of_constraints int;
-    DECLARE @constraint_title varchar(100);
-    DECLARE @schema_title varchar(100);
     DECLARE @k int;
 
     SET @k = (SELECT COUNT(*) FROM (SELECT name FROM ${ohdsiSchema}.ir_analysis
@@ -414,9 +396,6 @@ BEGIN
     DECLARE @duplicate_names TABLE(id int IDENTITY (1, 1), duplicate_name varchar(100));
     DECLARE @name_repeats TABLE (id int IDENTITY (1, 1), repeat_number int);
     DECLARE @amount_of_duplicate_names int;
-    DECLARE @amount_of_constraints int;
-    DECLARE @constraint_title varchar(100);
-    DECLARE @schema_title varchar(100);
     DECLARE @k int;
 
     SET @k = (SELECT COUNT(*) FROM (SELECT name FROM ${ohdsiSchema}.estimation
@@ -482,9 +461,6 @@ BEGIN
     DECLARE @duplicate_names TABLE(id int IDENTITY (1, 1), duplicate_name varchar(100));
     DECLARE @name_repeats TABLE (id int IDENTITY (1, 1), repeat_number int);
     DECLARE @amount_of_duplicate_names int;
-    DECLARE @amount_of_constraints int;
-    DECLARE @constraint_title varchar(100);
-    DECLARE @schema_title varchar(100);
     DECLARE @k int;
 
     SET @k = (SELECT COUNT(*) FROM (SELECT name FROM ${ohdsiSchema}.prediction


### PR DESCRIPTION
Re-applying the approach originally developed by @aklochkova and made a small modification to the names of the unique constraint. This addresses the problem nicely described here: https://github.com/OHDSI/WebAPI/pull/1073#issuecomment-493748843. 

@aklochkova - I'm not sure why but when I re-tested on our SQL Server instance with the original approach, it worked fine. It may have been something in my environment that caused my problems when testing your change. Thanks for keeping an eye on the changes and for coming up with a robust solution to resolve the duplicate names!