### PR TITLE
Ensure unique feature analysis names upon import - fixes #1192

### DIFF
--- a/src/main/java/org/ohdsi/webapi/cohortcharacterization/CcImportEvent.java
+++ b/src/main/java/org/ohdsi/webapi/cohortcharacterization/CcImportEvent.java
@@ -1,18 +1,16 @@
 package org.ohdsi.webapi.cohortcharacterization;
 
-import org.ohdsi.webapi.cohortcharacterization.domain.CohortCharacterizationEntity;
+import java.util.List;
 
 public class CcImportEvent {
 
-    private CohortCharacterizationEntity entity;
+    private List<Integer> savedAnalysesIds;
 
-    public CcImportEvent(CohortCharacterizationEntity entity) {
-
-        this.entity = entity;
+    public CcImportEvent(List<Integer> savedAnalysesIds) {
+        this.savedAnalysesIds = savedAnalysesIds;
     }
 
-    public CohortCharacterizationEntity getEntity() {
-
-        return entity;
+    public List<Integer> getSavedAnalysesIds() {
+        return savedAnalysesIds;
     }
 }

--- a/src/main/java/org/ohdsi/webapi/cohortcharacterization/CcImportEvent.java
+++ b/src/main/java/org/ohdsi/webapi/cohortcharacterization/CcImportEvent.java
@@ -4,6 +4,7 @@ import java.util.List;
 
 public class CcImportEvent {
 
+    // should keep list of ids to prevent error for duplication of permissions
     private List<Integer> savedAnalysesIds;
 
     public CcImportEvent(List<Integer> savedAnalysesIds) {

--- a/src/main/java/org/ohdsi/webapi/cohortcharacterization/CcServiceImpl.java
+++ b/src/main/java/org/ohdsi/webapi/cohortcharacterization/CcServiceImpl.java
@@ -631,12 +631,14 @@ public class CcServiceImpl extends AbstractDaoService implements CcService, Gene
             switch (analysis.getType()) {
                 case CRITERIA_SET:
                     FeAnalysisWithCriteriaEntity criteriaAnalysis = (FeAnalysisWithCriteriaEntity)analysis;
+                    criteriaAnalysis.setName(NameUtils.getNameWithSuffix(criteriaAnalysis.getName(), this::getFeNamesLike));
                     entityAnalyses.add(analysisService.createCriteriaAnalysis(criteriaAnalysis));
                     break;
                 case PRESET:
                     entityAnalyses.add(presetAnalysesMap.get(analysis.getDesign()));
                     break;
                 case CUSTOM_FE:
+                    analysis.setName(NameUtils.getNameWithSuffix(analysis.getName(), this::getFeNamesLike));
                     entityAnalyses.add(analysisService.createAnalysis(analysis));
                     break;
                 default:
@@ -700,6 +702,10 @@ public class CcServiceImpl extends AbstractDaoService implements CcService, Gene
             });
             return null;
         });
+    }
+    
+    private List<String> getFeNamesLike(String name) {
+        return analysisService.getNamesLike(name);
     }
 
 }

--- a/src/main/java/org/ohdsi/webapi/cohortcharacterization/CcServiceImpl.java
+++ b/src/main/java/org/ohdsi/webapi/cohortcharacterization/CcServiceImpl.java
@@ -635,8 +635,7 @@ public class CcServiceImpl extends AbstractDaoService implements CcService, Gene
                 case CRITERIA_SET:
                     FeAnalysisWithCriteriaEntity<? extends FeAnalysisCriteriaEntity> criteriaAnalysis = (FeAnalysisWithCriteriaEntity) analysis;
                     List<? extends FeAnalysisCriteriaEntity> design = criteriaAnalysis.getDesign();
