### PR TITLE
Replacement for RANDOM keyword was added to netezza

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
 
     <circe.version>1.9.2</circe.version>
     <jersey.version>2.14</jersey.version>
-    <SqlRender.version>1.6.8</SqlRender.version>
+    <SqlRender.version>1.7.0-SNAPSHOT</SqlRender.version>
     <hive-jdbc.version>3.1.2</hive-jdbc.version>
     <pac4j.version>4.0.0</pac4j.version>
     <jackson.version>2.10.5</jackson.version>


### PR DESCRIPTION
fixes #1782
(cherry picked from commit ac21b68)