### PR TITLE
Rollback logout option #1457

### DIFF
--- a/src/main/java/org/ohdsi/webapi/OidcConfCreator.java
+++ b/src/main/java/org/ohdsi/webapi/OidcConfCreator.java
@@ -36,9 +36,6 @@ public class OidcConfCreator {
     @Value("${security.oid.url}")
     private String url;
 
-    @Value("${security.oid.logoutUrl}")
-    private String logoutUrl;
-
     @Value("${security.oauth.callback.api}")
     private String oauthApiCallback;
 
@@ -47,7 +44,6 @@ public class OidcConfCreator {
         conf.setClientId(clientId);
         conf.setSecret(apiSecret);
         conf.setDiscoveryURI(url);
-        conf.setLogoutUrl(logoutUrl);
         conf.setCallbackUrl(oauthApiCallback);
         conf.setPreferredJwsAlgorithm(JWSAlgorithm.RS256);
         return conf;


### PR DESCRIPTION
Rolls back changes from #1457. 

Tagging @phozzy - apologies but I need to roll this back since we're using an older version of pac4j that does not support the logout option (http://www.pac4j.org/apidocs/pac4j/1.9.2/org/pac4j/oidc/config/OidcConfiguration.html). 