### PR TITLE
Additional fixes SQL/Oracle for #1105

### DIFF
--- a/src/main/resources/db/migration/oracle/V2.8.0.20190424150601__add-unique-name-constraint-to-entities.sql
+++ b/src/main/resources/db/migration/oracle/V2.8.0.20190424150601__add-unique-name-constraint-to-entities.sql
@@ -2,13 +2,13 @@
 
 CREATE OR REPLACE PROCEDURE ${ohdsiSchema}.rename_cs_names AS
     TYPE NumberArray IS TABLE OF NUMBER;
-    TYPE CharArray IS TABLE OF VARCHAR(100);
+    TYPE CharArray IS TABLE OF VARCHAR(255);
     duplicate_names CharArray;
     name_repeats NumberArray;
     amount_of_duplicate_names INT;
     amount_of_constraints INT;
-    constraint_title VARCHAR(100);
-    schema_title VARCHAR(100);
+    constraint_title VARCHAR(255);
+    schema_title VARCHAR(255);
     all_duplicates INT;
 
 BEGIN
@@ -72,13 +72,13 @@ end;
 
 CREATE OR REPLACE PROCEDURE ${ohdsiSchema}.rename_cd_names AS
     TYPE NumberArray IS TABLE OF NUMBER;
-    TYPE CharArray IS TABLE OF VARCHAR(100);
+    TYPE CharArray IS TABLE OF VARCHAR(255);
     duplicate_names CharArray;
     name_repeats NumberArray;
     amount_of_duplicate_names INT;
     amount_of_constraints INT;
-    constraint_title VARCHAR(100);
-    schema_title VARCHAR(100);
+    constraint_title VARCHAR(255);
+    schema_title VARCHAR(255);
     all_duplicates INT;
 
 BEGIN
@@ -141,13 +141,13 @@ end;
 
 CREATE OR REPLACE PROCEDURE ${ohdsiSchema}.rename_cc_names AS
     TYPE NumberArray IS TABLE OF NUMBER;
-    TYPE CharArray IS TABLE OF VARCHAR(100);
+    TYPE CharArray IS TABLE OF VARCHAR(255);
     duplicate_names CharArray;
     name_repeats NumberArray;
     amount_of_duplicate_names INT;
     amount_of_constraints INT;
-    constraint_title VARCHAR(100);
-    schema_title VARCHAR(100);
+    constraint_title VARCHAR(255);
+    schema_title VARCHAR(255);
     all_duplicates INT;
 
 BEGIN
@@ -209,13 +209,13 @@ end;
 
 CREATE OR REPLACE PROCEDURE ${ohdsiSchema}.rename_fe_names AS
     TYPE NumberArray IS TABLE OF NUMBER;
-    TYPE CharArray IS TABLE OF VARCHAR(100);
+    TYPE CharArray IS TABLE OF VARCHAR(255);
     duplicate_names CharArray;
     name_repeats NumberArray;
     amount_of_duplicate_names INT;
     amount_of_constraints INT;
-    constraint_title VARCHAR(100);
-    schema_title VARCHAR(100);
+    constraint_title VARCHAR(255);
+    schema_title VARCHAR(255);
     all_duplicates INT;
 
 BEGIN
@@ -277,13 +277,13 @@ end;
 
 CREATE OR REPLACE PROCEDURE ${ohdsiSchema}.rename_pathway_names AS
     TYPE NumberArray IS TABLE OF NUMBER;
-    TYPE CharArray IS TABLE OF VARCHAR(100);
+    TYPE CharArray IS TABLE OF VARCHAR(255);
     duplicate_names CharArray;
     name_repeats NumberArray;
     amount_of_duplicate_names INT;
     amount_of_constraints INT;
-    constraint_title VARCHAR(100);
-    schema_title VARCHAR(100);
+    constraint_title VARCHAR(255);
+    schema_title VARCHAR(255);
     all_duplicates INT;
 
 BEGIN
@@ -345,13 +345,13 @@ end;
 
 CREATE OR REPLACE PROCEDURE ${ohdsiSchema}.rename_ir_names AS
     TYPE NumberArray IS TABLE OF NUMBER;
-    TYPE CharArray IS TABLE OF VARCHAR(100);
+    TYPE CharArray IS TABLE OF VARCHAR(255);
     duplicate_names CharArray;
     name_repeats NumberArray;
     amount_of_duplicate_names INT;
     amount_of_constraints INT;
-    constraint_title VARCHAR(100);
-    schema_title VARCHAR(100);
+    constraint_title VARCHAR(255);
+    schema_title VARCHAR(255);
     all_duplicates INT;
 
 BEGIN
@@ -413,13 +413,13 @@ end;
 
 CREATE OR REPLACE PROCEDURE ${ohdsiSchema}.rename_estimation_names AS
     TYPE NumberArray IS TABLE OF NUMBER;
