### PR TITLE
[2.7.3] Fix compatability of /cohortdefinition/{id} endpoint

### DIFF
--- a/src/main/java/org/ohdsi/webapi/cohortdefinition/converter/CohortDefinitionToCohortRawDTOConverter.java
+++ b/src/main/java/org/ohdsi/webapi/cohortdefinition/converter/CohortDefinitionToCohortRawDTOConverter.java
@@ -1,0 +1,25 @@
+package org.ohdsi.webapi.cohortdefinition.converter;
+
+import org.ohdsi.webapi.cohortdefinition.CohortDefinition;
+import org.ohdsi.webapi.cohortdefinition.dto.CohortRawDTO;
+import org.springframework.stereotype.Component;
+
+@Component
+public class CohortDefinitionToCohortRawDTOConverter extends BaseCohortDefinitionToCohortMetadataDTOConverter<CohortRawDTO> {
+
+	@Override
+	public CohortRawDTO convert(final CohortDefinition source) {
+
+		final CohortRawDTO dto = super.convert(source);
+		dto.setExpressionType(source.getExpressionType());
+		if (source.getDetails() != null) {
+			dto.setExpression(source.getDetails().getExpression());
+		}
+		return dto;
+	}
+
+	@Override
+	protected CohortRawDTO getResultObject() {
+		return new CohortRawDTO();
+	}
+}

--- a/src/main/java/org/ohdsi/webapi/cohortdefinition/dto/CohortRawDTO.java
+++ b/src/main/java/org/ohdsi/webapi/cohortdefinition/dto/CohortRawDTO.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2019 cknoll1.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.ohdsi.webapi.cohortdefinition.dto;
+
+import org.ohdsi.webapi.cohortdefinition.ExpressionType;
+
+/**
+ *
+ * @author cknoll1
+ */
+public class CohortRawDTO extends CohortMetadataDTO {
+
+	private String expression;
+	private ExpressionType expressionType;
+
+	public String getExpression() {
+		return expression;
+	}
+
+	public void setExpression(final String expression) {
+		this.expression = expression;
+	}
+
+	public ExpressionType getExpressionType() {
+		return expressionType;
+	}
+
+	public void setExpressionType(final ExpressionType expressionType) {
+		this.expressionType = expressionType;
+	}
+}

--- a/src/main/java/org/ohdsi/webapi/service/CohortDefinitionService.java
+++ b/src/main/java/org/ohdsi/webapi/service/CohortDefinitionService.java
@@ -74,6 +74,7 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import static org.ohdsi.webapi.Constants.Params.*;
+import org.ohdsi.webapi.cohortdefinition.dto.CohortRawDTO;
 import static org.ohdsi.webapi.util.SecurityUtils.whitelist;
 
 /**
@@ -379,7 +380,21 @@ public class CohortDefinitionService extends AbstractDaoService {
   @GET
   @Path("/{id}")
   @Produces(MediaType.APPLICATION_JSON)
-  public CohortDTO getCohortDefinition(@PathParam("id") final int id) {
+  public CohortRawDTO getCohortDefinitionRaw(@PathParam("id") final int id) {
+
+    return getTransactionTemplate().execute(transactionStatus -> {
+      CohortDefinition d = this.cohortDefinitionRepository.findOneWithDetail(id);
+      ExceptionUtils.throwNotFoundExceptionIfNull(d, String.format("There is no cohort definition with id = %d.", id));
+      return conversionService.convert(d, CohortRawDTO.class);
+    });
+  }
+
+	/**
+	 * This method returns the cohort definition containg the circe cohort expression
+	 * @param id
+	 * @return 
+	 */
+  public CohortDTO getCohortDefinition( final int id) {
 
     return getTransactionTemplate().execute(transactionStatus -> {
       CohortDefinition d = this.cohortDefinitionRepository.findOneWithDetail(id);
@@ -387,7 +402,7 @@ public class CohortDefinitionService extends AbstractDaoService {
       return conversionService.convert(d, CohortDTO.class);
     });
   }
-
+	
   @GET
   @Path("/{id}/exists")
   @Produces(MediaType.APPLICATION_JSON)


### PR DESCRIPTION
Note, This was a one-off patch on a single endpoint, because changing the core getCohortDefinition(id) would have had broad ranging impact on different subsystems. A new method getCohortDefinitionRaw() was added to restore backwards compatibility with that single endpoint, while the other clients to getCohrotDefinition can use the new API.

Fixes #1229