-                    Optional<FeAnalysisEntity> entityCriteriaSet = analysisService
-                            .findByCriteriaListAndName(design, criteriaAnalysis.getName());
+                    Optional<FeAnalysisEntity> entityCriteriaSet = analysisService.findByCriteriaList(design);
                     if (entityCriteriaSet.isPresent()) {
                         entityAnalyses.add(entityCriteriaSet.get());
                     } else {
@@ -651,7 +650,7 @@ public class CcServiceImpl extends AbstractDaoService implements CcService, Gene
                     break;
                 case CUSTOM_FE:
                     FeAnalysisWithStringEntity withStringEntity = (FeAnalysisWithStringEntity) analysis;
-                    Optional<FeAnalysisEntity> findAnalysisResult = this.getFeByDesignAndName(withStringEntity, withStringEntity.getName());
+                    Optional<FeAnalysisEntity> findAnalysisResult = analysisService.findByDesignAndName(withStringEntity, withStringEntity.getName());
                     if (findAnalysisResult.isPresent()) {
                         entityAnalyses.add(findAnalysisResult.get());
                     } else {
@@ -727,10 +726,6 @@ public class CcServiceImpl extends AbstractDaoService implements CcService, Gene
     
     private List<String> getFeNamesLike(String name) {
         return analysisService.getNamesLike(name);
-    }
-    
-    private Optional<FeAnalysisEntity> getFeByDesignAndName(final FeAnalysisWithStringEntity withStringEntity, final String feAnalysisName) {
-        return analysisService.findByDesignAndName(withStringEntity, feAnalysisName);
     }
 
 }

--- a/src/main/java/org/ohdsi/webapi/feanalysis/FeAnalysisService.java
+++ b/src/main/java/org/ohdsi/webapi/feanalysis/FeAnalysisService.java
@@ -5,6 +5,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 import org.ohdsi.webapi.cohortcharacterization.domain.CohortCharacterizationEntity;
+import org.ohdsi.webapi.feanalysis.domain.FeAnalysisCriteriaEntity;
 import org.ohdsi.webapi.feanalysis.domain.FeAnalysisEntity;
 import org.ohdsi.webapi.feanalysis.domain.FeAnalysisWithCriteriaEntity;
 import org.ohdsi.webapi.feanalysis.domain.FeAnalysisWithStringEntity;
@@ -38,4 +39,6 @@ public interface FeAnalysisService {
     List<String> getNamesLike(String name);
     
     Optional<FeAnalysisEntity> findByDesignAndName(FeAnalysisWithStringEntity withStringEntity, final String name);
+
+    Optional<FeAnalysisEntity> findByCriteriaListAndName(List<? extends FeAnalysisCriteriaEntity> criteriaList, final String name);
 }

--- a/src/main/java/org/ohdsi/webapi/feanalysis/FeAnalysisService.java
+++ b/src/main/java/org/ohdsi/webapi/feanalysis/FeAnalysisService.java
@@ -40,5 +40,5 @@ public interface FeAnalysisService {
     
     Optional<FeAnalysisEntity> findByDesignAndName(FeAnalysisWithStringEntity withStringEntity, final String name);
 
-    Optional<FeAnalysisEntity> findByCriteriaListAndName(List<? extends FeAnalysisCriteriaEntity> criteriaList, final String name);
+    Optional<FeAnalysisEntity> findByCriteriaList(List<? extends FeAnalysisCriteriaEntity> newCriteriaList);
 }

--- a/src/main/java/org/ohdsi/webapi/feanalysis/FeAnalysisService.java
+++ b/src/main/java/org/ohdsi/webapi/feanalysis/FeAnalysisService.java
@@ -34,4 +34,6 @@ public interface FeAnalysisService {
     void deleteAnalysis(FeAnalysisEntity entity);
     
     void deleteAnalysis(int id);
+    
+    List<String> getNamesLike(String name);
 }

--- a/src/main/java/org/ohdsi/webapi/feanalysis/FeAnalysisService.java
+++ b/src/main/java/org/ohdsi/webapi/feanalysis/FeAnalysisService.java
@@ -36,4 +36,6 @@ public interface FeAnalysisService {
     void deleteAnalysis(int id);
     
     List<String> getNamesLike(String name);
+    
+    Optional<FeAnalysisEntity> findByDesignAndName(FeAnalysisWithStringEntity withStringEntity, final String name);
 }

--- a/src/main/java/org/ohdsi/webapi/feanalysis/FeAnalysisServiceImpl.java
+++ b/src/main/java/org/ohdsi/webapi/feanalysis/FeAnalysisServiceImpl.java
@@ -188,10 +188,12 @@ public class FeAnalysisServiceImpl extends AbstractDaoService implements FeAnaly
     }
 
     @Override
