### PR TITLE
pac4j and Authz google id from 2.7

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -699,7 +699,7 @@
     </dependency>
     <dependency>
       <groupId>org.pac4j</groupId>
-      <artifactId>pac4j-saml</artifactId>
+      <artifactId>pac4j-saml-opensamlv3</artifactId>
       <version>${pac4j.version}</version>
     </dependency>
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -71,6 +71,8 @@
     <security.ssl.enabled>false</security.ssl.enabled>
     <security.oauth.callback.ui>http://localhost/Atlas/#/welcome</security.oauth.callback.ui>
     <security.oauth.callback.api>http://localhost:8080/WebAPI/user/oauth/callback</security.oauth.callback.api>
+    <!-- Available options for callback urlResolver are: query and path -->
+    <security.oauth.callback.urlResolver>query</security.oauth.callback.urlResolver>
     <security.oauth.google.apiKey></security.oauth.google.apiKey>
     <security.oauth.google.apiSecret></security.oauth.google.apiSecret>
     <security.oauth.facebook.apiKey></security.oauth.facebook.apiKey>

--- a/pom.xml
+++ b/pom.xml
@@ -128,6 +128,7 @@
 
     <security.googleIap.cloudProjectId></security.googleIap.cloudProjectId>
     <security.googleIap.backendServiceId></security.googleIap.backendServiceId>
+    <security.google.accessToken.enabled>false</security.google.accessToken.enabled>
 
     <security.cors.enabled>true</security.cors.enabled>
     <security.maxLoginAttempts>3</security.maxLoginAttempts>

--- a/pom.xml
+++ b/pom.xml
@@ -15,12 +15,12 @@
     <spring.boot.version>1.5.20.RELEASE</spring.boot.version>
     <flyway.version>4.2.0</flyway.version>
     <waffle.version>1.7.3</waffle.version>
+
     <circe.version>1.9.0-SNAPSHOT</circe.version>
     <jersey.version>2.14</jersey.version>
     <SqlRender.version>1.6.3-SNAPSHOT</SqlRender.version>
     <hive-jdbc.version>3.1.2</hive-jdbc.version>
-    <pac4j.version>1.9.2</pac4j.version>
-
+    <pac4j.version>4.0.0</pac4j.version>
     <start-class>org.ohdsi.webapi.WebApi</start-class>
     <skipTests>true</skipTests>
 
@@ -684,7 +684,7 @@
     <dependency>
       <groupId>io.buji</groupId>
       <artifactId>buji-pac4j</artifactId>
-      <version>2.0.2</version>
+      <version>5.0.0</version>
     </dependency>
     <dependency>
       <groupId>org.pac4j</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -80,6 +80,7 @@
     <security.oid.clientId></security.oid.clientId>
     <security.oid.apiSecret></security.oid.apiSecret>
     <security.oid.url></security.oid.url>
+    <security.oid.logoutUrl></security.oid.logoutUrl>
     <security.oid.redirectUrl>http://localhost/index.html#/welcome/</security.oid.redirectUrl>
     <security.kerberos.spn></security.kerberos.spn>
     <security.kerberos.keytabPath></security.kerberos.keytabPath>

--- a/src/main/java/org/ohdsi/webapi/Constants.java
+++ b/src/main/java/org/ohdsi/webapi/Constants.java
@@ -88,4 +88,9 @@ public interface Constants {
     String COHORT_SUMMARY_STATS_CACHE = "cohort_summary_stats_cache";
     String COHORT_CENSOR_STATS_CACHE = "cohort_censor_stats_cache";
   }
+
+  interface CallbackUrlResolvers {
+    String QUERY = "query";
+    String PATH = "path";
+  }
 }

--- a/src/main/java/org/ohdsi/webapi/OidcConfCreator.java
+++ b/src/main/java/org/ohdsi/webapi/OidcConfCreator.java
@@ -44,7 +44,6 @@ public class OidcConfCreator {
         conf.setClientId(clientId);
         conf.setSecret(apiSecret);
         conf.setDiscoveryURI(url);
-        conf.setCallbackUrl(oauthApiCallback);
         conf.setPreferredJwsAlgorithm(JWSAlgorithm.RS256);
         return conf;
     }

