### PR TITLE
Fixes for postgresql 9.5

### DIFF
--- a/src/main/resources/db/migration/postgresql/V2.5.0.20180730192730__schema-add-kerberos-to-source.sql
+++ b/src/main/resources/db/migration/postgresql/V2.5.0.20180730192730__schema-add-kerberos-to-source.sql
@@ -1,4 +1,4 @@
-ALTER TABLE ${ohdsiSchema}.source ADD COLUMN IF NOT EXISTS krb_auth_method VARCHAR DEFAULT 'PASSWORD' NOT NULL;
+ALTER TABLE ${ohdsiSchema}.source ADD COLUMN krb_auth_method VARCHAR DEFAULT 'PASSWORD' NOT NULL;
 ALTER TABLE ${ohdsiSchema}.source ADD COLUMN keytab_name VARCHAR;
 ALTER TABLE ${ohdsiSchema}.source ADD COLUMN krb_keytab BYTEA;
 ALTER TABLE ${ohdsiSchema}.source ADD COLUMN krb_admin_server VARCHAR;

--- a/src/main/resources/db/migration/postgresql/V2.6.0.20181016171200__add_last_viewed_notifications_time.sql
+++ b/src/main/resources/db/migration/postgresql/V2.6.0.20181016171200__add_last_viewed_notifications_time.sql
@@ -1,4 +1,4 @@
-ALTER TABLE ${ohdsiSchema}.sec_user ADD IF NOT EXISTS last_viewed_notifications_time TIMESTAMP WITH TIME ZONE;
+ALTER TABLE ${ohdsiSchema}.sec_user ADD last_viewed_notifications_time TIMESTAMP WITH TIME ZONE;
 
 INSERT INTO ${ohdsiSchema}.sec_permission(id, value, description)
 VALUES

--- a/src/main/resources/db/migration/postgresql/V2.7.0.20190129083000__fe-analysis-created-modified-fix.sql
+++ b/src/main/resources/db/migration/postgresql/V2.7.0.20190129083000__fe-analysis-created-modified-fix.sql
@@ -1,10 +1,10 @@
-ALTER TABLE ${ohdsiSchema}.fe_analysis_criteria DROP COLUMN IF EXISTS created_by_id;
-ALTER TABLE ${ohdsiSchema}.fe_analysis_criteria DROP COLUMN IF EXISTS created_date;
-ALTER TABLE ${ohdsiSchema}.fe_analysis_criteria DROP COLUMN IF EXISTS modified_by_id;
-ALTER TABLE ${ohdsiSchema}.fe_analysis_criteria DROP COLUMN IF EXISTS modified_date;
+ALTER TABLE ${ohdsiSchema}.fe_analysis_criteria DROP COLUMN  created_by_id;
+ALTER TABLE ${ohdsiSchema}.fe_analysis_criteria DROP COLUMN  created_date;
+ALTER TABLE ${ohdsiSchema}.fe_analysis_criteria DROP COLUMN  modified_by_id;
+ALTER TABLE ${ohdsiSchema}.fe_analysis_criteria DROP COLUMN  modified_date;
 
 ALTER TABLE ${ohdsiSchema}.fe_analysis
-  ADD COLUMN IF NOT EXISTS created_by_id INTEGER REFERENCES ${ohdsiSchema}.sec_user(id),
-  ADD COLUMN IF NOT EXISTS created_date TIMESTAMP,
-  ADD COLUMN IF NOT EXISTS modified_by_id INTEGER REFERENCES ${ohdsiSchema}.sec_user(id),
-  ADD COLUMN IF NOT EXISTS modified_date TIMESTAMP;
+  ADD COLUMN  created_by_id INTEGER REFERENCES ${ohdsiSchema}.sec_user(id),
+  ADD COLUMN  created_date TIMESTAMP,
+  ADD COLUMN  modified_by_id INTEGER REFERENCES ${ohdsiSchema}.sec_user(id),
+  ADD COLUMN  modified_date TIMESTAMP;

--- a/src/main/resources/db/migration/postgresql/V2.7.0.20190208164736__analysis_execution-add-job_id.sql
+++ b/src/main/resources/db/migration/postgresql/V2.7.0.20190208164736__analysis_execution-add-job_id.sql
@@ -1,4 +1,4 @@
-ALTER TABLE ${ohdsiSchema}.analysis_execution ADD IF NOT EXISTS job_execution_id BIGINT;
+ALTER TABLE ${ohdsiSchema}.analysis_execution ADD job_execution_id BIGINT;
 
 alter table ${ohdsiSchema}.analysis_execution drop column analysis_id;
 ALTER TABLE ${ohdsiSchema}.analysis_execution DROP COLUMN analysis_type;

--- a/src/main/resources/db/migration/postgresql/V2.7.0.20190212154939__analysis_execution_files.sql
+++ b/src/main/resources/db/migration/postgresql/V2.7.0.20190212154939__analysis_execution_files.sql
@@ -1,13 +1,13 @@
-ALTER TABLE ${ohdsiSchema}.output_files ADD IF NOT EXISTS media_type VARCHAR(255);
+ALTER TABLE ${ohdsiSchema}.output_files ADD media_type VARCHAR(255);
 
-ALTER TABLE ${ohdsiSchema}.output_files DROP CONSTRAINT IF EXISTS fk_sif_cca_execution;
-ALTER TABLE ${ohdsiSchema}.output_files DROP COLUMN IF EXISTS cca_execution_id;
+ALTER TABLE ${ohdsiSchema}.output_files DROP CONSTRAINT fk_sif_cca_execution;
+ALTER TABLE ${ohdsiSchema}.output_files DROP COLUMN  cca_execution_id;
 
-ALTER TABLE ${ohdsiSchema}.input_files DROP CONSTRAINT IF EXISTS fk_sof_cca_execution;
-ALTER TABLE ${ohdsiSchema}.input_files DROP COLUMN IF EXISTS cca_execution_id;
+ALTER TABLE ${ohdsiSchema}.input_files DROP CONSTRAINT  fk_sof_cca_execution;
+ALTER TABLE ${ohdsiSchema}.input_files DROP COLUMN  cca_execution_id;
 
-ALTER TABLE ${ohdsiSchema}.output_files ADD IF NOT EXISTS execution_id INT;
-ALTER TABLE ${ohdsiSchema}.input_files ADD IF NOT EXISTS execution_id INT;
+--ALTER TABLE ${ohdsiSchema}.output_files ADD  execution_id INT;
+--ALTER TABLE ${ohdsiSchema}.input_files ADD  execution_id INT;
 
-CREATE SEQUENCE IF NOT EXISTS ${ohdsiSchema}.output_file_seq;
-CREATE SEQUENCE IF NOT EXISTS ${ohdsiSchema}.input_file_seq;
+CREATE SEQUENCE  ${ohdsiSchema}.output_file_seq;
+CREATE SEQUENCE  ${ohdsiSchema}.input_file_seq;


### PR DESCRIPTION
Worked with @PRijnbeek to get the Flyway scripts compatible with PG 9.5 since some of the SQL Scripts were using extraneous `IF NOT EXIST` clauses which are not desirable in Flyway migrations.