-    public Optional<FeAnalysisEntity> findByCriteriaListAndName(List<? extends FeAnalysisCriteriaEntity> newCriteriaList, String name) {
-        List<FeAnalysisEntity> analysis = analysisRepository.findAllByNameStartsWith(name);
-        return analysis.stream()
-                .filter(a -> this.checkCriteriaList(criteriaRepository.findAllByFeatureAnalysisId(a.getId()), newCriteriaList)).findFirst();
+    public Optional<FeAnalysisEntity> findByCriteriaList(List<? extends FeAnalysisCriteriaEntity> newCriteriaList) {
+        Map<FeAnalysisWithCriteriaEntity, List<FeAnalysisCriteriaEntity>> feAnalysisEntityListMap = newCriteriaList.stream()
+                .map(c -> criteriaRepository.findAllByExpressionString(c.getExpressionString()))
+                .flatMap(List::stream).collect(Collectors.groupingBy(FeAnalysisCriteriaEntity::getFeatureAnalysis));
+        return feAnalysisEntityListMap.entrySet().stream().filter(e -> checkCriteriaList(e.getValue(), newCriteriaList))
+                .findAny().map(Map.Entry::getKey);
     }
 
     private boolean checkCriteriaList(List<FeAnalysisCriteriaEntity> curCriteriaList, List<? extends FeAnalysisCriteriaEntity> newCriteriaList) {

--- a/src/main/java/org/ohdsi/webapi/feanalysis/FeAnalysisServiceImpl.java
+++ b/src/main/java/org/ohdsi/webapi/feanalysis/FeAnalysisServiceImpl.java
@@ -174,6 +174,12 @@ public class FeAnalysisServiceImpl extends AbstractDaoService implements FeAnaly
     public void deleteAnalysis(int id) {
         deleteAnalysis(analysisRepository.findById(id).orElseThrow(() -> new RuntimeException("There is no Feature Analysis with id = " + id)));
     }
+    
+    @Override
+    public List<String> getNamesLike(String name) {
+        return analysisRepository.findAllByNameStartsWith(name).stream().map(FeAnalysisEntity::getName).collect(Collectors.toList());
+    }
+    
 
     private void checkEntityLocked(FeAnalysisEntity entity) {
         if (entity.getLocked() == Boolean.TRUE) {

--- a/src/main/java/org/ohdsi/webapi/feanalysis/FeAnalysisServiceImpl.java
+++ b/src/main/java/org/ohdsi/webapi/feanalysis/FeAnalysisServiceImpl.java
@@ -18,6 +18,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import javax.ws.rs.NotFoundException;
 import java.util.*;
+import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
 @Service
@@ -178,6 +179,20 @@ public class FeAnalysisServiceImpl extends AbstractDaoService implements FeAnaly
     @Override
     public List<String> getNamesLike(String name) {
         return analysisRepository.findAllByNameStartsWith(name).stream().map(FeAnalysisEntity::getName).collect(Collectors.toList());
+    }
+    
+    @Override
+    public Optional<FeAnalysisEntity> findByDesignAndName(final FeAnalysisWithStringEntity withStringEntity, final String name) {
+        return this.findByDesignAndPredicate(withStringEntity.getDesign(), f -> Objects.equals(f.getName(), name));
+    }
+    
+    private Optional<FeAnalysisEntity> findByDesignAndPredicate(final String design, final Predicate<FeAnalysisEntity> f) {
+        List<FeAnalysisEntity> detailsFromDb = analysisRepository.findByDesign(design);
+        return detailsFromDb
+                .stream()
+                .filter(v -> Objects.equals(v.getDesign(), design))
+                .filter(f)
+                .findFirst();
     }
     
 

--- a/src/main/java/org/ohdsi/webapi/feanalysis/FeAnalysisServiceImpl.java
+++ b/src/main/java/org/ohdsi/webapi/feanalysis/FeAnalysisServiceImpl.java
@@ -206,7 +206,6 @@ public class FeAnalysisServiceImpl extends AbstractDaoService implements FeAnaly
         List<FeAnalysisEntity> detailsFromDb = analysisRepository.findByDesign(design);
         return detailsFromDb
                 .stream()
-                .filter(v -> Objects.equals(v.getDesign(), design))
                 .filter(f)
                 .findFirst();
     }

--- a/src/main/java/org/ohdsi/webapi/feanalysis/repository/FeAnalysisCriteriaRepository.java
+++ b/src/main/java/org/ohdsi/webapi/feanalysis/repository/FeAnalysisCriteriaRepository.java
@@ -2,9 +2,12 @@ package org.ohdsi.webapi.feanalysis.repository;
 
 import org.ohdsi.webapi.feanalysis.domain.FeAnalysisCriteriaEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 import java.util.List;
 
 public interface FeAnalysisCriteriaRepository extends JpaRepository<FeAnalysisCriteriaEntity, Long> {
     List<FeAnalysisCriteriaEntity> findAllByFeatureAnalysisId(Integer id);
+    @Query("select fa from FeAnalysisCriteriaEntity AS fa JOIN FETCH fa.featureAnalysis where expression = ?1")
+    List<FeAnalysisCriteriaEntity> findAllByExpressionString(String expression);
 }

--- a/src/main/java/org/ohdsi/webapi/feanalysis/repository/FeAnalysisCriteriaRepository.java
+++ b/src/main/java/org/ohdsi/webapi/feanalysis/repository/FeAnalysisCriteriaRepository.java
@@ -3,5 +3,8 @@ package org.ohdsi.webapi.feanalysis.repository;
 import org.ohdsi.webapi.feanalysis.domain.FeAnalysisCriteriaEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface FeAnalysisCriteriaRepository extends JpaRepository<FeAnalysisCriteriaEntity, Long> {
+    List<FeAnalysisCriteriaEntity> findAllByFeatureAnalysisId(Integer id);
 }

--- a/src/main/java/org/ohdsi/webapi/feanalysis/repository/FeAnalysisEntityRepository.java
+++ b/src/main/java/org/ohdsi/webapi/feanalysis/repository/FeAnalysisEntityRepository.java
@@ -9,6 +9,9 @@ import java.util.List;
 public interface FeAnalysisEntityRepository extends BaseFeAnalysisEntityRepository<FeAnalysisEntity> {
     @Query("Select fe FROM FeAnalysisEntity fe WHERE fe.name LIKE ?1 ESCAPE '\\'")
     List<FeAnalysisEntity> findAllByNameStartsWith(String pattern);
+    
+    @Query("Select fe FROM FeAnalysisEntity fe WHERE fe.design = ?1")
+    List<FeAnalysisEntity> findByDesign(String design);    
 
     @Query("SELECT COUNT(fe) FROM FeAnalysisEntity fe WHERE fe.name = :name and fe.id <> :id")
     int getCountFeWithSameName(@Param("id") Integer id, @Param("name") String name);

--- a/src/main/java/org/ohdsi/webapi/feanalysis/repository/FeAnalysisEntityRepository.java
+++ b/src/main/java/org/ohdsi/webapi/feanalysis/repository/FeAnalysisEntityRepository.java
@@ -4,7 +4,11 @@ import org.ohdsi.webapi.feanalysis.domain.FeAnalysisEntity;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import java.util.List;
+
 public interface FeAnalysisEntityRepository extends BaseFeAnalysisEntityRepository<FeAnalysisEntity> {
+    @Query("Select fe FROM FeAnalysisEntity fe WHERE fe.name LIKE ?1 ESCAPE '\\'")
+    List<FeAnalysisEntity> findAllByNameStartsWith(String pattern);
 
     @Query("SELECT COUNT(fe) FROM FeAnalysisEntity fe WHERE fe.name = :name and fe.id <> :id")
     int getCountFeWithSameName(@Param("id") Integer id, @Param("name") String name);

--- a/src/main/java/org/ohdsi/webapi/shiro/management/AtlasSecurity.java
+++ b/src/main/java/org/ohdsi/webapi/shiro/management/AtlasSecurity.java
@@ -462,10 +462,8 @@ public abstract class AtlasSecurity extends Security {
   // Since we need to create permissions only for certain analyses, we cannot go with `addProcessEntityFilter`
   @EventListener
   public void onCcImport(CcImportEvent event) throws Exception {
-    for (FeAnalysisEntity analysis : event.getEntity().getFeatureAnalyses()) {
-      if (!Objects.equals(analysis.getType(), StandardFeatureAnalysisType.PRESET)) {
-        authorizer.addPermissionsFromTemplate(featureAnalysisPermissionTemplates, analysis.getId().toString());
+      for (Integer id : event.getSavedAnalysesIds()) {
+          authorizer.addPermissionsFromTemplate(featureAnalysisPermissionTemplates, id.toString());
       }
-    }
   }
 }


### PR DESCRIPTION
Adds checks to ensure feature analysis names are not duplicated upon import of a cohort characterization design. This fixes issue #1192. I've tested this against SQL Server and PostgreSQL.