--- a/src/main/java/org/ohdsi/webapi/OidcConfCreator.java
+++ b/src/main/java/org/ohdsi/webapi/OidcConfCreator.java
@@ -35,7 +35,10 @@ public class OidcConfCreator {
 
     @Value("${security.oid.url}")
     private String url;
-
+    
+    @Value("${security.oid.logoutUrl}")
+    private String logoutUrl;
+    
     @Value("${security.oauth.callback.api}")
     private String oauthApiCallback;
 
@@ -44,6 +47,7 @@ public class OidcConfCreator {
         conf.setClientId(clientId);
         conf.setSecret(apiSecret);
         conf.setDiscoveryURI(url);
+        conf.setLogoutUrl(logoutUrl);
         conf.setPreferredJwsAlgorithm(JWSAlgorithm.RS256);
         return conf;
     }

--- a/src/main/java/org/ohdsi/webapi/security/SSOController.java
+++ b/src/main/java/org/ohdsi/webapi/security/SSOController.java
@@ -68,7 +68,7 @@ public class SSOController {
     @GET
     @Path("/slo")
     public Response logout() throws URISyntaxException {
-        return Response.status(HttpConstants.TEMP_REDIRECT)
+        return Response.status(HttpConstants.TEMPORARY_REDIRECT)
                 .header(HttpConstants.ACCESS_CONTROL_ALLOW_ORIGIN_HEADER, this.origin)
                 .location(new URI(sloUri))
                 .build();

--- a/src/main/java/org/ohdsi/webapi/shiro/filters/CasHandleFilter.java
+++ b/src/main/java/org/ohdsi/webapi/shiro/filters/CasHandleFilter.java
@@ -18,6 +18,7 @@ import org.slf4j.LoggerFactory;
 import javax.servlet.ServletRequest;
 import javax.servlet.ServletResponse;
 import javax.servlet.http.HttpSession;
+import java.util.Collections;
 import java.util.LinkedHashMap;
 
 /**
@@ -80,9 +81,7 @@ public class CasHandleFilter extends AtlasAuthFilter {
                         casProfile.addAttributes(principal.getAttributes());
                         
                         Subject currentUser = SecurityUtils.getSubject();
-                        LinkedHashMap<String, CommonProfile> pMap = new LinkedHashMap<String, CommonProfile>();
-                        pMap.put(principal.getName(), casProfile);
-                        ct = new Pac4jToken(pMap, currentUser.isRemembered());
+                        ct = new Pac4jToken(Collections.singletonList(casProfile), currentUser.isRemembered());
                         /*
                          * let AuthenticatingFilter.executeLogin login user
                          */

--- a/src/main/java/org/ohdsi/webapi/shiro/filters/GoogleAccessTokenFilter.java
+++ b/src/main/java/org/ohdsi/webapi/shiro/filters/GoogleAccessTokenFilter.java
@@ -1,0 +1,99 @@
+package org.ohdsi.webapi.shiro.filters;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.shiro.SecurityUtils;
+import org.apache.shiro.authc.AuthenticationException;
+import org.apache.shiro.authc.AuthenticationToken;
+import org.apache.shiro.subject.PrincipalCollection;
+import org.ohdsi.webapi.shiro.PermissionManager;
+import org.ohdsi.webapi.shiro.TokenManager;
+import org.ohdsi.webapi.shiro.tokens.JwtAuthToken;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.client.HttpClientErrorException;
+import org.springframework.web.client.RestTemplate;
+
+import javax.servlet.ServletRequest;
+import javax.servlet.ServletResponse;
+import java.io.IOException;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+
+public class GoogleAccessTokenFilter extends AtlasAuthFilter {
+
+    private static final String VALIDATE_URL = "https://oauth2.googleapis.com/tokeninfo?access_token=%s";
+
+    private static final Logger logger = LoggerFactory.getLogger(GoogleAccessTokenFilter.class);
+
+    private RestTemplate restTemplate;
+
+    private ObjectMapper mapper = new ObjectMapper();
+
+    private PermissionManager authorizer;
+
+    private Set<String> defaultRoles;
+
+    public GoogleAccessTokenFilter(RestTemplate restTemplate,
+                                   PermissionManager authorizer,
+                                   Set<String> roles) {
+        this.restTemplate = restTemplate;
+        this.authorizer = authorizer;
+        this.defaultRoles = roles;
+    }
+
+    @Override
+    protected AuthenticationToken createToken(ServletRequest servletRequest, ServletResponse servletResponse) throws Exception {
+
+        String token = TokenManager.extractToken(servletRequest);
+        String userId = getTokenInfo(token);
+        return Optional.ofNullable(userId).map(JwtAuthToken::new)
+                .orElseThrow(AuthenticationException::new);
+    }
+
+    @Override
+    protected boolean onAccessDenied(ServletRequest servletRequest, ServletResponse servletResponse) throws Exception {
+
+        try {
+            if (TokenManager.extractToken(servletRequest) != null) {
+                boolean loggedIn = executeLogin(servletRequest, servletResponse);
+                if (loggedIn) {
+                    final PrincipalCollection principals = SecurityUtils.getSubject().getPrincipals();
+                    String name = (String) principals.getPrimaryPrincipal();
+                    this.authorizer.registerUser(name, name, defaultRoles);
+                }
+            }
+        } catch (AuthenticationException ignored) {
+        }
+        return true;
+    }
+
+    private String getTokenInfo(String token) throws IOException {
+
+        String result = null;
+        try {
+            ResponseEntity<String> response = restTemplate.getForEntity(String.format(VALIDATE_URL, token), String.class);
+            if (response.getStatusCode() == HttpStatus.OK) {
+                JsonNode root = mapper.readTree(response.getBody());
+                result = getValueAsString(root, "email");
+                if (Objects.isNull(result)) {
+                    result = getValueAsString(root, "aud");
+                }
+            }
+        } catch (HttpClientErrorException e) {
+            logger.warn("Access token is invalid {}", e.getMessage());
+        }
+        return result;
+    }
+
+    private String getValueAsString(JsonNode node, String property) {
+        JsonNode valueNode = node.get(property);
+        if (!valueNode.isNull()) {
+            return valueNode.textValue();
+        }
+        return null;
+    }
+}

--- a/src/main/java/org/ohdsi/webapi/shiro/filters/UpdateAccessTokenFilter.java
+++ b/src/main/java/org/ohdsi/webapi/shiro/filters/UpdateAccessTokenFilter.java
@@ -64,12 +64,7 @@ public class UpdateAccessTokenFilter extends AdviceFilter {
     final PrincipalCollection principals = SecurityUtils.getSubject().getPrincipals();
     Object principal = principals.getPrimaryPrincipal();
     
-    if (principal instanceof Principal) {
-      login = ((Principal) principal).getName();
-    } else if (principal instanceof UserPrincipal){
-      login = ((UserPrincipal) principal).getUsername();
-      name = ((UserPrincipal) principal).getName();
-    } else if (principal instanceof Pac4jPrincipal) {
+    if (principal instanceof Pac4jPrincipal) {
       login = ((Pac4jPrincipal)principal).getProfile().getEmail();
       name = ((Pac4jPrincipal)principal).getProfile().getDisplayName();
       
@@ -98,6 +93,11 @@ public class UpdateAccessTokenFilter extends AdviceFilter {
         httpResponse.sendRedirect(oauthFailURI.toString());
         return false;
       }
+    } else     if (principal instanceof Principal) {
+      login = ((Principal) principal).getName();
+    } else if (principal instanceof UserPrincipal){
+      login = ((UserPrincipal) principal).getUsername();
+      name = ((UserPrincipal) principal).getName();
     } else if (principal instanceof String) {
       login = (String)principal;
     } else {

--- a/src/main/java/org/ohdsi/webapi/shiro/filters/auth/SamlHandleFilter.java
+++ b/src/main/java/org/ohdsi/webapi/shiro/filters/auth/SamlHandleFilter.java
@@ -1,13 +1,11 @@
 package org.ohdsi.webapi.shiro.filters.auth;
 
 import org.apache.shiro.SecurityUtils;
-import org.apache.shiro.authc.AuthenticationException;
 import org.apache.shiro.authc.AuthenticationToken;
 import org.apache.shiro.web.servlet.ShiroHttpServletRequest;
 import org.ohdsi.webapi.shiro.filters.AtlasAuthFilter;
 import org.ohdsi.webapi.shiro.tokens.JwtAuthToken;
-import org.pac4j.core.context.J2EContext;
-import org.pac4j.core.exception.HttpAction;
+import org.pac4j.core.context.JEEContext;
 import org.pac4j.saml.client.SAML2Client;
 import org.pac4j.saml.credentials.SAML2Credentials;
 import org.pac4j.saml.profile.SAML2Profile;
@@ -41,20 +39,16 @@ public class SamlHandleFilter extends AtlasAuthFilter {
         AuthenticationToken token = null;
         if (request.getSession() != null) {
             if (!SecurityUtils.getSubject().isAuthenticated()) {
-                try {
-                    request.setAttribute(AUTH_CLIENT_ATTRIBUTE, AUTH_CLIENT_SAML);
+                request.setAttribute(AUTH_CLIENT_ATTRIBUTE, AUTH_CLIENT_SAML);
 
-                    HttpServletRequest httpRequest = (HttpServletRequest) servletRequest;
-                    HttpServletResponse httpResponse = (HttpServletResponse) servletResponse;
-                    J2EContext context = new J2EContext(httpRequest, httpResponse);
+                HttpServletRequest httpRequest = (HttpServletRequest) servletRequest;
+                HttpServletResponse httpResponse = (HttpServletResponse) servletResponse;
+                JEEContext context = new JEEContext(httpRequest, httpResponse);
 
-                    SAML2Credentials credentials = saml2Client.getCredentials(context);
-                    SAML2Profile samlProfile = saml2Client.getUserProfile(credentials, context);
+                SAML2Credentials credentials = saml2Client.getCredentials(context).get();
+                SAML2Profile samlProfile = (SAML2Profile)saml2Client.getUserProfile(credentials, context).get();
 
-                    token = new JwtAuthToken(samlProfile.getEmail());
-                } catch (HttpAction e) {
-                    throw new AuthenticationException(e);
-                }
+                token = new JwtAuthToken(samlProfile.getEmail());
             }
         }
         return token;

--- a/src/main/java/org/ohdsi/webapi/shiro/management/AtlasRegularSecurity.java
+++ b/src/main/java/org/ohdsi/webapi/shiro/management/AtlasRegularSecurity.java
@@ -34,7 +34,8 @@ import org.pac4j.cas.config.CasConfiguration;
 import org.pac4j.core.client.Client;
 import org.pac4j.core.client.Clients;
 import org.pac4j.core.config.Config;
-import org.pac4j.core.http.callback.PathParameterCallbackUrlResolver;
+import org.pac4j.core.http.callback.CallbackUrlResolver;
+import org.pac4j.core.http.callback.QueryParameterCallbackUrlResolver;
 import org.pac4j.oauth.client.FacebookClient;
 import org.pac4j.oauth.client.GitHubClient;
 import org.pac4j.oauth.client.Google2Client;
@@ -248,7 +249,10 @@ public class AtlasRegularSecurity extends AtlasSecurity {
 
         // OAuth
         //
+        CallbackUrlResolver urlResolver = new QueryParameterCallbackUrlResolver();
         Google2Client googleClient = new Google2Client(this.googleApiKey, this.googleApiSecret);
+        googleClient.setCallbackUrl(oauthApiCallback);
+        googleClient.setCallbackUrlResolver(urlResolver);
         googleClient.setScope(Google2Client.Google2Scope.EMAIL_AND_PROFILE);
 
         FacebookClient facebookClient = new FacebookClient(this.facebookApiKey, this.facebookApiSecret);
@@ -260,7 +264,8 @@ public class AtlasRegularSecurity extends AtlasSecurity {
 
         OidcConfiguration configuration = oidcConfCreator.build();
         OidcClient oidcClient = new OidcClient(configuration);
-        oidcClient.setCallbackUrlResolver(new PathParameterCallbackUrlResolver());
+        oidcClient.setCallbackUrl(oauthApiCallback);
+        oidcClient.setCallbackUrlResolver(urlResolver);
         List<Client> clients = new ArrayList<>(Arrays.asList(
                 googleClient,
                 facebookClient,

--- a/src/main/java/org/ohdsi/webapi/shiro/management/AtlasRegularSecurity.java
+++ b/src/main/java/org/ohdsi/webapi/shiro/management/AtlasRegularSecurity.java
@@ -37,8 +37,10 @@ import org.ohdsi.webapi.user.importer.providers.LdapProvider;
 import org.opensaml.saml.common.xml.SAMLConstants;
 import org.pac4j.cas.client.CasClient;
 import org.pac4j.cas.config.CasConfiguration;
+import org.pac4j.core.client.Client;
 import org.pac4j.core.client.Clients;
 import org.pac4j.core.config.Config;
+import org.pac4j.core.http.callback.PathParameterCallbackUrlResolver;
 import org.pac4j.core.io.Resource;
 import org.pac4j.core.util.CommonHelper;
 import org.pac4j.oauth.client.FacebookClient;
@@ -67,8 +69,7 @@ import javax.sql.DataSource;
 import java.io.UnsupportedEncodingException;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
-import java.util.Map;
-import java.util.Set;
+import java.util.*;
 
 import static com.odysseusinc.arachne.commons.utils.QuoteUtils.dequote;
 import static org.ohdsi.webapi.shiro.management.FilterTemplates.AD_FILTER;
@@ -271,15 +272,35 @@ public class AtlasRegularSecurity extends AtlasSecurity {
         filters.put(RUN_AS, new RunAsFilter(userRepository));
 
         // OAuth
+        //
+        Google2Client googleClient = new Google2Client(this.googleApiKey, this.googleApiSecret);
+        googleClient.setScope(Google2Client.Google2Scope.EMAIL_AND_PROFILE);
+
+        FacebookClient facebookClient = new FacebookClient(this.facebookApiKey, this.facebookApiSecret);
+        facebookClient.setScope("email");
+        facebookClient.setFields("email");
+
+        GitHubClient githubClient = new GitHubClient(this.githubApiKey, this.githubApiSecret);
+        githubClient.setScope("user:email");
+
+        OidcConfiguration configuration = oidcConfCreator.build();
+        OidcClient oidcClient = new OidcClient(configuration);
+        oidcClient.setCallbackUrlResolver(new PathParameterCallbackUrlResolver());
+        List<Client> clients = new ArrayList<>(Arrays.asList(
+                googleClient,
+                facebookClient,
+                githubClient
+                // ... put new clients here and then assign them to filters ...
+        ));
+        if (StringUtils.isNotBlank(configuration.getClientId())) {
+            clients.add(oidcClient);
+        }
+
         Config cfg =
                 new Config(
                         new Clients(
-                                this.oauthApiCallback
-                                , getGoogle2Client()
-                                , getFacebookClient()
-                                , getGitHubClient()
-                                , getOidcClient()
-                                // ... put new clients here and then assign them to filters ...
+                                this.oauthApiCallback,
+                                clients
                         )
                 );
 
@@ -480,7 +501,7 @@ public class AtlasRegularSecurity extends AtlasSecurity {
             casConf.setLoginUrl(casLoginUrlString);
 
             Cas20ServiceTicketValidator cas20Validator = new Cas20ServiceTicketValidator(casServerUrl);
-            casConf.setTicketValidator(cas20Validator);
+            casConf.setDefaultTicketValidator(cas20Validator);
 
             CasClient casClient = new CasClient(casConf);
             Config casCfg = new Config(new Clients(casCallbackUrl, casClient));

--- a/src/main/java/org/ohdsi/webapi/shiro/management/AtlasRegularSecurity.java
+++ b/src/main/java/org/ohdsi/webapi/shiro/management/AtlasRegularSecurity.java
@@ -35,15 +35,13 @@ import org.pac4j.core.client.Client;
 import org.pac4j.core.client.Clients;
 import org.pac4j.core.config.Config;
 import org.pac4j.core.http.callback.PathParameterCallbackUrlResolver;
-import org.pac4j.core.io.Resource;
-import org.pac4j.core.util.CommonHelper;
 import org.pac4j.oauth.client.FacebookClient;
 import org.pac4j.oauth.client.GitHubClient;
 import org.pac4j.oauth.client.Google2Client;
 import org.pac4j.oidc.client.OidcClient;
 import org.pac4j.oidc.config.OidcConfiguration;
 import org.pac4j.saml.client.SAML2Client;
-import org.pac4j.saml.client.SAML2ClientConfiguration;
+import org.pac4j.saml.config.SAML2Configuration;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -393,20 +391,16 @@ public class AtlasRegularSecurity extends AtlasSecurity {
 
     private void setUpSaml(Map<FilterTemplates, Filter> filters) {
       try {
-        Resource keystorePath = CommonHelper.getResource(keyStoreFile);
-        Resource metadataLocationPath = CommonHelper.getResource(metadataLocation);
-        final SAML2ClientConfiguration cfg = new SAML2ClientConfiguration(
-                keystorePath,
-                alias,
-                null,
+        final SAML2Configuration cfg = new SAML2Configuration(
+                keyStoreFile,
                 keyStorePassword,
                 privateKeyPassword,
-                metadataLocationPath);
+                metadataLocation);
         cfg.setMaximumAuthenticationLifetime(3600);
         cfg.setServiceProviderEntityId(identityProviderEntityId);
 
         cfg.setServiceProviderMetadataPath(spMetadataLocation);
-        cfg.setDestinationBindingType(SAMLConstants.SAML2_REDIRECT_BINDING_URI);
+        cfg.setAuthnRequestBindingType(SAMLConstants.SAML2_REDIRECT_BINDING_URI);
 
         final SAML2Client saml2Client = new SAML2Client(cfg);
         Config samlCfg = new Config(new Clients(samlCallbackUrl, saml2Client));

--- a/src/main/java/org/ohdsi/webapi/shiro/management/AtlasRegularSecurity.java
+++ b/src/main/java/org/ohdsi/webapi/shiro/management/AtlasRegularSecurity.java
@@ -12,14 +12,8 @@ import org.jasig.cas.client.validation.Cas20ServiceTicketValidator;
 import org.ohdsi.webapi.Constants;
 import org.ohdsi.webapi.security.model.EntityPermissionSchemaResolver;
 import org.ohdsi.webapi.shiro.Entities.UserRepository;
-import org.ohdsi.webapi.shiro.filters.CasHandleFilter;
-import org.ohdsi.webapi.shiro.filters.LogoutFilter;
-import org.ohdsi.webapi.shiro.filters.RedirectOnFailedOAuthFilter;
-import org.ohdsi.webapi.shiro.filters.RunAsFilter;
-import org.ohdsi.webapi.shiro.filters.SendTokenInHeaderFilter;
-import org.ohdsi.webapi.shiro.filters.SendTokenInRedirectFilter;
-import org.ohdsi.webapi.shiro.filters.SendTokenInUrlFilter;
-import org.ohdsi.webapi.shiro.filters.UpdateAccessTokenFilter;
+import org.ohdsi.webapi.shiro.PermissionManager;
+import org.ohdsi.webapi.shiro.filters.*;
 import org.ohdsi.webapi.shiro.filters.auth.ActiveDirectoryAuthFilter;
 import org.ohdsi.webapi.shiro.filters.auth.AtlasJwtAuthFilter;
 import org.ohdsi.webapi.shiro.filters.auth.JdbcAuthFilter;
@@ -60,6 +54,7 @@ import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.context.annotation.DependsOn;
 import org.springframework.ldap.core.LdapTemplate;
 import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestTemplate;
 import waffle.shiro.negotiate.NegotiateAuthenticationFilter;
 import waffle.shiro.negotiate.NegotiateAuthenticationRealm;
 
@@ -72,34 +67,7 @@ import java.nio.charset.StandardCharsets;
 import java.util.*;
 
 import static com.odysseusinc.arachne.commons.utils.QuoteUtils.dequote;
-import static org.ohdsi.webapi.shiro.management.FilterTemplates.AD_FILTER;
-import static org.ohdsi.webapi.shiro.management.FilterTemplates.AUTHZ;
-import static org.ohdsi.webapi.shiro.management.FilterTemplates.CAS_AUTHC;
-import static org.ohdsi.webapi.shiro.management.FilterTemplates.CORS;
-import static org.ohdsi.webapi.shiro.management.FilterTemplates.FACEBOOK_AUTHC;
-import static org.ohdsi.webapi.shiro.management.FilterTemplates.FORCE_SESSION_CREATION;
-import static org.ohdsi.webapi.shiro.management.FilterTemplates.GITHUB_AUTHC;
-import static org.ohdsi.webapi.shiro.management.FilterTemplates.GOOGLE_AUTHC;
-import static org.ohdsi.webapi.shiro.management.FilterTemplates.HANDLE_CAS;
-import static org.ohdsi.webapi.shiro.management.FilterTemplates.HANDLE_SAML;
-import static org.ohdsi.webapi.shiro.management.FilterTemplates.HANDLE_UNSUCCESSFUL_OAUTH;
-import static org.ohdsi.webapi.shiro.management.FilterTemplates.JDBC_FILTER;
-import static org.ohdsi.webapi.shiro.management.FilterTemplates.JWT_AUTHC;
-import static org.ohdsi.webapi.shiro.management.FilterTemplates.KERBEROS_FILTER;
-import static org.ohdsi.webapi.shiro.management.FilterTemplates.LDAP_FILTER;
-import static org.ohdsi.webapi.shiro.management.FilterTemplates.LOGOUT;
-import static org.ohdsi.webapi.shiro.management.FilterTemplates.NEGOTIATE_AUTHC;
-import static org.ohdsi.webapi.shiro.management.FilterTemplates.NO_CACHE;
-import static org.ohdsi.webapi.shiro.management.FilterTemplates.NO_SESSION_CREATION;
-import static org.ohdsi.webapi.shiro.management.FilterTemplates.OAUTH_CALLBACK;
-import static org.ohdsi.webapi.shiro.management.FilterTemplates.OIDC_AUTH;
-import static org.ohdsi.webapi.shiro.management.FilterTemplates.RUN_AS;
-import static org.ohdsi.webapi.shiro.management.FilterTemplates.SAML_AUTHC;
-import static org.ohdsi.webapi.shiro.management.FilterTemplates.SEND_TOKEN_IN_HEADER;
-import static org.ohdsi.webapi.shiro.management.FilterTemplates.SEND_TOKEN_IN_REDIRECT;
-import static org.ohdsi.webapi.shiro.management.FilterTemplates.SEND_TOKEN_IN_URL;
-import static org.ohdsi.webapi.shiro.management.FilterTemplates.SSL;
-import static org.ohdsi.webapi.shiro.management.FilterTemplates.UPDATE_TOKEN;
+import static org.ohdsi.webapi.shiro.management.FilterTemplates.*;
 
 @Component
 @ConditionalOnProperty(name = "security.provider", havingValue = Constants.SecurityProviders.REGULAR)
@@ -180,6 +148,9 @@ public class AtlasRegularSecurity extends AtlasSecurity {
     @Value("${security.ad.ignore.partial.result.exception}")
     private Boolean adIgnorePartialResultException;
 
+    @Value("${security.google.accessToken.enabled}")
+    private Boolean googleAccessTokenEnabled;
+
     @Value("${security.saml.keyManager.storePassword}")
     private String keyStorePassword;
 
@@ -241,6 +212,11 @@ public class AtlasRegularSecurity extends AtlasSecurity {
 
     @Value("${security.cas.casticket}")
     private String casticket;
+
+    private RestTemplate restTemplate = new RestTemplate();
+
+    @Autowired
+    private PermissionManager permissionManager;
     
     private boolean samlEnabled = false;
 
@@ -258,6 +234,7 @@ public class AtlasRegularSecurity extends AtlasSecurity {
         filters.put(UPDATE_TOKEN, new UpdateAccessTokenFilter(this.authorizer, this.defaultRoles, this.tokenExpirationIntervalInSeconds,
                 this.redirectUrl));
 
+        filters.put(ACCESS_AUTHC, new GoogleAccessTokenFilter(restTemplate, permissionManager, Collections.emptySet()));
         filters.put(JWT_AUTHC, new AtlasJwtAuthFilter());
         filters.put(JDBC_FILTER, new JdbcAuthFilter(eventPublisher));
         filters.put(KERBEROS_FILTER, new KerberosAuthFilter());
@@ -339,12 +316,14 @@ public class AtlasRegularSecurity extends AtlasSecurity {
     @Override
     protected FilterChainBuilder getFilterChainBuilder() {
 
+        List<FilterTemplates> authcFilters = googleAccessTokenEnabled ? Arrays.asList(ACCESS_AUTHC, JWT_AUTHC) :
+                Collections.singletonList(JWT_AUTHC);
         // the order does matter - first match wins
         FilterChainBuilder filterChainBuilder = new FilterChainBuilder()
                 .setBeforeOAuthFilters(SSL, CORS, FORCE_SESSION_CREATION)
                 .setAfterOAuthFilters(UPDATE_TOKEN, SEND_TOKEN_IN_URL)
                 .setRestFilters(SSL, NO_SESSION_CREATION, CORS, NO_CACHE)
-                .setAuthcFilter(JWT_AUTHC)
+                .setAuthcFilter(authcFilters.toArray(new FilterTemplates[0]))
                 .setAuthzFilter(AUTHZ)
                 // login/logout
                 .addRestPath("/user/login/openid", FORCE_SESSION_CREATION, OIDC_AUTH, UPDATE_TOKEN, SEND_TOKEN_IN_REDIRECT)

--- a/src/main/java/org/ohdsi/webapi/shiro/management/FilterTemplates.java
+++ b/src/main/java/org/ohdsi/webapi/shiro/management/FilterTemplates.java
@@ -7,6 +7,7 @@ public enum FilterTemplates {
     SEND_TOKEN_IN_REDIRECT("sendTokenInRedirect"),
 
     JWT_AUTHC("jwtAuthc"),
+    ACCESS_AUTHC("accessAuthc"),
     NEGOTIATE_AUTHC("negotiateAuthc"),
     GOOGLE_AUTHC("googleAuthc"),
     FACEBOOK_AUTHC("facebookAuthc"),

--- a/src/main/java/org/ohdsi/webapi/shiro/management/FilterTemplates.java
+++ b/src/main/java/org/ohdsi/webapi/shiro/management/FilterTemplates.java
@@ -45,4 +45,6 @@ public enum FilterTemplates {
     public String getTemplateName() {
         return templateName;
     }
+
+    public static final FilterTemplates[] OAUTH_CALLBACK_FILTERS = new FilterTemplates[]{ SSL, FORCE_SESSION_CREATION, HANDLE_UNSUCCESSFUL_OAUTH, OAUTH_CALLBACK };
 }

--- a/src/main/java/org/pac4j/oidc/profile/converter/OidcLongTimeConverter.java
+++ b/src/main/java/org/pac4j/oidc/profile/converter/OidcLongTimeConverter.java
@@ -19,13 +19,11 @@
 package org.pac4j.oidc.profile.converter;
 
 import org.pac4j.core.exception.TechnicalException;
-import org.pac4j.core.profile.FormattedDate;
 import org.pac4j.core.profile.converter.AttributeConverter;
 
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.util.Date;
-import java.util.Locale;
 
 
 public class OidcLongTimeConverter implements AttributeConverter<Date> {
@@ -34,18 +32,18 @@ public class OidcLongTimeConverter implements AttributeConverter<Date> {
 
     public Date convert(Object attribute) {
         if (attribute instanceof Long) {
-            long seconds = ((Long)attribute).longValue();
-            return new FormattedDate(new Date(seconds * 1000L), "yyyy-MM-dd'T'HH:mm:ss'z'", Locale.getDefault());
+            long milliseconds = (Long) attribute * 1000L;
+            return new Date(milliseconds);
         } else if (attribute instanceof String) {
             SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.sss'Z'");
 
             try {
-                return new FormattedDate(sdf.parse((String)attribute), "yyyy-MM-dd'T'HH:mm:ssz", Locale.getDefault());
+                return sdf.parse((String)attribute);
             } catch (ParseException var4) {
                 throw new TechnicalException(var4);
             }
         } else {
-            return attribute instanceof FormattedDate ? (Date)attribute : null;
+            return attribute instanceof Date ? (Date)attribute : null;
         }
     }
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -107,6 +107,7 @@ security.origin=${security.origin}
 security.ssl.enabled=${security.ssl.enabled}
 security.oauth.callback.ui=${security.oauth.callback.ui}
 security.oauth.callback.api=${security.oauth.callback.api}
+security.oauth.callback.urlResolver=${security.oauth.callback.urlResolver}
 security.oauth.google.apiKey=${security.oauth.google.apiKey}
 security.oauth.google.apiSecret=${security.oauth.google.apiSecret}
 security.oauth.facebook.apiKey=${security.oauth.facebook.apiKey}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -117,6 +117,7 @@ security.oid.clientId=${security.oid.clientId}
 security.oid.apiSecret=${security.oid.apiSecret}
 security.oid.url=${security.oid.url}
 security.oid.redirectUrl=${security.oid.redirectUrl}
+security.oid.logoutUrl=${security.oid.logoutUrl}
 security.db.datasource.driverClassName=${security.db.datasource.driverClassName}
 security.db.datasource.url=${security.db.datasource.url}
 security.db.datasource.username=${security.db.datasource.username}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -163,6 +163,7 @@ security.saml.sloUrl=${security.saml.sloUrl}
 
 security.googleIap.cloudProjectId=${security.googleIap.cloudProjectId}
 security.googleIap.backendServiceId=${security.googleIap.backendServiceId}
+security.google.accessToken.enabled=${security.google.accessToken.enabled}
 
 security.kerberos.spn=${security.kerberos.spn}
 security.kerberos.keytabPath=${security.kerberos.keytabPath}

--- a/src/main/resources/db/migration/oracle/V2.8.0.20200427161830__modify_user_login.sql
+++ b/src/main/resources/db/migration/oracle/V2.8.0.20200427161830__modify_user_login.sql
@@ -1,0 +1,5 @@
+ALTER TABLE ${ohdsiSchema}.sec_user DROP CONSTRAINT sec_user_login_unique;
+
+ALTER TABLE ${ohdsiSchema}.sec_user MODIFY(login VARCHAR(1024));
+
+ALTER TABLE ${ohdsiSchema}.sec_user ADD CONSTRAINT sec_user_login_unique UNIQUE (login);

--- a/src/main/resources/db/migration/postgresql/V2.8.0.20200427161830__modify_user_login.sql
+++ b/src/main/resources/db/migration/postgresql/V2.8.0.20200427161830__modify_user_login.sql
@@ -1,0 +1,5 @@
+ALTER TABLE ${ohdsiSchema}.sec_user DROP CONSTRAINT sec_user_login_unique;
+
+ALTER TABLE ${ohdsiSchema}.sec_user ALTER COLUMN login SET DATA TYPE VARCHAR;
+
+ALTER TABLE ${ohdsiSchema}.sec_user ADD CONSTRAINT sec_user_login_unique UNIQUE (login);

--- a/src/main/resources/db/migration/sqlserver/V2.8.0.20200427161830__modify_user_login.sql
+++ b/src/main/resources/db/migration/sqlserver/V2.8.0.20200427161830__modify_user_login.sql
@@ -1,0 +1,5 @@
+ALTER TABLE ${ohdsiSchema}.sec_user DROP CONSTRAINT sec_user_login_unique;
+
+ALTER TABLE ${ohdsiSchema}.sec_user ALTER COLUMN login VARCHAR(MAX);
+
+ALTER TABLE ${ohdsiSchema}.sec_user ADD CONSTRAINT sec_user_login_unique UNIQUE (login);

--- a/src/main/resources/log4j.xml
+++ b/src/main/resources/log4j.xml
@@ -20,6 +20,9 @@
 	<logger name="org.apache.shiro">
 		<level value="${logging.level.org.apache.shiro}" />
 	</logger>
+	<logger name="org.pac4j">
+		<level value="${logging.level.org.pac4j:INFO}" />
+	</logger>
 	<root>
 		<level value="${logging.level.root}" />
 		<appender-ref ref="stdout" />


### PR DESCRIPTION
This is an attempt to bring in pac4j changes from 2.7 into master.

There were several API changes and dependencies on JDK 11 that were needed to be resolved for use in 2.8.

I am unable to confirm oAuth or SAML authentications, so I will depend on the origional authors to verify these commits look correct.

Important note:  when adding the changes for the OidcConfiguration object, i noticed that there is no longer a `conf.setCallbackUrl(oauthApiCallback);` available on the configuration object.  I'm not sure if that needs to be specified elsewhere, but it leaves the application.properties value 'security.oauth.callback.api' unused.
