### PR TITLE
Role "atlas user" lacks rights to create incidence rates - revert gra…

### DIFF
--- a/src/main/resources/db/migration/oracle/V2.8.0.20190531181956__alter_job-execution-params_string-val.sql
+++ b/src/main/resources/db/migration/oracle/V2.8.0.20190531181956__alter_job-execution-params_string-val.sql
@@ -4,7 +4,7 @@ DROP VIEW ${ohdsiSchema}.pathway_analysis_generation;
 DROP VIEW ${ohdsiSchema}.prediction_analysis_generation;
 DROP VIEW ${ohdsiSchema}.user_import_job_history;
 
-ALTER TABLE ${ohdsiSchema}.user_import_job ADD (user_roles VARCHAR);
+ALTER TABLE ${ohdsiSchema}.user_import_job ADD (user_roles CLOB);
 
 CREATE OR REPLACE VIEW ${ohdsiSchema}.cc_generation as
   SELECT job.job_execution_id                                               id,

--- a/src/main/resources/db/migration/oracle/V2.8.0.20200409133802__add-ir-permission-to-atlas-user.sql
+++ b/src/main/resources/db/migration/oracle/V2.8.0.20200409133802__add-ir-permission-to-atlas-user.sql
@@ -1,4 +1,4 @@
 INSERT INTO ${ohdsiSchema}.sec_role_permission(id, role_id, permission_id)
   SELECT ${ohdsiSchema}.sec_role_permission_sequence.nextval, sr.id, sp.id
 FROM ${ohdsiSchema}.sec_permission SP, ${ohdsiSchema}.sec_role sr
-WHERE sp.value = 'ir:*:put' AND sr.name sr.name = 'Atlas users';
+WHERE sp.value = 'ir:*:put' AND sr.name = 'Atlas users';

--- a/src/main/resources/db/migration/oracle/V2.8.0.20200811155100__remove-ir-put-permission-from-atlas-user.sql
+++ b/src/main/resources/db/migration/oracle/V2.8.0.20200811155100__remove-ir-put-permission-from-atlas-user.sql
@@ -1,0 +1,4 @@
+DELETE FROM ${ohdsiSchema}.sec_role_permission srp WHERE
+        srp.permission_id in (SELECT id FROM ${ohdsiSchema}.sec_permission sp WHERE sp.value = 'ir:*:put')
+        AND
+        srp.role_id in (SELECT id FROM ${ohdsiSchema}.sec_role sr WHERE sr.name = 'Atlas users');

--- a/src/main/resources/db/migration/postgresql/V2.8.0.20200811155100__remove-ir-put-permission-from-atlas-user.sql
+++ b/src/main/resources/db/migration/postgresql/V2.8.0.20200811155100__remove-ir-put-permission-from-atlas-user.sql
@@ -1,0 +1,4 @@
+DELETE FROM ${ohdsiSchema}.sec_role_permission srp WHERE
+        srp.permission_id in (SELECT id FROM ${ohdsiSchema}.sec_permission sp WHERE sp.value = 'ir:*:put')
+        AND
+        srp.role_id in (SELECT id FROM ${ohdsiSchema}.sec_role sr WHERE sr.name = 'Atlas users');

--- a/src/main/resources/db/migration/sqlserver/V2.8.0.20200811155100__remove-ir-put-permission-from-atlas-user.sql
+++ b/src/main/resources/db/migration/sqlserver/V2.8.0.20200811155100__remove-ir-put-permission-from-atlas-user.sql
@@ -1,0 +1,4 @@
+DELETE FROM ${ohdsiSchema}.sec_role_permission srp WHERE
+        srp.permission_id in (SELECT id FROM ${ohdsiSchema}.sec_permission sp WHERE sp.value = 'ir:*:put')
+        AND
+        srp.role_id in (SELECT id FROM ${ohdsiSchema}.sec_role sr WHERE sr.name = 'Atlas users');

--- a/src/main/resources/db/migration/sqlserver/V2.8.0.20200811155100__remove-ir-put-permission-from-atlas-user.sql
+++ b/src/main/resources/db/migration/sqlserver/V2.8.0.20200811155100__remove-ir-put-permission-from-atlas-user.sql
@@ -1,4 +1,4 @@
-DELETE FROM ${ohdsiSchema}.sec_role_permission srp WHERE
-        srp.permission_id in (SELECT id FROM ${ohdsiSchema}.sec_permission sp WHERE sp.value = 'ir:*:put')
+DELETE FROM ${ohdsiSchema}.sec_role_permission WHERE
+        permission_id in (SELECT id FROM ${ohdsiSchema}.sec_permission sp WHERE sp.value = 'ir:*:put')
         AND
-        srp.role_id in (SELECT id FROM ${ohdsiSchema}.sec_role sr WHERE sr.name = 'Atlas users');
+        role_id in (SELECT id FROM ${ohdsiSchema}.sec_role sr WHERE sr.name = 'Atlas users');


### PR DESCRIPTION
Revert granting ir:*:put role to Atlas user (#1488). Create rights comes from ir:post permission. It was frontend problem - see PR OHDSI/Atlas#2275