### PR TITLE
Update V2.8.0.20200427161830__modify_user_login.sql

### DIFF
--- a/src/main/resources/db/migration/postgresql/V2.8.0.20200427161830__modify_user_login.sql
+++ b/src/main/resources/db/migration/postgresql/V2.8.0.20200427161830__modify_user_login.sql
@@ -1,5 +1,5 @@
 ALTER TABLE ${ohdsiSchema}.sec_user DROP CONSTRAINT sec_user_login_unique;
 
-ALTER TABLE ${ohdsiSchema}.sec_user ALTER COLUMN login SET DATA TYPE VARCHAR;
+ALTER TABLE ${ohdsiSchema}.sec_user ALTER COLUMN login SET DATA TYPE VARCHAR(1024);
 
 ALTER TABLE ${ohdsiSchema}.sec_user ADD CONSTRAINT sec_user_login_unique UNIQUE (login);

--- a/src/main/resources/db/migration/sqlserver/V2.8.0.20200427161830__modify_user_login.sql
+++ b/src/main/resources/db/migration/sqlserver/V2.8.0.20200427161830__modify_user_login.sql
@@ -1,5 +1,5 @@
 ALTER TABLE ${ohdsiSchema}.sec_user DROP CONSTRAINT sec_user_login_unique;
 
-ALTER TABLE ${ohdsiSchema}.sec_user ALTER COLUMN login VARCHAR(MAX);
+ALTER TABLE ${ohdsiSchema}.sec_user ALTER COLUMN login VARCHAR(1024);
 
 ALTER TABLE ${ohdsiSchema}.sec_user ADD CONSTRAINT sec_user_login_unique UNIQUE (login);


### PR DESCRIPTION
This PR sets login to varchar(1024) on sql server to match oracle.

Postgresql is specifying a 'varchar' column type, but that should also probably be modified to be consistent.
