### PR TITLE
Update pom dependencies to address vulnerabilities.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -565,12 +565,12 @@
     <dependency>
       <groupId>org.hibernate</groupId>
       <artifactId>hibernate-core</artifactId>
-      <version>5.4.2.Final</version>
+      <version>5.4.24.Final</version>
     </dependency>
     <dependency>
       <groupId>org.hibernate</groupId>
       <artifactId>hibernate-entitymanager</artifactId>
-      <version>5.4.2.Final</version>
+      <version>5.4.24.Final</version>
     </dependency>
     <dependency>
       <groupId>javax.servlet</groupId>
@@ -648,7 +648,7 @@
     <dependency>
       <groupId>org.postgresql</groupId>
       <artifactId>postgresql</artifactId>
-      <version>9.4-1201-jdbc41</version>
+      <version>42.2.13</version>
       <type>jar</type>
     </dependency>
     <dependency>
@@ -686,7 +686,7 @@
     <dependency>
       <groupId>org.apache.shiro</groupId>
       <artifactId>shiro-web</artifactId>
-      <version>1.5.1</version>
+      <version>1.6.0</version>
     </dependency>
     <dependency>
       <groupId>org.apache.shiro</groupId>
@@ -726,12 +726,12 @@
     <dependency>
       <groupId>io.jsonwebtoken</groupId>
       <artifactId>jjwt</artifactId>
-      <version>0.6.0</version>
+      <version>0.9.1</version>
     </dependency>
     <dependency>
       <groupId>io.buji</groupId>
       <artifactId>buji-pac4j</artifactId>
-      <version>5.0.0</version>
+      <version>5.0.1</version>
     </dependency>
     <dependency>
       <groupId>org.pac4j</groupId>
@@ -917,7 +917,13 @@
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-annotations</artifactId>
-      <version>2.8.7</version>
+      <version>2.9.10</version>
+      <type>jar</type>
+    </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-databind</artifactId>
+      <version>2.9.10.1</version>
       <type>jar</type>
     </dependency>
     <dependency>


### PR DESCRIPTION
This PR attempts to address the issues identified in #1698, #1697, #1696, #1695.

I encountered problems trying to move the jackson dependencies to the new version.  I believe there is a conflict in one of the other transient dependencies, but I couldn't unwind them, and I'm afraid I do not have the time to dig into this.  If anyone else has the cycles, please feel free to add to this branch.
