### PR TITLE
Revise concept path in cohort results queries

### DIFF
--- a/src/main/resources/resources/cohortresults/sql/drugera/sqlDrugEraTreemap.sql
+++ b/src/main/resources/resources/cohortresults/sql/drugera/sqlDrugEraTreemap.sql
@@ -1,6 +1,7 @@
 select  concept_hierarchy.concept_id,
 	CONCAT(
-		coalesce(concept_hierarchy.level4_concept_name,'NA'), '||',
+                -- Note: concept_hierarchy.level4_concept_name is null so removing from this query
+		--coalesce(concept_hierarchy.level4_concept_name,'NA'), '||', 
 		coalesce(concept_hierarchy.level3_concept_name,'NA'), '||',
 		coalesce(concept_hierarchy.level2_concept_name,'NA'), '||',
 		coalesce(concept_hierarchy.level1_concept_name,'NA'), '||',

--- a/src/main/resources/resources/cohortresults/sql/drugera/sqlDrugEraTreemap.sql
+++ b/src/main/resources/resources/cohortresults/sql/drugera/sqlDrugEraTreemap.sql
@@ -1,11 +1,11 @@
 select  concept_hierarchy.concept_id,
 	CONCAT(
-                -- Note: concept_hierarchy.level4_concept_name is null so removing from this query
-		--coalesce(concept_hierarchy.level4_concept_name,'NA'), '||', 
-		coalesce(concept_hierarchy.level3_concept_name,'NA'), '||',
-		coalesce(concept_hierarchy.level2_concept_name,'NA'), '||',
-		coalesce(concept_hierarchy.level1_concept_name,'NA'), '||',
-		coalesce(concept_hierarchy.concept_name,'NA')
+                -- Note: concept_hierarchy.level4_concept_name is null 
+                -- and so it is not included in this query
+		isNull(concept_hierarchy.level3_concept_name,'NA'), '||',
+		isNull(concept_hierarchy.level2_concept_name,'NA'), '||',
+		isNull(concept_hierarchy.level1_concept_name,'NA'), '||',
+		isNull(concept_hierarchy.concept_name,'NA')
 	) concept_path,
 	hr1.count_value as num_persons, 
 	ROUND(1.0*hr1.count_value / denom.count_value,5) as percent_persons,

--- a/src/main/resources/resources/cohortresults/sql/measurement/sqlMeasurementTreemap.sql
+++ b/src/main/resources/resources/cohortresults/sql/measurement/sqlMeasurementTreemap.sql
@@ -1,6 +1,7 @@
 select  concept_hierarchy.concept_id,
 	CONCAT(
-		coalesce(concept_hierarchy.level4_concept_name,'NA'), '||',
+                -- Note: concept_hierarchy.level4_concept_name is null so removing from this query
+		--coalesce(concept_hierarchy.level4_concept_name,'NA'), '||', 
 		coalesce(concept_hierarchy.level3_concept_name,'NA'), '||',
 		coalesce(concept_hierarchy.level2_concept_name,'NA'), '||',
 		coalesce(concept_hierarchy.level1_concept_name,'NA'), '||',

--- a/src/main/resources/resources/cohortresults/sql/measurement/sqlMeasurementTreemap.sql
+++ b/src/main/resources/resources/cohortresults/sql/measurement/sqlMeasurementTreemap.sql
@@ -1,11 +1,11 @@
 select  concept_hierarchy.concept_id,
 	CONCAT(
-                -- Note: concept_hierarchy.level4_concept_name is null so removing from this query
-		--coalesce(concept_hierarchy.level4_concept_name,'NA'), '||', 
-		coalesce(concept_hierarchy.level3_concept_name,'NA'), '||',
-		coalesce(concept_hierarchy.level2_concept_name,'NA'), '||',
-		coalesce(concept_hierarchy.level1_concept_name,'NA'), '||',
-		coalesce(concept_hierarchy.concept_name,'NA')
+                -- Note: concept_hierarchy.level4_concept_name is null 
+                -- and so it is not included in this query
+		isNull(concept_hierarchy.level3_concept_name,'NA'), '||',
+		isNull(concept_hierarchy.level2_concept_name,'NA'), '||',
+		isNull(concept_hierarchy.level1_concept_name,'NA'), '||',
+		isNull(concept_hierarchy.concept_name,'NA')
 	) concept_path,
 	hr1.count_value as num_persons, 
 	ROUND(1.0*hr1.count_value / denom.count_value,5) as percent_persons,

--- a/src/main/resources/resources/cohortresults/sql/observation/sqlObservationTreemap.sql
+++ b/src/main/resources/resources/cohortresults/sql/observation/sqlObservationTreemap.sql
@@ -1,10 +1,11 @@
 select  concept_hierarchy.concept_id,
 	CONCAT(
-                -- Note: concept_hierarchy.level4_concept_name is null so removing from this query
-		--coalesce(concept_hierarchy.level4_concept_name,'NA'), '||', 
-		coalesce(concept_hierarchy.level2_concept_name,'NA'), '||',
-		coalesce(concept_hierarchy.level1_concept_name,'NA'), '||',
-		coalesce(concept_hierarchy.concept_name, 'NA')
+                -- Note: concept_hierarchy.level4_concept_name is null 
+                -- and so it is not included in this query
+		isNull(concept_hierarchy.level3_concept_name,'NA'), '||',
+		isNull(concept_hierarchy.level2_concept_name,'NA'), '||',
+		isNull(concept_hierarchy.level1_concept_name,'NA'), '||',
+		isNull(concept_hierarchy.concept_name, 'NA')
 	) as concept_path,
 	hr1.count_value as num_persons, 
 	ROUND(1.0*hr1.count_value / denom.count_value,5) as percent_persons,

--- a/src/main/resources/resources/cohortresults/sql/observation/sqlObservationTreemap.sql
+++ b/src/main/resources/resources/cohortresults/sql/observation/sqlObservationTreemap.sql
@@ -1,6 +1,7 @@
 select  concept_hierarchy.concept_id,
 	CONCAT(
-		coalesce(concept_hierarchy.level3_concept_name,'NA'), '||',
+                -- Note: concept_hierarchy.level4_concept_name is null so removing from this query
+		--coalesce(concept_hierarchy.level4_concept_name,'NA'), '||', 
 		coalesce(concept_hierarchy.level2_concept_name,'NA'), '||',
 		coalesce(concept_hierarchy.level1_concept_name,'NA'), '||',
 		coalesce(concept_hierarchy.concept_name, 'NA')

--- a/src/main/resources/resources/cohortresults/sql/procedure/sqlProcedureTreemap.sql
+++ b/src/main/resources/resources/cohortresults/sql/procedure/sqlProcedureTreemap.sql
@@ -1,9 +1,11 @@
 select  concept_hierarchy.concept_id,
 	CONCAT(
-	  coalesce(concept_hierarchy.level3_concept_name,'NA'), '||',
-	  coalesce(concept_hierarchy.level2_concept_name,'NA'), '||',
-	  coalesce(concept_hierarchy.level1_concept_name,'NA'), '||',
-	  coalesce(concept_hierarchy.concept_name,'NA')
+          -- Note: concept_hierarchy.level4_concept_name is null 
+          -- and so it is not included in this query
+	  isNull(concept_hierarchy.level3_concept_name,'NA'), '||',
+	  isNull(concept_hierarchy.level2_concept_name,'NA'), '||',
+	  isNull(concept_hierarchy.level1_concept_name,'NA'), '||',
+	  isNull(concept_hierarchy.concept_name,'NA')
 	) concept_path,
 	hr1.count_value as num_persons, 
 	ROUND(1.0*hr1.count_value / denom.count_value,5) as percent_persons,

--- a/src/main/resources/resources/cohortresults/sql/procedure/sqlProcedureTreemap.sql
+++ b/src/main/resources/resources/cohortresults/sql/procedure/sqlProcedureTreemap.sql
@@ -1,9 +1,9 @@
 select  concept_hierarchy.concept_id,
 	CONCAT(
-	  isNull(concept_hierarchy.level3_concept_name,'NA'), '||',
-	  isNull(concept_hierarchy.level2_concept_name,'NA'), '||',
-	  isNull(concept_hierarchy.level1_concept_name,'NA'), '||',
-	  isNull(concept_hierarchy.concept_name,'NA')
+	  coalesce(concept_hierarchy.level3_concept_name,'NA'), '||',
+	  coalesce(concept_hierarchy.level2_concept_name,'NA'), '||',
+	  coalesce(concept_hierarchy.level1_concept_name,'NA'), '||',
+	  coalesce(concept_hierarchy.concept_name,'NA')
 	) concept_path,
 	hr1.count_value as num_persons, 
 	ROUND(1.0*hr1.count_value / denom.count_value,5) as percent_persons,


### PR DESCRIPTION
Per OHDSI/Atlas#1872, I've noted that the queries that are used to retrieve the cohort reporting results are using the `concept_hierarchy.level4_concept_name` column from the `concept_hierarchy` table. However, this column is not populated for the following:

1. Drug Era: https://github.com/OHDSI/WebAPI/blob/master/src/main/resources/ddl/results/init_concept_hierarchy.sql#L144
2. Measurement: https://github.com/OHDSI/WebAPI/blob/master/src/main/resources/ddl/results/init_concept_hierarchy.sql#L205
3. Observation: https://github.com/OHDSI/WebAPI/blob/master/src/main/resources/ddl/results/init_concept_hierarchy.sql#L230
4. Procedure: https://github.com/OHDSI/WebAPI/blob/master/src/main/resources/ddl/results/init_concept_hierarchy.sql#L255

So, I've removed (commented out) the `concept_hierarchy.level4_concept_name` references from the corresponding cohort results queries so that we eliminate the "NA" value that was at the beginning of the concept_path display as mentioned in OHDSI/Atlas#1872.

For `sqlProcedureTreemap.sql`, I noted that the `CONCAT()` operation was inconsistent in using `isNull` while the others use `coalesce` so I've adjusted this accordingly. 