### PR TITLE
Fix overlap logic.

### DIFF
--- a/src/main/resources/resources/pathway/runPathwayAnalysis.sql
+++ b/src/main/resources/resources/pathway/runPathwayAnalysis.sql
@@ -21,7 +21,7 @@ FROM (
 	  e.cohort_end_date
 	FROM @target_cohort_table e
 	  JOIN ( @event_cohort_id_index_map ) ec ON e.cohort_definition_id = ec.cohort_definition_id
-	  JOIN @target_cohort_table t ON t.cohort_start_date <= e.cohort_start_date AND e.cohort_end_date <= t.cohort_end_date AND t.subject_id = e.subject_id
+	  JOIN @target_cohort_table t ON t.cohort_start_date <= e.cohort_start_date AND e.cohort_start_date <= t.cohort_end_date AND t.subject_id = e.subject_id
 	WHERE t.cohort_definition_id = @pathway_target_cohort_id
 ) RE;
 
@@ -52,7 +52,7 @@ replacements AS (
   SELECT orig.subject_id, orig.cohort_date, FIRST_VALUE(cohort_date) OVER (PARTITION BY group_idx ORDER BY ordinal ASC ROWS UNBOUNDED PRECEDING) as replacement_date
   FROM grouped_dates orig
 )
-SELECT *
+SELECT subject_id, cohort_date, replacement_date
 INTO #date_replacements
 FROM replacements
 WHERE cohort_date <> replacement_date;
@@ -77,6 +77,11 @@ FROM #raw_events event
 ;
 
 /*
+The collapsed dates (or the raw event cohort dates) may have intervals where start == end, so these should be expanded to cover a minimum of 1 day
+*/
+update #collapsed_dates_events set cohort_end_date = dateadd(d,1,cohort_end_date) where cohort_start_date = cohort_end_date;
+
+/*
 Split partially overlapping events into a set of events which either do not overlap or fully overlap (for later GROUP BY start_date, end_date)
 
 e.g.
@@ -86,68 +91,38 @@ into
 
   |A--|A--|
       |B--|B--|
+
+or 
+  |A--------------|
+      |B-----|
+into   
+  |A--|A-----|A---|
+      |B-----|
 */
 
