### PR TITLE
Set Maven Central as the first repository

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -440,6 +440,10 @@
 
   <repositories>
     <repository>
+      <id>central</id>
+      <url>https://repo.maven.apache.org/maven2</url>
+    </repository>
+    <repository>
       <id>ohdsi</id>
       <name>repo.ohdsi.org</name>
       <url>http://repo.ohdsi.org:8085/nexus/content/repositories/releases</url>


### PR DESCRIPTION
This speeds up the build A LOT when none of the dependencies have been cached yet (e.g. when performing a docker build). Reason: without putting this repository first, all dependencies are first searched in all of the specified repositories and only afterwards the central repository is tried. Because most dependencies are not present in the specified repositories, still central needs to be queried afterwards. When putting the central repository first, this reduces time to retrieve dependencies in two ways:

1. For most dependencies, it reduces the number of repositories queried from eight to one. Since the repositories are queried sequentially for each dependency, this reduces the time by eight-fold for many packages if the latency were equal.
2. The central repository has a much lower latency than the other repositories. If a dependency can be fetched from here, it will be faster than when it is fetched elsewhere.
