### PR TITLE
Allow cache endpoint to be accessed in secured mode.

### DIFF
--- a/src/main/java/org/ohdsi/webapi/shiro/management/AtlasSecurity.java
+++ b/src/main/java/org/ohdsi/webapi/shiro/management/AtlasSecurity.java
@@ -290,6 +290,9 @@ public abstract class AtlasSecurity extends Security {
             //executionservice callbacks
             .addRestPath("/executionservice/callbacks/**")
 
+						//cache
+            .addRestPath("/cache/*")
+						
             .addProtectedRestPath("/**/*");
   }
 


### PR DESCRIPTION
This PR apples the endpoint change for issue #1033, but based on the 2.7.3 release, not master.
