### PR TITLE
Server-side rendering of cohort expressions.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -689,7 +689,6 @@
       <artifactId>waffle-shiro</artifactId>
       <version>2.2.1</version>
     </dependency>
-
     <dependency>
       <groupId>com.github.waffle</groupId>
       <artifactId>waffle-jna</artifactId>
@@ -922,6 +921,21 @@
       <groupId>com.qmino</groupId>
       <artifactId>miredot-annotations</artifactId>
       <version>1.5.0</version>
+    </dependency>
+    <dependency>
+      <groupId>com.atlassian.commonmark</groupId>
+      <artifactId>commonmark</artifactId>
+      <version>0.15.2</version>
+    </dependency>
+    <dependency>
+      <groupId>org.freemarker</groupId>
+      <artifactId>freemarker</artifactId>
+      <version>2.3.30</version>
+    </dependency>
+    <dependency>
+      <groupId>com.atlassian.commonmark</groupId>
+      <artifactId>commonmark-ext-gfm-tables</artifactId>
+      <version>0.15.2</version>
     </dependency>
     <dependency>
       <groupId>com.opentable.components</groupId>

--- a/src/main/java/org/ohdsi/webapi/service/CohortDefinitionService.java
+++ b/src/main/java/org/ohdsi/webapi/service/CohortDefinitionService.java
@@ -101,6 +101,7 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
+import javax.ws.rs.core.Response.ResponseBuilder;
 
 import static org.ohdsi.webapi.Constants.Params.COHORT_DEFINITION_ID;
 import static org.ohdsi.webapi.Constants.Params.JOB_NAME;
