### PR TITLE
Updates CohortCharacterization Skeleton version from 2.7.8

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -836,7 +836,7 @@
     <dependency>
       <groupId>org.ohdsi</groupId>
       <artifactId>SkeletonCohortCharacterization</artifactId>
-      <version>1.1.0-SNAPSHOT</version>
+      <version>1.1.0</version>
       <exclusions>
         <exclusion>
           <groupId>org.ohdsi</groupId>


### PR DESCRIPTION
fixes #1591 
2.7.8/update skeleton cc ver 

* version 2.7.8

* Updates SkeletonCohortCharacterization version

(cherry picked from commit 3627bcb)