-    TYPE CharArray IS TABLE OF VARCHAR(100);
+    TYPE CharArray IS TABLE OF VARCHAR(255);
     duplicate_names CharArray;
     name_repeats NumberArray;
     amount_of_duplicate_names INT;
     amount_of_constraints INT;
-    constraint_title VARCHAR(100);
-    schema_title VARCHAR(100);
+    constraint_title VARCHAR(255);
+    schema_title VARCHAR(255);
     all_duplicates INT;
 
 BEGIN
@@ -481,13 +481,13 @@ end;
 
 CREATE OR REPLACE PROCEDURE ${ohdsiSchema}.rename_prediction_names AS
     TYPE NumberArray IS TABLE OF NUMBER;
-    TYPE CharArray IS TABLE OF VARCHAR(100);
+    TYPE CharArray IS TABLE OF VARCHAR(255);
     duplicate_names CharArray;
     name_repeats NumberArray;
     amount_of_duplicate_names INT;
     amount_of_constraints INT;
-    constraint_title VARCHAR(100);
-    schema_title VARCHAR(100);
+    constraint_title VARCHAR(255);
+    schema_title VARCHAR(255);
     all_duplicates INT;
 
 BEGIN

--- a/src/main/resources/db/migration/sqlserver/V2.8.0.20190424150601__add-unique-name-constraint-to-entities.sql
+++ b/src/main/resources/db/migration/sqlserver/V2.8.0.20190424150601__add-unique-name-constraint-to-entities.sql
@@ -2,7 +2,7 @@
 
 CREATE PROCEDURE ${ohdsiSchema}.rename_cs_names AS
 BEGIN
-    DECLARE @duplicate_names TABLE(id int IDENTITY (1, 1), duplicate_name varchar(100));
+    DECLARE @duplicate_names TABLE(id int IDENTITY (1, 1), duplicate_name varchar(255));
     DECLARE @name_repeats TABLE (id int IDENTITY (1, 1), repeat_number int);
     DECLARE @amount_of_duplicate_names int;
     DECLARE @k int;
@@ -28,7 +28,7 @@ BEGIN
             DECLARE @i int = 1;
             DECLARE @j int = 1;
             DECLARE @name_repeat int = 0;
-            DECLARE @dupl_name varchar(100);
+            DECLARE @dupl_name varchar(255);
         
             WHILE @i <= coalesce(@amount_of_duplicate_names, 0)
             BEGIN
@@ -67,7 +67,7 @@ GO
 
 CREATE PROCEDURE ${ohdsiSchema}.rename_cd_names AS
 BEGIN
-    DECLARE @duplicate_names TABLE(id int IDENTITY (1, 1), duplicate_name varchar(100));
+    DECLARE @duplicate_names TABLE(id int IDENTITY (1, 1), duplicate_name varchar(255));
     DECLARE @name_repeats TABLE (id int IDENTITY (1, 1), repeat_number int);
     DECLARE @amount_of_duplicate_names int;
     DECLARE @k int;
@@ -93,7 +93,7 @@ BEGIN
             DECLARE @i int = 1;
             DECLARE @j int = 1;
             DECLARE @name_repeat int = 0;
-            DECLARE @dupl_name varchar(100);
+            DECLARE @dupl_name varchar(255);
         
             WHILE @i <= coalesce(@amount_of_duplicate_names, 0)
             BEGIN
@@ -132,7 +132,7 @@ GO
 
 CREATE PROCEDURE ${ohdsiSchema}.rename_cc_names AS
 BEGIN
-    DECLARE @duplicate_names TABLE(id int IDENTITY (1, 1), duplicate_name varchar(100));
+    DECLARE @duplicate_names TABLE(id int IDENTITY (1, 1), duplicate_name varchar(255));
     DECLARE @name_repeats TABLE (id int IDENTITY (1, 1), repeat_number int);
     DECLARE @amount_of_duplicate_names int;
     DECLARE @k int;
@@ -158,7 +158,7 @@ BEGIN
             DECLARE @i int = 1;
             DECLARE @j int = 1;
             DECLARE @name_repeat int = 0;
-            DECLARE @dupl_name varchar(100);
+            DECLARE @dupl_name varchar(255);
         
             WHILE @i <= coalesce(@amount_of_duplicate_names, 0)
             BEGIN
@@ -197,7 +197,7 @@ GO
 
 CREATE PROCEDURE ${ohdsiSchema}.rename_fe_names AS
 BEGIN
-    DECLARE @duplicate_names TABLE(id int IDENTITY (1, 1), duplicate_name varchar(100));
+    DECLARE @duplicate_names TABLE(id int IDENTITY (1, 1), duplicate_name varchar(255));
     DECLARE @name_repeats TABLE (id int IDENTITY (1, 1), repeat_number int);
     DECLARE @amount_of_duplicate_names int;
     DECLARE @k int;