@@ -692,27 +693,43 @@ public class CohortDefinitionService extends AbstractDaoService {
 
 	@POST
 	@Path("/printfriendly/cohort")
-	@Produces(MediaType.TEXT_HTML)
 	@Consumes(MediaType.APPLICATION_JSON)
-	public String cohortPrintFriendly(CohortExpression expression) {
+	public Response cohortPrintFriendly(CohortExpression expression, @DefaultValue("html") @QueryParam("format") String format) {
 		String markdown = markdownPF.renderCohort(expression);
-		Parser parser = Parser.builder().extensions(extensions).build();
-		Node document = parser.parse(markdown);
-		HtmlRenderer renderer = HtmlRenderer.builder().extensions(extensions).build();
-		String html = renderer.render(document);
-		return html;
+		ResponseBuilder res;
+		if ("html".equalsIgnoreCase(format)) {
+			Parser parser = Parser.builder().extensions(extensions).build();
+			Node document = parser.parse(markdown);
+			HtmlRenderer renderer = HtmlRenderer.builder().extensions(extensions).build();
+			String html = renderer.render(document);
+			res = Response.ok(html, MediaType.TEXT_HTML);
+			
+		} else if ("markdown".equals(format)) {
+			res = Response.ok(markdown, MediaType.TEXT_PLAIN);
+		} else {
+			res = Response.status(Response.Status.UNSUPPORTED_MEDIA_TYPE);
+		}
+		return res.build();
 	}
 
 	@POST
 	@Path("/printfriendly/conceptsets")
-	@Produces(MediaType.TEXT_HTML)
 	@Consumes(MediaType.APPLICATION_JSON)
-	public String conceptSetListPrintFriendly(List<ConceptSet> conceptSetList) {
+	public Response conceptSetListPrintFriendly(List<ConceptSet> conceptSetList, @DefaultValue("html") @QueryParam("format") String format) {
 		String markdown = markdownPF.renderConceptSetList(conceptSetList.toArray(new ConceptSet[0]));
-		Parser parser = Parser.builder().extensions(extensions).build();
-		Node document = parser.parse(markdown);
-		HtmlRenderer renderer = HtmlRenderer.builder().extensions(extensions).build();
-		String html = renderer.render(document);
-		return html;
+		ResponseBuilder res;
+		if ("html".equalsIgnoreCase(format)) {
+			Parser parser = Parser.builder().extensions(extensions).build();
+			Node document = parser.parse(markdown);
+			HtmlRenderer renderer = HtmlRenderer.builder().extensions(extensions).build();
+			String html = renderer.render(document);
+			res = Response.ok(html, MediaType.TEXT_HTML);
+			
+		} else if ("markdown".equals(format)) {
+			res = Response.ok(markdown, MediaType.TEXT_PLAIN);
+		} else {
+			res = Response.status(Response.Status.UNSUPPORTED_MEDIA_TYPE);
+		}
+		return res.build();
 	}
 }

--- a/src/main/java/org/ohdsi/webapi/service/CohortDefinitionService.java
+++ b/src/main/java/org/ohdsi/webapi/service/CohortDefinitionService.java
@@ -696,20 +696,7 @@ public class CohortDefinitionService extends AbstractDaoService {
 	@Consumes(MediaType.APPLICATION_JSON)
 	public Response cohortPrintFriendly(CohortExpression expression, @DefaultValue("html") @QueryParam("format") String format) {
 		String markdown = markdownPF.renderCohort(expression);
-		ResponseBuilder res;
-		if ("html".equalsIgnoreCase(format)) {
-			Parser parser = Parser.builder().extensions(extensions).build();
-			Node document = parser.parse(markdown);
-			HtmlRenderer renderer = HtmlRenderer.builder().extensions(extensions).build();
-			String html = renderer.render(document);
-			res = Response.ok(html, MediaType.TEXT_HTML);
-			
-		} else if ("markdown".equals(format)) {
-			res = Response.ok(markdown, MediaType.TEXT_PLAIN);
-		} else {
-			res = Response.status(Response.Status.UNSUPPORTED_MEDIA_TYPE);
-		}
-		return res.build();
+		return printFrindly(markdown, format);
 	}
 
 	@POST
@@ -717,6 +704,11 @@ public class CohortDefinitionService extends AbstractDaoService {
 	@Consumes(MediaType.APPLICATION_JSON)
 	public Response conceptSetListPrintFriendly(List<ConceptSet> conceptSetList, @DefaultValue("html") @QueryParam("format") String format) {
 		String markdown = markdownPF.renderConceptSetList(conceptSetList.toArray(new ConceptSet[0]));
+		return printFrindly(markdown, format);
+	}
+
+	private Response printFrindly(String markdown, String format) {
+
 		ResponseBuilder res;
 		if ("html".equalsIgnoreCase(format)) {
 			Parser parser = Parser.builder().extensions(extensions).build();
@@ -724,7 +716,7 @@ public class CohortDefinitionService extends AbstractDaoService {
 			HtmlRenderer renderer = HtmlRenderer.builder().extensions(extensions).build();
 			String html = renderer.render(document);
 			res = Response.ok(html, MediaType.TEXT_HTML);
-			
+
 		} else if ("markdown".equals(format)) {
 			res = Response.ok(markdown, MediaType.TEXT_PLAIN);
 		} else {

--- a/src/main/java/org/ohdsi/webapi/service/CohortDefinitionService.java
+++ b/src/main/java/org/ohdsi/webapi/service/CohortDefinitionService.java
@@ -8,12 +8,17 @@ package org.ohdsi.webapi.service;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.commons.lang3.StringUtils;
-import org.apache.commons.lang3.tuple.ImmutablePair;
-import org.apache.commons.lang3.tuple.Pair;
+import org.commonmark.Extension;
+import org.commonmark.ext.gfm.tables.TablesExtension;
+import org.commonmark.node.*;
+import org.commonmark.parser.Parser;
+import org.commonmark.renderer.html.HtmlRenderer;
 import org.ohdsi.analysis.Utils;
 import org.ohdsi.circe.check.Checker;
 import org.ohdsi.circe.cohortdefinition.CohortExpression;
 import org.ohdsi.circe.cohortdefinition.CohortExpressionQueryBuilder;
+import org.ohdsi.circe.cohortdefinition.ConceptSet;
+import org.ohdsi.circe.cohortdefinition.printfriendly.MarkdownRender;
 import org.ohdsi.sql.SqlRender;
 import org.ohdsi.webapi.Constants;
 import org.ohdsi.webapi.cohortdefinition.CleanupCohortTasklet;
@@ -36,8 +41,6 @@ import org.ohdsi.webapi.job.JobExecutionResource;
 import org.ohdsi.webapi.job.JobTemplate;
 import org.ohdsi.webapi.service.dto.CheckResultDTO;
 import org.ohdsi.webapi.shiro.Entities.UserEntity;
-import org.ohdsi.webapi.shiro.Entities.UserRepository;
-import org.ohdsi.webapi.shiro.management.Security;
 import org.ohdsi.webapi.shiro.management.datasource.SourceIdAccessor;
 import org.ohdsi.webapi.source.Source;
 import org.ohdsi.webapi.source.SourceDaimon;
@@ -53,9 +56,7 @@ import org.springframework.batch.core.JobParametersBuilder;
 import org.springframework.batch.core.Step;
 import org.springframework.batch.core.configuration.annotation.JobBuilderFactory;
 import org.springframework.batch.core.configuration.annotation.StepBuilderFactory;
-import org.springframework.batch.core.explore.JobExplorer;
 import org.springframework.batch.core.job.builder.SimpleJobBuilder;
-import org.springframework.batch.core.launch.JobOperator;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.core.convert.ConversionService;
@@ -99,7 +100,6 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
-import java.util.UUID;
 import java.util.stream.Collectors;
 
 import static org.ohdsi.webapi.Constants.Params.COHORT_DEFINITION_ID;
@@ -116,582 +116,603 @@ import static org.ohdsi.webapi.util.SecurityUtils.whitelist;
 @Component
 public class CohortDefinitionService extends AbstractDaoService {
 
-  private static final CohortExpressionQueryBuilder queryBuilder = new CohortExpressionQueryBuilder();
+	private static final CohortExpressionQueryBuilder queryBuilder = new CohortExpressionQueryBuilder();
 
-  @Autowired
-  private CohortDefinitionRepository cohortDefinitionRepository;
+	@Autowired
+	private CohortDefinitionRepository cohortDefinitionRepository;
 
-  @Autowired
-  private JobBuilderFactory jobBuilders;
+	@Autowired
+	private JobBuilderFactory jobBuilders;
 
-  @Autowired
-  private StepBuilderFactory stepBuilders;
+	@Autowired
+	private StepBuilderFactory stepBuilders;
 
-  @Autowired
-  private JobTemplate jobTemplate;
+	@Autowired
+	private JobTemplate jobTemplate;
 
-  @Autowired
-  private JobExplorer jobExplorer;
+	@Autowired
+	private CohortGenerationService cohortGenerationService;
 
-  @Autowired
-  private JobOperator jobOperator;
+	@Autowired
+	private JobService jobService;
 
-  @Autowired
-  private UserRepository userRepository;
+	@Autowired
+	private CohortGenerationSensitiveInfoService sensitiveInfoService;
 
-  @Autowired
-  private CohortGenerationService cohortGenerationService;
+	@Autowired
+	private SourceIdAccessor sourceIdAccessor;
 
-  @Autowired
-  private JobService jobService;
+	@Autowired
+	ConversionService conversionService;
 
-  @Autowired
-  private CohortGenerationSensitiveInfoService sensitiveInfoService;
+	@Autowired
+	private ObjectMapper objectMapper;
 
-  @Autowired
-  private SourceIdAccessor sourceIdAccessor;
+	@Autowired
+	private ApplicationEventPublisher eventPublisher;
 
-  @Autowired
-  ConversionService conversionService;
+	@Autowired
+	private SourceService sourceService;
 
-  @Autowired
-  private ObjectMapper objectMapper;
+	@Autowired
+	private VocabularyService vocabularyService;
 
-  @Autowired
-  private ApplicationEventPublisher eventPublisher;
-  
-  @Autowired 
-  private SourceService sourceService;
+	@PersistenceContext
+	protected EntityManager entityManager;
 
-  @Autowired 
-  private VocabularyService vocabularyService;
+	private final MarkdownRender markdownPF = new MarkdownRender();
 
-  @PersistenceContext
-  protected EntityManager entityManager;
-	
-  private final RowMapper<InclusionRuleReport.Summary> summaryMapper = (rs, rowNum) -> {
-    InclusionRuleReport.Summary summary = new InclusionRuleReport.Summary();
-    summary.baseCount = rs.getLong("base_count");
-    summary.finalCount = rs.getLong("final_count");
-    summary.lostCount = rs.getLong("lost_count");
+	private final List<Extension> extensions = Arrays.asList(TablesExtension.create());
 
-    double matchRatio = (summary.baseCount > 0) ? ((double) summary.finalCount / (double) summary.baseCount) : 0.0;
-    summary.percentMatched = new BigDecimal(matchRatio * 100.0).setScale(2, RoundingMode.HALF_UP).toPlainString() + "%";
-    return summary;
-  };
+	private final RowMapper<InclusionRuleReport.Summary> summaryMapper = (rs, rowNum) -> {
+		InclusionRuleReport.Summary summary = new InclusionRuleReport.Summary();
+		summary.baseCount = rs.getLong("base_count");
+		summary.finalCount = rs.getLong("final_count");
+		summary.lostCount = rs.getLong("lost_count");
 
-  private final RowMapper<InclusionRuleReport.InclusionRuleStatistic> inclusionRuleStatisticMapper = new RowMapper<InclusionRuleReport.InclusionRuleStatistic>() {
+		double matchRatio = (summary.baseCount > 0) ? ((double) summary.finalCount / (double) summary.baseCount) : 0.0;
+		summary.percentMatched = new BigDecimal(matchRatio * 100.0).setScale(2, RoundingMode.HALF_UP).toPlainString() + "%";
+		return summary;
+	};
 
-    @Override
-    public InclusionRuleReport.InclusionRuleStatistic mapRow(ResultSet rs, int rowNum) throws SQLException {
-      InclusionRuleReport.InclusionRuleStatistic statistic = new InclusionRuleReport.InclusionRuleStatistic();
-      statistic.id = rs.getInt("rule_sequence");
-      statistic.name = rs.getString("name");
-      statistic.countSatisfying = rs.getLong("person_count");
-      long personTotal = rs.getLong("person_total");
+	private final RowMapper<InclusionRuleReport.InclusionRuleStatistic> inclusionRuleStatisticMapper = new RowMapper<InclusionRuleReport.InclusionRuleStatistic>() {
 
-      long gainCount = rs.getLong("gain_count");
-      double excludeRatio = personTotal > 0 ? (double) gainCount / (double) personTotal : 0.0;
-      String percentExcluded = new BigDecimal(excludeRatio * 100.0).setScale(2, RoundingMode.HALF_UP).toPlainString();
-      statistic.percentExcluded = percentExcluded + "%";
+		@Override
+		public InclusionRuleReport.InclusionRuleStatistic mapRow(ResultSet rs, int rowNum) throws SQLException {
+			InclusionRuleReport.InclusionRuleStatistic statistic = new InclusionRuleReport.InclusionRuleStatistic();
+			statistic.id = rs.getInt("rule_sequence");
+			statistic.name = rs.getString("name");
+			statistic.countSatisfying = rs.getLong("person_count");
+			long personTotal = rs.getLong("person_total");
 
-      long satisfyCount = rs.getLong("person_count");
-      double satisfyRatio = personTotal > 0 ? (double) satisfyCount / (double) personTotal : 0.0;
-      String percentSatisfying = new BigDecimal(satisfyRatio * 100.0).setScale(2, RoundingMode.HALF_UP).toPlainString();
-      statistic.percentSatisfying = percentSatisfying + "%";
-      return statistic;
-    }
-  };
-  
-  private final RowMapper<Long[]> inclusionRuleResultItemMapper = new RowMapper<Long[]>() {
+			long gainCount = rs.getLong("gain_count");
+			double excludeRatio = personTotal > 0 ? (double) gainCount / (double) personTotal : 0.0;
+			String percentExcluded = new BigDecimal(excludeRatio * 100.0).setScale(2, RoundingMode.HALF_UP).toPlainString();
+			statistic.percentExcluded = percentExcluded + "%";
 
-    @Override
-    public Long[] mapRow(ResultSet rs, int rowNum) throws SQLException {
-      Long[] resultItem = new Long[2];
-      resultItem[0] = rs.getLong("inclusion_rule_mask");
-      resultItem[1] = rs.getLong("person_count");
-      return resultItem;
-    }
-  };
+			long satisfyCount = rs.getLong("person_count");
+			double satisfyRatio = personTotal > 0 ? (double) satisfyCount / (double) personTotal : 0.0;
+			String percentSatisfying = new BigDecimal(satisfyRatio * 100.0).setScale(2, RoundingMode.HALF_UP).toPlainString();
+			statistic.percentSatisfying = percentSatisfying + "%";
+			return statistic;
+		}
+	};
 
-  private CohortGenerationInfo findBySourceId(Set<CohortGenerationInfo> infoList, Integer sourceId) {
-    for (CohortGenerationInfo info : infoList) {
-      if (info.getId().getSourceId().equals(sourceId)) {
-        return info;
-      }
-    }
-    return null;
-  }
-  
-  private InclusionRuleReport.Summary getInclusionRuleReportSummary(int id, Source source, int modeId) {
+	private final RowMapper<Long[]> inclusionRuleResultItemMapper = new RowMapper<Long[]>() {
 
-    String sql = "select cs.base_count, cs.final_count, cc.lost_count from @tableQualifier.cohort_summary_stats cs left join @tableQualifier.cohort_censor_stats cc " +
-            "on cc.cohort_definition_id = cs.cohort_definition_id where cs.cohort_definition_id = @id and cs.mode_id = @modeId";
-    String tqName = "tableQualifier";
-    String tqValue = source.getTableQualifier(SourceDaimon.DaimonType.Results);
+		@Override
+		public Long[] mapRow(ResultSet rs, int rowNum) throws SQLException {
+			Long[] resultItem = new Long[2];
+			resultItem[0] = rs.getLong("inclusion_rule_mask");
+			resultItem[1] = rs.getLong("person_count");
+			return resultItem;
+		}
+	};
+
+	private CohortGenerationInfo findBySourceId(Set<CohortGenerationInfo> infoList, Integer sourceId) {
+		for (CohortGenerationInfo info : infoList) {
+			if (info.getId().getSourceId().equals(sourceId)) {
+				return info;
+			}
+		}
+		return null;
+	}
+
+	private InclusionRuleReport.Summary getInclusionRuleReportSummary(int id, Source source, int modeId) {
+
+		String sql = "select cs.base_count, cs.final_count, cc.lost_count from @tableQualifier.cohort_summary_stats cs left join @tableQualifier.cohort_censor_stats cc "
+						+ "on cc.cohort_definition_id = cs.cohort_definition_id where cs.cohort_definition_id = @id and cs.mode_id = @modeId";
+		String tqName = "tableQualifier";
+		String tqValue = source.getTableQualifier(SourceDaimon.DaimonType.Results);
 		String[] varNames = {"id", "modeId"};
 		Object[] varValues = {whitelist(id), whitelist(modeId)};
-    PreparedStatementRenderer psr = new PreparedStatementRenderer(source, sql, tqName, tqValue, varNames, varValues , SessionUtils.sessionId());
-    List<InclusionRuleReport.Summary> result = getSourceJdbcTemplate(source).query(psr.getSql(), psr.getSetter(), summaryMapper);
-    return result.isEmpty()? new InclusionRuleReport.Summary() : result.get(0);
-  }
+		PreparedStatementRenderer psr = new PreparedStatementRenderer(source, sql, tqName, tqValue, varNames, varValues, SessionUtils.sessionId());
+		List<InclusionRuleReport.Summary> result = getSourceJdbcTemplate(source).query(psr.getSql(), psr.getSetter(), summaryMapper);
+		return result.isEmpty() ? new InclusionRuleReport.Summary() : result.get(0);
+	}
 
-  private List<InclusionRuleReport.InclusionRuleStatistic> getInclusionRuleStatistics(int id, Source source, int modeId) {
+	private List<InclusionRuleReport.InclusionRuleStatistic> getInclusionRuleStatistics(int id, Source source, int modeId) {
 
-    String sql = "select i.rule_sequence, i.name, s.person_count, s.gain_count, s.person_total"
-      + " from @tableQualifier.cohort_inclusion i join @tableQualifier.cohort_inclusion_stats s on i.cohort_definition_id = s.cohort_definition_id"
-      + " and i.rule_sequence = s.rule_sequence"
-      + " where i.cohort_definition_id = @id and mode_id = @modeId ORDER BY i.rule_sequence";
-    String tqName = "tableQualifier";
-    String tqValue = source.getTableQualifier(SourceDaimon.DaimonType.Results);
+		String sql = "select i.rule_sequence, i.name, s.person_count, s.gain_count, s.person_total"
+						+ " from @tableQualifier.cohort_inclusion i join @tableQualifier.cohort_inclusion_stats s on i.cohort_definition_id = s.cohort_definition_id"
+						+ " and i.rule_sequence = s.rule_sequence"
+						+ " where i.cohort_definition_id = @id and mode_id = @modeId ORDER BY i.rule_sequence";
+		String tqName = "tableQualifier";
+		String tqValue = source.getTableQualifier(SourceDaimon.DaimonType.Results);
 		String[] varNames = {"id", "modeId"};
-		Object[] varValues = {whitelist(id), whitelist(modeId)};		
-    PreparedStatementRenderer psr = new PreparedStatementRenderer(source, sql, tqName, tqValue, varNames, varValues, SessionUtils.sessionId());
-    return getSourceJdbcTemplate(source).query(psr.getSql(), psr.getSetter(), inclusionRuleStatisticMapper);
-  }
-  
-  private int countSetBits(long n) {
-    int count = 0;
-    while (n > 0) {
-      n &= (n - 1);
-      count++;
-    }
-    return count;
-  }
-  
-  private String formatBitMask(Long n, int size) {
-    return StringUtils.reverse(StringUtils.leftPad(Long.toBinaryString(n), size, "0"));
-  }  
-  
-  private String getInclusionRuleTreemapData(int id, int inclusionRuleCount, Source source, int modeId) {
+		Object[] varValues = {whitelist(id), whitelist(modeId)};
+		PreparedStatementRenderer psr = new PreparedStatementRenderer(source, sql, tqName, tqValue, varNames, varValues, SessionUtils.sessionId());
+		return getSourceJdbcTemplate(source).query(psr.getSql(), psr.getSetter(), inclusionRuleStatisticMapper);
+	}
 
-    String sql = "select inclusion_rule_mask, person_count from @tableQualifier.cohort_inclusion_result where cohort_definition_id = @id and mode_id = @modeId";
-    String tqName = "tableQualifier";
-    String tqValue = source.getTableQualifier(SourceDaimon.DaimonType.Results);
+	private int countSetBits(long n) {
+		int count = 0;
+		while (n > 0) {
+			n &= (n - 1);
+			count++;
+		}
+		return count;
+	}
+
+	private String formatBitMask(Long n, int size) {
+		return StringUtils.reverse(StringUtils.leftPad(Long.toBinaryString(n), size, "0"));
+	}
+
+	private String getInclusionRuleTreemapData(int id, int inclusionRuleCount, Source source, int modeId) {
+
+		String sql = "select inclusion_rule_mask, person_count from @tableQualifier.cohort_inclusion_result where cohort_definition_id = @id and mode_id = @modeId";
+		String tqName = "tableQualifier";
+		String tqValue = source.getTableQualifier(SourceDaimon.DaimonType.Results);
 		String[] varNames = {"id", "modeId"};
-		Object[] varValues = {whitelist(id), whitelist(modeId)};		
-    PreparedStatementRenderer psr = new PreparedStatementRenderer(source, sql, tqName, tqValue, varNames, varValues, SessionUtils.sessionId());
+		Object[] varValues = {whitelist(id), whitelist(modeId)};
+		PreparedStatementRenderer psr = new PreparedStatementRenderer(source, sql, tqName, tqValue, varNames, varValues, SessionUtils.sessionId());
 
-    // [0] is the inclusion rule bitmask, [1] is the count of the match
-    List<Long[]> items = this.getSourceJdbcTemplate(source).query(psr.getSql(), psr.getSetter(), inclusionRuleResultItemMapper);
-    Map<Integer, List<Long[]>> groups = new HashMap<>();
-    for (Long[] item : items) {
-      int bitsSet = countSetBits(item[0]);
-      if (!groups.containsKey(bitsSet)) {
-        groups.put(bitsSet, new ArrayList<Long[]>());
-      }
-      groups.get(bitsSet).add(item);
-    }
+		// [0] is the inclusion rule bitmask, [1] is the count of the match
+		List<Long[]> items = this.getSourceJdbcTemplate(source).query(psr.getSql(), psr.getSetter(), inclusionRuleResultItemMapper);
+		Map<Integer, List<Long[]>> groups = new HashMap<>();
+		for (Long[] item : items) {
+			int bitsSet = countSetBits(item[0]);
+			if (!groups.containsKey(bitsSet)) {
+				groups.put(bitsSet, new ArrayList<Long[]>());
+			}
+			groups.get(bitsSet).add(item);
+		}
 
-    StringBuilder treemapData = new StringBuilder("{\"name\" : \"Everyone\", \"children\" : [");
+		StringBuilder treemapData = new StringBuilder("{\"name\" : \"Everyone\", \"children\" : [");
 
-    List<Integer> groupKeys = new ArrayList<>(groups.keySet());
-    Collections.sort(groupKeys);
-    Collections.reverse(groupKeys);
+		List<Integer> groupKeys = new ArrayList<>(groups.keySet());
+		Collections.sort(groupKeys);
+		Collections.reverse(groupKeys);
 
-    int groupCount = 0;
-    // create a nested treemap data where more matches (more bits set in string) appear higher in the hierarchy)
-    for (Integer groupKey : groupKeys) {
-      if (groupCount > 0) {
-        treemapData.append(",");
-      }
+		int groupCount = 0;
+		// create a nested treemap data where more matches (more bits set in string) appear higher in the hierarchy)
+		for (Integer groupKey : groupKeys) {
+			if (groupCount > 0) {
+				treemapData.append(",");
+			}
 
-      treemapData.append(String.format("{\"name\" : \"Group %d\", \"children\" : [", groupKey));
+			treemapData.append(String.format("{\"name\" : \"Group %d\", \"children\" : [", groupKey));
 
-      int groupItemCount = 0;
-      for (Long[] groupItem : groups.get(groupKey)) {
-        if (groupItemCount > 0) {
-          treemapData.append(",");
-        }
+			int groupItemCount = 0;
+			for (Long[] groupItem : groups.get(groupKey)) {
+				if (groupItemCount > 0) {
+					treemapData.append(",");
+				}
 
-        //sb_treemap.Append("{\"name\": \"" + cohort_identifer + "\", \"size\": " + cohorts[cohort_identifer].ToString() + "}");
-        treemapData.append(String.format("{\"name\": \"%s\", \"size\": %d}", formatBitMask(groupItem[0], inclusionRuleCount), groupItem[1]));
-        groupItemCount++;
-      }
-      groupCount++;
-    }
+				//sb_treemap.Append("{\"name\": \"" + cohort_identifer + "\", \"size\": " + cohorts[cohort_identifer].ToString() + "}");
+				treemapData.append(String.format("{\"name\": \"%s\", \"size\": %d}", formatBitMask(groupItem[0], inclusionRuleCount), groupItem[1]));
+				groupItemCount++;
+			}
+			groupCount++;
+		}
 
-    treemapData.append(StringUtils.repeat("]}", groupCount + 1));
+		treemapData.append(StringUtils.repeat("]}", groupCount + 1));
 
-    return treemapData.toString();
-  }
+		return treemapData.toString();
+	}
 
-  public static class GenerateSqlRequest {
+	public static class GenerateSqlRequest {
 
-    public GenerateSqlRequest() {
-    }
+		public GenerateSqlRequest() {
+		}
 
-    @JsonProperty("expression")
-    public CohortExpression expression;
+		@JsonProperty("expression")
+		public CohortExpression expression;
 
-    @JsonProperty("options")
-    public CohortExpressionQueryBuilder.BuildExpressionQueryOptions options;
+		@JsonProperty("options")
+		public CohortExpressionQueryBuilder.BuildExpressionQueryOptions options;
 
-  }
-  @Context
-  ServletContext context;
+	}
+	@Context
+	ServletContext context;
 
-  @Path("sql")
-  @POST
-  @Produces(MediaType.APPLICATION_JSON)
-  @Consumes(MediaType.APPLICATION_JSON)
-  public GenerateSqlResult generateSql(GenerateSqlRequest request) {
-    CohortExpressionQueryBuilder.BuildExpressionQueryOptions options = request.options;
-    GenerateSqlResult result = new GenerateSqlResult();
-    if (options == null)
-    {
-      options = new CohortExpressionQueryBuilder.BuildExpressionQueryOptions();
-    }
-    String expressionSql = queryBuilder.buildExpressionQuery(request.expression, options);
-    result.templateSql = SqlRender.renderSql(expressionSql, null, null);
+	@Path("sql")
+	@POST
+	@Produces(MediaType.APPLICATION_JSON)
+	@Consumes(MediaType.APPLICATION_JSON)
+	public GenerateSqlResult generateSql(GenerateSqlRequest request) {
+		CohortExpressionQueryBuilder.BuildExpressionQueryOptions options = request.options;
+		GenerateSqlResult result = new GenerateSqlResult();
+		if (options == null) {
+			options = new CohortExpressionQueryBuilder.BuildExpressionQueryOptions();
+		}
+		String expressionSql = queryBuilder.buildExpressionQuery(request.expression, options);
+		result.templateSql = SqlRender.renderSql(expressionSql, null, null);
 
-    return result;
-  }
-
-  /**
-   * Returns all cohort definitions in the cohort schema
-   *
-   * @return List of cohort_definition
-   */
-  @GET
-  @Path("/")
-  @Produces(MediaType.APPLICATION_JSON)
-  @Transactional
-  public List<CohortMetadataDTO> getCohortDefinitionList() {
-
-    List<CohortDefinition> definitions = cohortDefinitionRepository.list();
-
-    return definitions.stream()
-            .map(def -> conversionService.convert(def, CohortMetadataDTO.class))
-            .collect(Collectors.toList());
-  }
-
-  /**
-   * Creates the cohort definition
-   *
-   * @param dto The cohort definition to create.
-   * @return The new CohortDefinition
-   */
-  @POST
-  @Path("/")
-  @Transactional
-  @Produces(MediaType.APPLICATION_JSON)
-  @Consumes(MediaType.APPLICATION_JSON)
-  public CohortDTO createCohortDefinition(CohortDTO dto) {
-    
-      Date currentTime = Calendar.getInstance().getTime();
-
-      UserEntity user = userRepository.findByLogin(security.getSubject());
-      //create definition in 2 saves, first to get the generated ID for the new dto
-      // then to associate the details with the definition
-      CohortDefinition newDef = new CohortDefinition();
-      newDef.setName(StringUtils.trim(dto.getName()))
-              .setDescription(dto.getDescription())
-              .setExpressionType(dto.getExpressionType());
-      newDef.setCreatedBy(user);
-      newDef.setCreatedDate(currentTime);
-
-      newDef = this.cohortDefinitionRepository.save(newDef);
-
-      // associate details
-      CohortDefinitionDetails details = new CohortDefinitionDetails();
-      details.setCohortDefinition(newDef)
-              .setExpression(Utils.serialize(dto.getExpression()));
-
-      newDef.setDetails(details);
-
-      CohortDefinition createdDefinition = this.cohortDefinitionRepository.save(newDef);      
-      return conversionService.convert(createdDefinition, CohortDTO.class);
-  }
-
-  /**
-   * Returns the cohort definition for the given id
-   *
-   * @param id The cohort definition id
-   * @return The CohortDefinition
-   */
-  @GET
-  @Path("/{id}")
-  @Produces(MediaType.APPLICATION_JSON)
-  public CohortRawDTO getCohortDefinitionRaw(@PathParam("id") final int id) {
-
-    return getTransactionTemplate().execute(transactionStatus -> {
-      CohortDefinition d = this.cohortDefinitionRepository.findOneWithDetail(id);
-      ExceptionUtils.throwNotFoundExceptionIfNull(d, String.format("There is no cohort definition with id = %d.", id));
-      return conversionService.convert(d, CohortRawDTO.class);
-    });
-  }
+		return result;
+	}
 
 	/**
-	 * This method returns the cohort definition containg the circe cohort expression
-	 * @param id
-	 * @return 
+	 * Returns all cohort definitions in the cohort schema
+	 *
+	 * @return List of cohort_definition
 	 */
-  public CohortDTO getCohortDefinition( final int id) {
+	@GET
+	@Path("/")
+	@Produces(MediaType.APPLICATION_JSON)
+	@Transactional
+	public List<CohortMetadataDTO> getCohortDefinitionList() {
 
-    return getTransactionTemplate().execute(transactionStatus -> {
-      CohortDefinition d = this.cohortDefinitionRepository.findOneWithDetail(id);
-      ExceptionUtils.throwNotFoundExceptionIfNull(d, String.format("There is no cohort definition with id = %d.", id));
-      return conversionService.convert(d, CohortDTO.class);
-    });
-  }
-	
-  @GET
-  @Path("/{id}/exists")
-  @Produces(MediaType.APPLICATION_JSON)
-  public int getCountCDefWithSameName(@PathParam("id") @DefaultValue("0") final int id, @QueryParam("name") String name) {
+		List<CohortDefinition> definitions = cohortDefinitionRepository.list();
 
-    return cohortDefinitionRepository.getCountCDefWithSameName(id, name);
-  }
+		return definitions.stream()
+						.map(def -> conversionService.convert(def, CohortMetadataDTO.class))
+						.collect(Collectors.toList());
+	}
 
-  /**
-   * Saves the cohort definition for the given id
-   *
-   * @param id The cohort definition id
-   * @return The CohortDefinition
-   */
-  @PUT
-  @Path("/{id}")
-  @Produces(MediaType.APPLICATION_JSON)
-  @Consumes(MediaType.APPLICATION_JSON)
-  public CohortDTO saveCohortDefinition(@PathParam("id") final int id, CohortDTO def) {
-    Date currentTime = Calendar.getInstance().getTime();
+	/**
+	 * Creates the cohort definition
+	 *
+	 * @param dto The cohort definition to create.
+	 * @return The new CohortDefinition
+	 */
+	@POST
+	@Path("/")
+	@Transactional
+	@Produces(MediaType.APPLICATION_JSON)
+	@Consumes(MediaType.APPLICATION_JSON)
+	public CohortDTO createCohortDefinition(CohortDTO dto) {
 
-    CohortDefinition currentDefinition = this.cohortDefinitionRepository.findOneWithDetail(id);
-    UserEntity modifier = userRepository.findByLogin(security.getSubject());
+		Date currentTime = Calendar.getInstance().getTime();
 
-    currentDefinition.setName(def.getName())
-            .setDescription(def.getDescription())
-            .setExpressionType(def.getExpressionType())
-            .getDetails().setExpression(Utils.serialize(def.getExpression()));
-    currentDefinition.setModifiedBy(modifier);
-    currentDefinition.setModifiedDate(currentTime);
+		UserEntity user = userRepository.findByLogin(security.getSubject());
+		//create definition in 2 saves, first to get the generated ID for the new dto
+		// then to associate the details with the definition
+		CohortDefinition newDef = new CohortDefinition();
+		newDef.setName(StringUtils.trim(dto.getName()))
+						.setDescription(dto.getDescription())
+						.setExpressionType(dto.getExpressionType());
+		newDef.setCreatedBy(user);
+		newDef.setCreatedDate(currentTime);
 
-    currentDefinition = this.cohortDefinitionRepository.save(currentDefinition);
-    eventPublisher.publishEvent(new CohortDefinitionChangedEvent(currentDefinition));
-    return getCohortDefinition(id);
-  }
+		newDef = this.cohortDefinitionRepository.save(newDef);
 
-  /**
-   * Queues up a generate cohort task for the specified cohort definition id.
-   *
-   * @param id - the Cohort Definition ID to generate
-   * @return information about the Cohort Analysis Job
-   */
-  @GET
-  @Produces(MediaType.APPLICATION_JSON)
-  @Path("/{id}/generate/{sourceKey}")
-  @Transactional
-  public JobExecutionResource generateCohort(@PathParam("id") final int id, @PathParam("sourceKey") final String sourceKey) {
+		// associate details
+		CohortDefinitionDetails details = new CohortDefinitionDetails();
+		details.setCohortDefinition(newDef)
+						.setExpression(Utils.serialize(dto.getExpression()));
 
-    Source source = getSourceRepository().findBySourceKey(sourceKey);
-    CohortDefinition currentDefinition = this.cohortDefinitionRepository.findOne(id);
-    UserEntity user = userRepository.findByLogin(security.getSubject());
-    return cohortGenerationService.generateCohortViaJob(user, currentDefinition, source);
-  }
+		newDef.setDetails(details);
 
-  @GET
-  @Produces(MediaType.APPLICATION_JSON)
-  @Path("/{id}/cancel/{sourceKey}")
-  public Response cancelGenerateCohort(@PathParam("id") final int id, @PathParam("sourceKey") final String sourceKey) {
+		CohortDefinition createdDefinition = this.cohortDefinitionRepository.save(newDef);
+		return conversionService.convert(createdDefinition, CohortDTO.class);
+	}
 
-    final Source source = Optional.ofNullable(getSourceRepository().findBySourceKey(sourceKey))
-            .orElseThrow(NotFoundException::new);
-    getTransactionTemplateRequiresNew().execute(status -> {
-      CohortDefinition currentDefinition = cohortDefinitionRepository.findOne(id);
-      if (Objects.nonNull(currentDefinition)) {
-        CohortGenerationInfo info = findBySourceId(currentDefinition.getGenerationInfoList(), source.getSourceId());
-        if (Objects.nonNull(info)) {
-          invalidateExecution(info);
-          cohortDefinitionRepository.save(currentDefinition);
-        }
-      }
-      return null;
-    });
+	/**
+	 * Returns the cohort definition for the given id
+	 *
+	 * @param id The cohort definition id
+	 * @return The CohortDefinition
+	 */
+	@GET
+	@Path("/{id}")
+	@Produces(MediaType.APPLICATION_JSON)
+	public CohortRawDTO getCohortDefinitionRaw(@PathParam("id") final int id) {
 
-      jobService.cancelJobExecution(e -> {
-          JobParameters parameters = e.getJobParameters();
-          String jobName = e.getJobInstance().getJobName();
-          return Objects.equals(parameters.getString(COHORT_DEFINITION_ID), Integer.toString(id))
-                  && Objects.equals(parameters.getString(SOURCE_ID), Integer.toString(source.getSourceId()))
-                  && Objects.equals(Constants.GENERATE_COHORT, jobName);
-      });
-    return Response.status(Response.Status.OK).build();
-  }
+		return getTransactionTemplate().execute(transactionStatus -> {
+			CohortDefinition d = this.cohortDefinitionRepository.findOneWithDetail(id);
+			ExceptionUtils.throwNotFoundExceptionIfNull(d, String.format("There is no cohort definition with id = %d.", id));
+			return conversionService.convert(d, CohortRawDTO.class);
+		});
+	}
 
-  /**
-   * Queues up a generate cohort task for the specified cohort definition id.
-   *
-   * @param id - the Cohort Definition ID to generate
-   * @return information about the Cohort Analysis Job
-   * @throws Exception
-   */
-  @GET
-  @Produces(MediaType.APPLICATION_JSON)
-  @Path("/{id}/info")
-  @Transactional
-  public List<CohortGenerationInfoDTO> getInfo(@PathParam("id") final int id) {
-    CohortDefinition def = this.cohortDefinitionRepository.findOne(id);
-    if (Objects.isNull(def)) {
-      throw new IllegalArgumentException(String.format("There is no cohort definition with id = %d.", id));
-    }
-    Set<CohortGenerationInfo> infoList = def.getGenerationInfoList();
+	/**
+	 * This method returns the cohort definition containg the circe cohort
+	 * expression
+	 *
+	 * @param id
+	 * @return
+	 */
+	public CohortDTO getCohortDefinition(final int id) {
 
-    List<CohortGenerationInfo> result = infoList.stream().filter(genInfo -> sourceIdAccessor.hasAccess(genInfo.getId().getSourceId())).collect(Collectors.toList());
+		return getTransactionTemplate().execute(transactionStatus -> {
+			CohortDefinition d = this.cohortDefinitionRepository.findOneWithDetail(id);
+			ExceptionUtils.throwNotFoundExceptionIfNull(d, String.format("There is no cohort definition with id = %d.", id));
+			return conversionService.convert(d, CohortDTO.class);
+		});
+	}
 
-    Map<Integer, Source> sourceMap = sourceService.getSourcesMap(SourceMapKey.BY_SOURCE_ID);
-    List<CohortGenerationInfo> filteredResult = sensitiveInfoService.filterSensitiveInfo(result,
-            gi -> Collections.singletonMap(Constants.Variables.SOURCE, sourceMap.get(gi.getId().getSourceId())));
-    return filteredResult.stream()
-            .map(t -> conversionService.convert(t, CohortGenerationInfoDTO.class))
-            .collect(Collectors.toList());
-  }
+	@GET
+	@Path("/{id}/exists")
+	@Produces(MediaType.APPLICATION_JSON)
+	public int getCountCDefWithSameName(@PathParam("id") @DefaultValue("0") final int id, @QueryParam("name") String name) {
 
-  /**
-   * Copies the specified cohort definition
-   * 
-   * @param id - the Cohort Definition ID to copy
-   * @return the copied cohort definition as a CohortDTO
-   */
-  @GET
-  @Produces(MediaType.APPLICATION_JSON)
-  @Path("/{id}/copy")
-  @Transactional
-  public CohortDTO copy(@PathParam("id") final int id) {
-    CohortDTO sourceDef = getCohortDefinition(id);
-    sourceDef.setId(null); // clear the ID
-    sourceDef.setName(NameUtils.getNameForCopy(sourceDef.getName(), this::getNamesLike, cohortDefinitionRepository.findByName(sourceDef.getName())));
-    CohortDTO copyDef = createCohortDefinition(sourceDef);
+		return cohortDefinitionRepository.getCountCDefWithSameName(id, name);
+	}
 
-    return copyDef;
-  }
-  
-  public List<String> getNamesLike(String copyName) {
+	/**
+	 * Saves the cohort definition for the given id
+	 *
+	 * @param id The cohort definition id
+	 * @return The CohortDefinition
+	 */
+	@PUT
+	@Path("/{id}")
+	@Produces(MediaType.APPLICATION_JSON)
+	@Consumes(MediaType.APPLICATION_JSON)
+	public CohortDTO saveCohortDefinition(@PathParam("id") final int id, CohortDTO def) {
+		Date currentTime = Calendar.getInstance().getTime();
 
-    return cohortDefinitionRepository.findAllByNameStartsWith(copyName).stream().map(CohortDefinition::getName).collect(Collectors.toList());
-  }
+		CohortDefinition currentDefinition = this.cohortDefinitionRepository.findOneWithDetail(id);
+		UserEntity modifier = userRepository.findByLogin(security.getSubject());
 
-  /**
-   * Deletes the specified cohort definition
-   * 
-   * @param id - the Cohort Definition ID to copy
-   */
-  @DELETE
-  @Produces(MediaType.APPLICATION_JSON)
-  @Path("/{id}")
-  public void delete(@PathParam("id") final int id) {
-    // perform the JPA update in a separate transaction
-    this.getTransactionTemplateRequiresNew().execute(new TransactionCallbackWithoutResult() {
-        @Override
-        public void doInTransactionWithoutResult(final TransactionStatus status) {
-            CohortDefinition def = cohortDefinitionRepository.findOne(id);
-            if (!Objects.isNull(def)) {
-                def.getGenerationInfoList().forEach(cohortGenerationInfo -> {
-                    Integer sourceId = cohortGenerationInfo.getId().getSourceId();
+		currentDefinition.setName(def.getName())
+						.setDescription(def.getDescription())
+						.setExpressionType(def.getExpressionType())
+						.getDetails().setExpression(Utils.serialize(def.getExpression()));
+		currentDefinition.setModifiedBy(modifier);
+		currentDefinition.setModifiedDate(currentTime);
 
-                    jobService.cancelJobExecution(e -> {
-                        JobParameters parameters = e.getJobParameters();
-                        String jobName = e.getJobInstance().getJobName();
-                        return Objects.equals(parameters.getString(COHORT_DEFINITION_ID), Integer.toString(id))
-                                && Objects.equals(parameters.getString(SOURCE_ID), Integer.toString(sourceId))
-                                && Objects.equals(Constants.GENERATE_COHORT, jobName);
-                    });
-                });
-                cohortDefinitionRepository.delete(def);
-            } else {
-                log.warn("Failed to delete Cohort Definition with ID = {}", id);
-            }
-        }
-    });
+		currentDefinition = this.cohortDefinitionRepository.save(currentDefinition);
+		eventPublisher.publishEvent(new CohortDefinitionChangedEvent(currentDefinition));
+		return getCohortDefinition(id);
+	}
+
+	/**
+	 * Queues up a generate cohort task for the specified cohort definition id.
+	 *
+	 * @param id - the Cohort Definition ID to generate
+	 * @return information about the Cohort Analysis Job
+	 */
+	@GET
+	@Produces(MediaType.APPLICATION_JSON)
+	@Path("/{id}/generate/{sourceKey}")
+	@Transactional
+	public JobExecutionResource generateCohort(@PathParam("id") final int id, @PathParam("sourceKey") final String sourceKey) {
+
+		Source source = getSourceRepository().findBySourceKey(sourceKey);
+		CohortDefinition currentDefinition = this.cohortDefinitionRepository.findOne(id);
+		UserEntity user = userRepository.findByLogin(security.getSubject());
+		return cohortGenerationService.generateCohortViaJob(user, currentDefinition, source);
+	}
+
+	@GET
+	@Produces(MediaType.APPLICATION_JSON)
+	@Path("/{id}/cancel/{sourceKey}")
+	public Response cancelGenerateCohort(@PathParam("id") final int id, @PathParam("sourceKey") final String sourceKey) {
+
+		final Source source = Optional.ofNullable(getSourceRepository().findBySourceKey(sourceKey))
+						.orElseThrow(NotFoundException::new);
+		getTransactionTemplateRequiresNew().execute(status -> {
+			CohortDefinition currentDefinition = cohortDefinitionRepository.findOne(id);
+			if (Objects.nonNull(currentDefinition)) {
+				CohortGenerationInfo info = findBySourceId(currentDefinition.getGenerationInfoList(), source.getSourceId());
+				if (Objects.nonNull(info)) {
+					invalidateExecution(info);
+					cohortDefinitionRepository.save(currentDefinition);
+				}
+			}
+			return null;
+		});
+
+		jobService.cancelJobExecution(e -> {
+			JobParameters parameters = e.getJobParameters();
+			String jobName = e.getJobInstance().getJobName();
+			return Objects.equals(parameters.getString(COHORT_DEFINITION_ID), Integer.toString(id))
+							&& Objects.equals(parameters.getString(SOURCE_ID), Integer.toString(source.getSourceId()))
+							&& Objects.equals(Constants.GENERATE_COHORT, jobName);
+		});
+		return Response.status(Response.Status.OK).build();
+	}
+
+	/**
+	 * Queues up a generate cohort task for the specified cohort definition id.
+	 *
+	 * @param id - the Cohort Definition ID to generate
+	 * @return information about the Cohort Analysis Job
+	 * @throws Exception
+	 */
+	@GET
+	@Produces(MediaType.APPLICATION_JSON)
+	@Path("/{id}/info")
+	@Transactional
+	public List<CohortGenerationInfoDTO> getInfo(@PathParam("id") final int id) {
+		CohortDefinition def = this.cohortDefinitionRepository.findOne(id);
+		if (Objects.isNull(def)) {
+			throw new IllegalArgumentException(String.format("There is no cohort definition with id = %d.", id));
+		}
+		Set<CohortGenerationInfo> infoList = def.getGenerationInfoList();
+
+		List<CohortGenerationInfo> result = infoList.stream().filter(genInfo -> sourceIdAccessor.hasAccess(genInfo.getId().getSourceId())).collect(Collectors.toList());
+
+		Map<Integer, Source> sourceMap = sourceService.getSourcesMap(SourceMapKey.BY_SOURCE_ID);
+		List<CohortGenerationInfo> filteredResult = sensitiveInfoService.filterSensitiveInfo(result,
+						gi -> Collections.singletonMap(Constants.Variables.SOURCE, sourceMap.get(gi.getId().getSourceId())));
+		return filteredResult.stream()
+						.map(t -> conversionService.convert(t, CohortGenerationInfoDTO.class))
+						.collect(Collectors.toList());
+	}
+
+	/**
+	 * Copies the specified cohort definition
+	 *
+	 * @param id - the Cohort Definition ID to copy
+	 * @return the copied cohort definition as a CohortDTO
+	 */
+	@GET
+	@Produces(MediaType.APPLICATION_JSON)
+	@Path("/{id}/copy")
+	@Transactional
+	public CohortDTO copy(@PathParam("id") final int id) {
+		CohortDTO sourceDef = getCohortDefinition(id);
+		sourceDef.setId(null); // clear the ID
+		sourceDef.setName(NameUtils.getNameForCopy(sourceDef.getName(), this::getNamesLike, cohortDefinitionRepository.findByName(sourceDef.getName())));
+		CohortDTO copyDef = createCohortDefinition(sourceDef);
+
+		return copyDef;
+	}
+
+	public List<String> getNamesLike(String copyName) {
+
+		return cohortDefinitionRepository.findAllByNameStartsWith(copyName).stream().map(CohortDefinition::getName).collect(Collectors.toList());
+	}
+
+	/**
+	 * Deletes the specified cohort definition
+	 *
+	 * @param id - the Cohort Definition ID to copy
+	 */
+	@DELETE
+	@Produces(MediaType.APPLICATION_JSON)
+	@Path("/{id}")
+	public void delete(@PathParam("id") final int id) {
+		// perform the JPA update in a separate transaction
+		this.getTransactionTemplateRequiresNew().execute(new TransactionCallbackWithoutResult() {
+			@Override
+			public void doInTransactionWithoutResult(final TransactionStatus status) {
+				CohortDefinition def = cohortDefinitionRepository.findOne(id);
+				if (!Objects.isNull(def)) {
+					def.getGenerationInfoList().forEach(cohortGenerationInfo -> {
+						Integer sourceId = cohortGenerationInfo.getId().getSourceId();
+
+						jobService.cancelJobExecution(e -> {
+							JobParameters parameters = e.getJobParameters();
+							String jobName = e.getJobInstance().getJobName();
+							return Objects.equals(parameters.getString(COHORT_DEFINITION_ID), Integer.toString(id))
+											&& Objects.equals(parameters.getString(SOURCE_ID), Integer.toString(sourceId))
+											&& Objects.equals(Constants.GENERATE_COHORT, jobName);
+						});
+					});
+					cohortDefinitionRepository.delete(def);
+				} else {
+					log.warn("Failed to delete Cohort Definition with ID = {}", id);
+				}
+			}
+		});
 
 		JobParametersBuilder builder = new JobParametersBuilder();
-		builder.addString(JOB_NAME, String.format("Cleanup cohort %d.",id));
+		builder.addString(JOB_NAME, String.format("Cleanup cohort %d.", id));
 		builder.addString(COHORT_DEFINITION_ID, ("" + id));
 
 		final JobParameters jobParameters = builder.toJobParameters();
 
 		log.info("Beginning cohort cleanup for cohort definition id: {}", "" + id);
 
-		CleanupCohortTasklet cleanupTasklet = new CleanupCohortTasklet(this.getTransactionTemplateNoTransaction(),this.getSourceRepository());
+		CleanupCohortTasklet cleanupTasklet = new CleanupCohortTasklet(this.getTransactionTemplateNoTransaction(), this.getSourceRepository());
 
 		Step cleanupStep = stepBuilders.get("cohortDefinition.cleanupCohort")
-			.tasklet(cleanupTasklet)
-			.build();
+						.tasklet(cleanupTasklet)
+						.build();
 
 		SimpleJobBuilder cleanupJobBuilder = jobBuilders.get("cleanupCohort")
-			.start(cleanupStep);
+						.start(cleanupStep);
 
 		Job cleanupCohortJob = cleanupJobBuilder.build();
 
 		this.jobTemplate.launch(cleanupCohortJob, jobParameters);
 	}
-	
-  private List<ConceptSetExport> getConceptSetExports(CohortDefinition def, SourceInfo vocabSource) throws RuntimeException {
 
-    CohortExpression expression;
-    try {
-      expression = objectMapper.readValue(def.getDetails().getExpression(), CohortExpression.class);
-    } catch (Exception e) {
-      throw new RuntimeException(e);
-    }
+	private List<ConceptSetExport> getConceptSetExports(CohortDefinition def, SourceInfo vocabSource) throws RuntimeException {
 
-    return Arrays.stream(expression.conceptSets)
-            .map(cs -> vocabularyService.exportConceptSet(cs, vocabSource))
-            .collect(Collectors.toList());
-  }
+		CohortExpression expression;
+		try {
+			expression = objectMapper.readValue(def.getDetails().getExpression(), CohortExpression.class);
+		} catch (Exception e) {
+			throw new RuntimeException(e);
+		}
 
-  @GET
-  @Path("/{id}/export/conceptset")
-  @Consumes(MediaType.APPLICATION_JSON)
-  @Produces(MediaType.APPLICATION_OCTET_STREAM)
-  public Response exportConceptSets(@PathParam("id") final int id)
-  {
-    
-    Source source = sourceService.getPriorityVocabularySource();
-    if (Objects.isNull(source)) {
-        throw new ForbiddenException();
-    }
-    CohortDefinition def = this.cohortDefinitionRepository.findOneWithDetail(id);
-    if (Objects.isNull(def)) {
-        throw new NotFoundException();
-    }
-    
-    List<ConceptSetExport> exports = getConceptSetExports(def, new SourceInfo(source));
-    ByteArrayOutputStream exportStream = ExportUtil.writeConceptSetExportToCSVAndZip(exports);
+		return Arrays.stream(expression.conceptSets)
+						.map(cs -> vocabularyService.exportConceptSet(cs, vocabSource))
+						.collect(Collectors.toList());
+	}
 
-    return HttpUtils.respondBinary(exportStream, String.format("cohortdefinition_%d_export.zip", def.getId()));
-  }    
+	@GET
+	@Path("/{id}/export/conceptset")
+	@Consumes(MediaType.APPLICATION_JSON)
+	@Produces(MediaType.APPLICATION_OCTET_STREAM)
+	public Response exportConceptSets(@PathParam("id") final int id) {
 
-  @GET
-  @Path("/{id}/report/{sourceKey}")
-  @Produces(MediaType.APPLICATION_JSON)
-  @Transactional
-  public InclusionRuleReport getInclusionRuleReport(
-					@PathParam("id") final int id, 
-					@PathParam("sourceKey") final String sourceKey, 
+		Source source = sourceService.getPriorityVocabularySource();
+		if (Objects.isNull(source)) {
+			throw new ForbiddenException();
+		}
+		CohortDefinition def = this.cohortDefinitionRepository.findOneWithDetail(id);
+		if (Objects.isNull(def)) {
+			throw new NotFoundException();
+		}
+
+		List<ConceptSetExport> exports = getConceptSetExports(def, new SourceInfo(source));
+		ByteArrayOutputStream exportStream = ExportUtil.writeConceptSetExportToCSVAndZip(exports);
+
+		return HttpUtils.respondBinary(exportStream, String.format("cohortdefinition_%d_export.zip", def.getId()));
+	}
+
+	@GET
+	@Path("/{id}/report/{sourceKey}")
+	@Produces(MediaType.APPLICATION_JSON)
+	@Transactional
+	public InclusionRuleReport getInclusionRuleReport(
+					@PathParam("id") final int id,
+					@PathParam("sourceKey") final String sourceKey,
 					@DefaultValue("0") @QueryParam("mode") int modeId) {
 
-    Source source = this.getSourceRepository().findBySourceKey(sourceKey);
+		Source source = this.getSourceRepository().findBySourceKey(sourceKey);
 
-    InclusionRuleReport.Summary summary = getInclusionRuleReportSummary(whitelist(id), source, modeId);
-    List<InclusionRuleReport.InclusionRuleStatistic> inclusionRuleStats = getInclusionRuleStatistics(whitelist(id), source, modeId);
-    String treemapData = getInclusionRuleTreemapData(whitelist(id), inclusionRuleStats.size(), source, modeId);
+		InclusionRuleReport.Summary summary = getInclusionRuleReportSummary(whitelist(id), source, modeId);
+		List<InclusionRuleReport.InclusionRuleStatistic> inclusionRuleStats = getInclusionRuleStatistics(whitelist(id), source, modeId);
+		String treemapData = getInclusionRuleTreemapData(whitelist(id), inclusionRuleStats.size(), source, modeId);
 
-    InclusionRuleReport report = new InclusionRuleReport();
-    report.summary = summary;
-    report.inclusionRuleStats = inclusionRuleStats;
-    report.treemapData = treemapData;
+		InclusionRuleReport report = new InclusionRuleReport();
+		report.summary = summary;
+		report.inclusionRuleStats = inclusionRuleStats;
+		report.treemapData = treemapData;
 
-    return report;
-  }
+		return report;
+	}
 
-  @POST
-  @Path("/check")
-  @Produces(MediaType.APPLICATION_JSON)
-  @Consumes(MediaType.APPLICATION_JSON)
-  @Transactional
-  public CheckResultDTO runDiagnostics(CohortExpression expression){
-      Checker checker = new Checker();
-      return new CheckResultDTO(checker.check(expression));
-  }
+	@POST
+	@Path("/check")
+	@Produces(MediaType.APPLICATION_JSON)
+	@Consumes(MediaType.APPLICATION_JSON)
+	@Transactional
+	public CheckResultDTO runDiagnostics(CohortExpression expression) {
+		Checker checker = new Checker();
+		return new CheckResultDTO(checker.check(expression));
+	}
+
+	@POST
+	@Path("/printfriendly/cohort")
+	@Produces(MediaType.TEXT_HTML)
+	@Consumes(MediaType.APPLICATION_JSON)
+	public String cohortPrintFriendly(CohortExpression expression) {
+		String markdown = markdownPF.renderCohort(expression);
+		Parser parser = Parser.builder().extensions(extensions).build();
+		Node document = parser.parse(markdown);
+		HtmlRenderer renderer = HtmlRenderer.builder().extensions(extensions).build();
+		String html = renderer.render(document);
+		return html;
+	}
+
+	@POST
+	@Path("/printfriendly/conceptsets")
+	@Produces(MediaType.TEXT_HTML)
+	@Consumes(MediaType.APPLICATION_JSON)
+	public String conceptSetListPrintFriendly(List<ConceptSet> conceptSetList) {
+		String markdown = markdownPF.renderConceptSetList(conceptSetList.toArray(new ConceptSet[0]));
+		Parser parser = Parser.builder().extensions(extensions).build();
+		Node document = parser.parse(markdown);
+		HtmlRenderer renderer = HtmlRenderer.builder().extensions(extensions).build();
+		String html = renderer.render(document);
+		return html;
+	}
 }

--- a/src/main/resources/db/migration/oracle/V2.8.0.202010130001__print_friendly_security.sql
+++ b/src/main/resources/db/migration/oracle/V2.8.0.202010130001__print_friendly_security.sql
@@ -1,0 +1,12 @@
+INSERT INTO ${ohdsiSchema}.SEC_PERMISSION (ID, VALUE, DESCRIPTION)
+  VALUES (${ohdsiSchema}.sec_permission_id_seq.nextval, 'cohortdefinition:printfriendly:cohort:post', 'Get print-friendly HTML of cohort expression');
+INSERT INTO ${ohdsiSchema}.SEC_PERMISSION (ID, VALUE, DESCRIPTION)
+  VALUES (${ohdsiSchema}.sec_permission_id_seq.nextval, 'cohortdefinition:printfriendly:conceptsets:post', 'Get print-friendly HTML of conceptset list');
+
+INSERT INTO ${ohdsiSchema}.sec_role_permission(id, role_id, permission_id)
+  SELECT ${ohdsiSchema}.sec_role_permission_sequence.nextval, sr.id, sp.id
+  FROM ${ohdsiSchema}.sec_permission SP, ${ohdsiSchema}.sec_role sr
+  WHERE sp.value IN (
+    'cohortdefinition:printfriendly:cohort:post',
+    'cohortdefinition:printfriendly:conceptsets:post'
+  ) AND sr.name IN ('Atlas users');

--- a/src/main/resources/db/migration/postgresql/V2.8.0.202010130001__print_friendly_security.sql
+++ b/src/main/resources/db/migration/postgresql/V2.8.0.202010130001__print_friendly_security.sql
@@ -1,0 +1,13 @@
+INSERT INTO ${ohdsiSchema}.sec_permission(id, value, description) VALUES
+  (nextval('${ohdsiSchema}.sec_permission_id_seq'), 'cohortdefinition:printfriendly:cohort:post', 'Get print-friendly HTML of cohort expression');
+INSERT INTO ${ohdsiSchema}.sec_permission(id, value, description) VALUES
+  (nextval('${ohdsiSchema}.sec_permission_id_seq'), 'cohortdefinition:printfriendly:conceptsets:post', 'Get print-friendly HTML of conceptset list');
+
+
+INSERT INTO ${ohdsiSchema}.sec_role_permission(id, role_id, permission_id)
+  SELECT nextval('${ohdsiSchema}.sec_role_permission_sequence'), sr.id, sp.id
+  FROM ${ohdsiSchema}.sec_permission SP, ${ohdsiSchema}.sec_role sr
+  WHERE sp.value IN (
+    'cohortdefinition:printfriendly:cohort:post',
+    'cohortdefinition:printfriendly:conceptsets:post'
+  ) AND sr.name IN ('Atlas users');

--- a/src/main/resources/db/migration/sqlserver/V2.8.0.202010130001__print_friendly_security.sql
+++ b/src/main/resources/db/migration/sqlserver/V2.8.0.202010130001__print_friendly_security.sql
@@ -1,0 +1,12 @@
+ INSERT INTO ${ohdsiSchema}.sec_permission(id, value, description) VALUES
+  (NEXT VALUE FOR ${ohdsiSchema}.sec_permission_id_seq, 'cohortdefinition:printfriendly:cohort:post', 'Get print-friendly HTML of cohort expression');
+ INSERT INTO ${ohdsiSchema}.sec_permission(id, value, description) VALUES
+  (NEXT VALUE FOR ${ohdsiSchema}.sec_permission_id_seq, 'cohortdefinition:printfriendly:conceptsets:post', 'Get print-friendly HTML of conceptset list');
+
+INSERT INTO ${ohdsiSchema}.sec_role_permission(id, role_id, permission_id)
+  SELECT NEXT VALUE FOR ${ohdsiSchema}.sec_role_permission_sequence, sr.id, sp.id
+  FROM ${ohdsiSchema}.sec_permission SP, ${ohdsiSchema}.sec_role sr
+  WHERE sp.value IN (
+    'cohortdefinition:printfriendly:cohort:post',
+    'cohortdefinition:printfriendly:conceptsets:post'
+  ) AND sr.name IN ('Atlas users');


### PR DESCRIPTION
This PR adds the endpoints (and security records) for exposing print-friendly for cohort expressions.

Fixes #617 .

I've reformatted CohortDefinitionService to tab-indent, so please set 'ignore whitespace' when reviewing changes.
