### PR TITLE
Include only necessary properties from git-commit-plugin.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -277,6 +277,12 @@
         </executions>
         <configuration>
           <generateGitPropertiesFile>false</generateGitPropertiesFile>
+          <!-- only include properties to speed up plugin -->
+          <!-- ref: https://github.com/git-commit-id/git-commit-id-maven-plugin/issues/462 -->
+          <includeOnlyProperties>    
+              <includeOnlyProperty>git.branch</includeOnlyProperty>
+              <includeOnlyProperty>git.commit.id.abbrev</includeOnlyProperty>
+          </includeOnlyProperties>          
         </configuration>
       </plugin>
       <plugin>


### PR DESCRIPTION
This PR amends PR #1453 by only including the git properties that are needed for the build.  The execution time for the plugin was exceeding 10 seconds in my enviornment, but limiting the properties  improves this 10-fold.  

Information found [here](https://github.com/git-commit-id/git-commit-id-maven-plugin/issues/462).