-IF OBJECT_ID('tempdb..#split_overlay_events', 'U') IS NOT NULL
-DROP TABLE #split_overlay_events;
+WITH 
+cohort_dates AS (
+	SELECT DISTINCT subject_id, cohort_date 
+	FROM (
+		  SELECT subject_id, cohort_start_date cohort_date FROM #collapsed_dates_events 
+		  UNION 
+		  SELECT subject_id,cohort_end_date cohort_date FROM #collapsed_dates_events
+		  ) all_dates
+),
+time_periods AS (
+	SELECT subject_id, cohort_date, LEAD(cohort_date,1) over (PARTITION BY subject_id ORDER BY cohort_date ASC) next_cohort_date
+	FROM cohort_dates 
+	GROUP BY subject_id, cohort_date
 
-SELECT soe.id, soe.event_cohort_index, soe.subject_id, soe.cohort_start_date, soe.cohort_end_date
-INTO #split_overlay_events
-FROM (
-  SELECT
-    CASE WHEN ordinal < 3 THEN f.id ELSE s.id END as id,
-    CASE WHEN ordinal < 3 THEN f.event_cohort_index ELSE s.event_cohort_index END event_cohort_index,
-    CASE WHEN ordinal < 3 THEN f.subject_id ELSE s.subject_id END subject_id,
-
-    CASE ordinal
-      WHEN 1 THEN
-      f.cohort_start_date
-      WHEN 2 THEN
-      s.cohort_start_date
-      WHEN 3 THEN
-      s.cohort_start_date
-      WHEN 4 THEN
-      f.cohort_end_date
-      END as cohort_start_date,
-
-    CASE ordinal
-      WHEN 1 THEN
-      s.cohort_start_date
-      WHEN 2 THEN
-      f.cohort_end_date
-      WHEN 3 THEN
-      f.cohort_end_date
-      WHEN 4 THEN
-      s.cohort_end_date
-      END as cohort_end_date
-  FROM #collapsed_dates_events f
-  JOIN #collapsed_dates_events s ON f.subject_id = s.subject_id
-      AND f.cohort_start_date < s.cohort_start_date
-      AND f.cohort_end_date < s.cohort_end_date
-      AND f.cohort_end_date > s.cohort_start_date
-  CROSS JOIN (SELECT 1 ordinal UNION SELECT 2 UNION SELECT 3 UNION SELECT 4) multiplier
-) soe;
-
-/*
-* Group fully overlapping events into combinations (e.g. two separate events A and B with same start and end dates -> single A+B event)
-* We'll use bitwise addition with SUM() to combine events instead of LIST_AGG(), replacing 'name' column with 'combo_id'.
-*/
-
-IF OBJECT_ID('tempdb..#combo_events', 'U') IS NOT NULL
-DROP TABLE #combo_events;
-
-WITH events AS (
-  SELECT *
-  FROM #collapsed_dates_events cde
-  WHERE NOT EXISTS(SELECT id FROM #split_overlay_events soe WHERE soe.id = cde.id)
-
-  UNION ALL
-
-  SELECT *
-  FROM #split_overlay_events
-)
-SELECT CAST(SUM(DISTINCT POWER(2, e.event_cohort_index)) as INT) as combo_id, subject_id, cohort_start_date, cohort_end_date
-INTO #combo_events
+),
+events AS (
+	SELECT tp.subject_id, event_cohort_index, cohort_date cohort_start_date, next_cohort_date cohort_end_date  
+	FROM time_periods tp
+	LEFT JOIN #collapsed_dates_events e ON e.subject_id = tp.subject_id
+	WHERE (e.cohort_start_date <= tp.cohort_date AND e.cohort_end_date >= tp.next_cohort_date)
+) 
+SELECT SUM(POWER(2, e.event_cohort_index)) as combo_id,  subject_id , cohort_start_date, cohort_end_date
+into #combo_events
 FROM events e
 GROUP BY subject_id, cohort_start_date, cohort_end_date;
 
@@ -200,12 +175,12 @@ SELECT
   target_count.cnt AS target_cohort_count,
   pathway_count.cnt AS pathways_count
 FROM (
-  SELECT CAST(COUNT(*) AS INT) cnt
+  SELECT COUNT_BIG(*) cnt
   FROM @target_cohort_table
   WHERE cohort_definition_id = @pathway_target_cohort_id
 ) target_count,
 (
-  SELECT CAST(COUNT(DISTINCT subject_id) AS INT) cnt
+  SELECT COUNT_BIG(DISTINCT subject_id) cnt
   FROM @target_database_schema.pathway_analysis_events
   WHERE pathway_analysis_generation_id = @generation_id
   AND target_cohort_id = @pathway_target_cohort_id


### PR DESCRIPTION
This PR is intended for post 2.7.2 release, so it's being attached to the 2.8.0 backlog.

This PR incorporates the fix for identifying overlapping event cohorts contributed by @mick-iqvia and @hms1.  To those collaborators: if you could pull this branch and run your local tests to determine if it identifies the overlaps properly.

This PR contains the following changes:
- Allow event cohort periods that start within the target cohort era.  Prior version required the event cohort era to start and end in the target cohort era.
- When collapsing, ensure start-end dates span at least a day.
- Use count_big when counting cohort events and pathways.

Note about what was discussed on prior WG calls:  this PR does not incorporate the new option for 'minimum segment length', since this PR is just going to focus on correctly identifying overlaps.  The pieces are in place to support the minimum segment length options, and that will be handled in a separate PR.  This PR is structured this way as to be included in a 2.7.3 without needing any changes to Atlas UI (which will be required when we add the new 'minimum segment length' option).  We had discussed switching 'collapse window' with 'minimum segment length' but the collapse window has very specific behavior that are desirable for our own research teams, so we are going to support both options (with adequate documentation).

For an example of the collapse window/multiple overlap fixes, i ran our own pathway analysis of T2DM medications over a T2DM patient population, an this was the resulting sunburst:

![image](https://user-images.githubusercontent.com/6818777/59949750-0d18eb00-9442-11e9-86f6-330dccddfe5d.png)

As you can see, by specifying a collapse window of 99999 days, all events were collapse to the same start/end dates.  This shows how this population had up to 4 distinct event cohorts (demonstrated by a single band having 4 different color stripes in it (note: it is very small slice of the sunburst)) in the same path segment, demonstrating that the new logic for finding overlapping periods is working.  Additional review would be welcome if there is any corner-cases that may remain undiscovered that should be addressed.

