### PR TITLE
Update pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -395,6 +395,11 @@
       <id>redshift</id>
       <url>http://redshift-maven-repository.s3-website-us-east-1.amazonaws.com/release</url>
     </repository>
+    <repository>
+      <id>oracle</id>
+      <name>Or</name>
+      <url>http://maven.jahia.org/maven2</url>
+    </repository>    
   </repositories>
 
   <pluginRepositories>


### PR DESCRIPTION
Issue #1233

In Maven repository "http://repo.maven.apache.org/maven2/", it didn't exist oracle's ojdbc.
So if someone want to build oracle setting, the man should add repository in the pom.xml.