### PR TITLE
Hibernate startsWith to use escape - Fixes #1153

### DIFF
--- a/src/main/java/org/ohdsi/webapi/cohortcharacterization/repository/CcRepository.java
+++ b/src/main/java/org/ohdsi/webapi/cohortcharacterization/repository/CcRepository.java
@@ -11,6 +11,7 @@ import org.springframework.data.repository.query.Param;
 public interface CcRepository extends EntityGraphJpaRepository<CohortCharacterizationEntity, Long> {
     Optional<CohortCharacterizationEntity> findById(final Long id);
 
+    @Query("SELECT cc FROM CohortCharacterizationEntity cc WHERE cc.name LIKE ?1 ESCAPE '\\'")
     List<CohortCharacterizationEntity> findAllByNameStartsWith(String pattern);
 
     Optional<CohortCharacterizationEntity> findByName(String name);

--- a/src/main/java/org/ohdsi/webapi/cohortdefinition/CohortDefinitionRepository.java
+++ b/src/main/java/org/ohdsi/webapi/cohortdefinition/CohortDefinitionRepository.java
@@ -43,6 +43,7 @@ public interface CohortDefinitionRepository extends CrudRepository<CohortDefinit
   @Query("select count(cd) from CohortDefinition AS cd WHERE cd.name = :name and cd.id <> :id")
   int getCountCDefWithSameName(@Param("id") Integer id, @Param("name") String name);
 
+  @Query("SELECT cd FROM CohortDefinition cd WHERE cd.name LIKE ?1 ESCAPE '\\'")
   List<CohortDefinition> findAllByNameStartsWith(String pattern);
   
   Optional<CohortDefinition> findByName(String name);

--- a/src/main/java/org/ohdsi/webapi/conceptset/ConceptSetRepository.java
+++ b/src/main/java/org/ohdsi/webapi/conceptset/ConceptSetRepository.java
@@ -37,6 +37,7 @@ public interface ConceptSetRepository extends CrudRepository<ConceptSet, Integer
   @Query("SELECT COUNT(cs) FROM ConceptSet cs WHERE cs.name = :conceptSetName and cs.id <> :conceptSetId")
   int getCountCSetWithSameName(@Param("conceptSetId") Integer conceptSetId, @Param("conceptSetName") String conceptSetName);
 
+  @Query("SELECT cs FROM ConceptSet cs WHERE cs.name LIKE ?1 ESCAPE '\\'")
   List<ConceptSet> findAllByNameStartsWith(String pattern);
   
   Optional<ConceptSet> findByName(String name);

--- a/src/main/java/org/ohdsi/webapi/estimation/repository/EstimationRepository.java
+++ b/src/main/java/org/ohdsi/webapi/estimation/repository/EstimationRepository.java
@@ -9,6 +9,7 @@ import java.util.List;
 import java.util.Optional;
 
 public interface EstimationRepository extends EntityGraphJpaRepository<Estimation, Integer> {
+    @Query("SELECT es FROM Estimation es WHERE es.name LIKE ?1 ESCAPE '\\'")
     List<Estimation> findAllByNameStartsWith(String pattern);
     Optional<Estimation> findByName(String name);
     @Query("SELECT COUNT(es) FROM Estimation es WHERE es.name = :name and es.id <> :id")

--- a/src/main/java/org/ohdsi/webapi/ircalc/IncidenceRateAnalysisRepository.java
+++ b/src/main/java/org/ohdsi/webapi/ircalc/IncidenceRateAnalysisRepository.java
@@ -38,6 +38,7 @@ public interface IncidenceRateAnalysisRepository extends EntityGraphCrudReposito
   @Query("SELECT COUNT(ira) FROM IncidenceRateAnalysis ira WHERE ira.name = :name and ira.id <> :id")
   int getCountIRWithSameName(@Param("id") Integer id, @Param("name") String name);
 
+  @Query("SELECT ira FROM IncidenceRateAnalysis ira WHERE ira.name LIKE ?1 ESCAPE '\\'")
   List<IncidenceRateAnalysis> findAllByNameStartsWith(String pattern);
   
   Optional<IncidenceRateAnalysis> findByName(String name);

--- a/src/main/java/org/ohdsi/webapi/pathway/repository/PathwayAnalysisEntityRepository.java
+++ b/src/main/java/org/ohdsi/webapi/pathway/repository/PathwayAnalysisEntityRepository.java
@@ -9,7 +9,7 @@ import java.util.List;
 import java.util.Optional;
 
 public interface PathwayAnalysisEntityRepository extends EntityGraphJpaRepository<PathwayAnalysisEntity, Integer> {
-
+  @Query("SELECT pa FROM pathway_analysis pa WHERE pa.name LIKE ?1 ESCAPE '\\'")
   List<PathwayAnalysisEntity> findAllByNameStartsWith(String pattern);
 
   Optional<PathwayAnalysisEntity> findByName(String name);

--- a/src/main/java/org/ohdsi/webapi/prediction/repository/PredictionAnalysisRepository.java
+++ b/src/main/java/org/ohdsi/webapi/prediction/repository/PredictionAnalysisRepository.java
@@ -9,6 +9,7 @@ import java.util.List;
 import java.util.Optional;
 
 public interface PredictionAnalysisRepository extends EntityGraphJpaRepository<PredictionAnalysis, Integer> {
+    @Query("SELECT pa FROM PredictionAnalysis pa WHERE pa.name LIKE ?1 ESCAPE '\\'")
     List<PredictionAnalysis> findAllByNameStartsWith(String pattern);
     Optional<PredictionAnalysis> findByName(String name);
     @Query("SELECT COUNT(pa) FROM PredictionAnalysis pa WHERE pa.name = :name and pa.id <> :id")

--- a/src/main/java/org/ohdsi/webapi/util/NameUtils.java
+++ b/src/main/java/org/ohdsi/webapi/util/NameUtils.java
@@ -22,7 +22,7 @@ public final class NameUtils {
     public static String getNameWithSuffix(String dtoName, Function<String, List<String>> getNamesLike){
         StringBuilder builder = new StringBuilder(dtoName);
 
-        List<String> nameList = getNamesLike.apply(dtoName);
+        List<String> nameList = getNamesLike.apply(dtoName.replace("[", "\\[") + "%");
         Pattern p = Pattern.compile(Pattern.quote(dtoName) + " \\(([0-9]+)\\)");
         nameList.stream()
                 .map(n -> {

--- a/src/main/java/org/ohdsi/webapi/util/NameUtils.java
+++ b/src/main/java/org/ohdsi/webapi/util/NameUtils.java
@@ -22,7 +22,7 @@ public final class NameUtils {
     public static String getNameWithSuffix(String dtoName, Function<String, List<String>> getNamesLike){
         StringBuilder builder = new StringBuilder(dtoName);
 
-        List<String> nameList = getNamesLike.apply(dtoName.replace("[", "\\[") + "%");
+        List<String> nameList = getNamesLike.apply(formatNameForLikeSearch(dtoName) + "%");
         Pattern p = Pattern.compile(Pattern.quote(dtoName) + " \\(([0-9]+)\\)");
         nameList.stream()
                 .map(n -> {
@@ -39,5 +39,9 @@ public final class NameUtils {
                 .ifPresent(cnt -> builder.append(" (").append(cnt + 1).append(")"));
 
         return builder.toString();
+    }
+    
+    public static String formatNameForLikeSearch(String name) {
+        return name.replace("[", "\\[").replace("]", "\\]").replace("%", "\\%").replace("_", "\\_");
     }
 }


### PR DESCRIPTION
Aims to correct the problems detailed in #1153 whereby entity names are not identified using the `startsWith` hibernate operator. 

As a note, I attempted to include the "%" as part of the `@Query` declaration like this:

`@Query("SELECT cs FROM ConceptSet cs WHERE cs.name LIKE ?1 + '%' ESCAPE '\\'")`

However, PostgreSQL did not like this so I instead add the "%" to the end of the string in the `NameUtils.getNameWithSuffix`  call instead.

I have not tested this for all entities but I was able to import the estimation example provided in #1153 which properly imported the estimation and the dependent cohort/concept set definitions without issue with these fixes.