### PR TITLE
Remove Maven Central Repo from pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -371,11 +371,6 @@
 
   <repositories>
     <repository>
-      <id>central</id>
-      <name>Central Repository</name>
-      <url>https://repo.maven.apache.org/maven2/ </url>
-    </repository>
-    <repository>
       <id>ohdsi</id>
       <name>repo.ohdsi.org</name>
       <url>http://repo.ohdsi.org:8085/nexus/content/repositories/releases</url>


### PR DESCRIPTION
remove http://repo.maven.apache.org/maven2
http is not longer supported by maven central. Default repo point to the correct https version 
https://stackoverflow.com/a/59764670/1167673