@@ -223,7 +223,7 @@ BEGIN
             DECLARE @i int = 1;
             DECLARE @j int = 1;
             DECLARE @name_repeat int = 0;
-            DECLARE @dupl_name varchar(100);
+            DECLARE @dupl_name varchar(255);
         
             WHILE @i <= coalesce(@amount_of_duplicate_names, 0)
             BEGIN
@@ -263,7 +263,7 @@ GO
 
 CREATE PROCEDURE ${ohdsiSchema}.rename_pw_names AS
 BEGIN
-    DECLARE @duplicate_names TABLE(id int IDENTITY (1, 1), duplicate_name varchar(100));
+    DECLARE @duplicate_names TABLE(id int IDENTITY (1, 1), duplicate_name varchar(255));
     DECLARE @name_repeats TABLE (id int IDENTITY (1, 1), repeat_number int);
     DECLARE @amount_of_duplicate_names int;
     DECLARE @k int;
@@ -289,7 +289,7 @@ BEGIN
             DECLARE @i int = 1;
             DECLARE @j int = 1;
             DECLARE @name_repeat int = 0;
-            DECLARE @dupl_name varchar(100);
+            DECLARE @dupl_name varchar(255);
         
             WHILE @i <= coalesce(@amount_of_duplicate_names, 0)
             BEGIN
@@ -328,7 +328,7 @@ GO
 
 CREATE PROCEDURE ${ohdsiSchema}.rename_ir_names AS
 BEGIN
-    DECLARE @duplicate_names TABLE(id int IDENTITY (1, 1), duplicate_name varchar(100));
+    DECLARE @duplicate_names TABLE(id int IDENTITY (1, 1), duplicate_name varchar(255));
     DECLARE @name_repeats TABLE (id int IDENTITY (1, 1), repeat_number int);
     DECLARE @amount_of_duplicate_names int;
     DECLARE @k int;
@@ -354,7 +354,7 @@ BEGIN
             DECLARE @i int = 1;
             DECLARE @j int = 1;
             DECLARE @name_repeat int = 0;
-            DECLARE @dupl_name varchar(100);
+            DECLARE @dupl_name varchar(255);
         
             WHILE @i <= coalesce(@amount_of_duplicate_names, 0)
             BEGIN
@@ -393,7 +393,7 @@ GO
 
 CREATE PROCEDURE ${ohdsiSchema}.rename_estimation_names AS
 BEGIN
-    DECLARE @duplicate_names TABLE(id int IDENTITY (1, 1), duplicate_name varchar(100));
+    DECLARE @duplicate_names TABLE(id int IDENTITY (1, 1), duplicate_name varchar(255));
     DECLARE @name_repeats TABLE (id int IDENTITY (1, 1), repeat_number int);
     DECLARE @amount_of_duplicate_names int;
     DECLARE @k int;
@@ -419,7 +419,7 @@ BEGIN
             DECLARE @i int = 1;
             DECLARE @j int = 1;
             DECLARE @name_repeat int = 0;
-            DECLARE @dupl_name varchar(100);
+            DECLARE @dupl_name varchar(255);
         
             WHILE @i <= coalesce(@amount_of_duplicate_names, 0)
             BEGIN
@@ -458,7 +458,7 @@ GO
 
 CREATE PROCEDURE ${ohdsiSchema}.rename_prediction_names AS
 BEGIN
-    DECLARE @duplicate_names TABLE(id int IDENTITY (1, 1), duplicate_name varchar(100));
+    DECLARE @duplicate_names TABLE(id int IDENTITY (1, 1), duplicate_name varchar(255));
     DECLARE @name_repeats TABLE (id int IDENTITY (1, 1), repeat_number int);
     DECLARE @amount_of_duplicate_names int;
     DECLARE @k int;
@@ -484,7 +484,7 @@ BEGIN
             DECLARE @i int = 1;
             DECLARE @j int = 1;
             DECLARE @name_repeat int = 0;
-            DECLARE @dupl_name varchar(100);
+            DECLARE @dupl_name varchar(255);
         
             WHILE @i <= coalesce(@amount_of_duplicate_names, 0)
             BEGIN


### PR DESCRIPTION
Updates the Flyway migration script `V2.8.0.20190424150601__add-unique-name-constraint-to-entities.sql `for Oracle/SQL Server to use a `varchar(255)` otherwise the script can fall into an infinite loop.

This PR does not address a very relevant comment from @chrisknoll noted here: https://github.com/OHDSI/WebAPI/issues/1105#issuecomment-504029253 since I'm not sure if this will happen practically when migrating. That said, I fully support using the `LEFT` operator as proposed by Chris but could use some assistance in implementing this on Oracle/PostgreSQL.

Tagging @pavgra @aklochkova @chrisknoll for awareness and feedback.