### PR TITLE
Broken WebAPI Builds due to changes in Maven repository

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -373,7 +373,7 @@
     <repository>
       <id>central</id>
       <name>Central Repository</name>
-      <url>http://repo.maven.apache.org/maven2/ </url>
+      <url>https://repo.maven.apache.org/maven2/ </url>
     </repository>
     <repository>
       <id>ohdsi</id>


### PR DESCRIPTION
As of January 15th, apparently, the Apache Maven repository only supports HTTPS connections (https://stackoverflow.com/questions/59763531/maven-dependencies-are-failing-with-a-501-error).

This change is necessary for WebAPI to build with Maven.