### PR TITLE
Revert Dockerfile to use Java 8

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM maven:3.6-jdk-11 as builder
+FROM maven:3.6-jdk-8 as builder
 
 WORKDIR /code
 
@@ -26,7 +26,7 @@ RUN mvn package \
     && rm WebAPI.war
 
 # OHDSI WebAPI and ATLAS web application running as a Spring Boot application with Java 11
-FROM openjdk:11-jre-slim
+FROM openjdk:8-jre-slim
 
 MAINTAINER Lee Evans - www.ltscomputingllc.com
 

--- a/pom.xml
+++ b/pom.xml
@@ -1166,8 +1166,6 @@
         <maven.gitcommitid.skip>true</maven.gitcommitid.skip>
         <miredot.phase>none</miredot.phase>
         <skipTests>true</skipTests>
-        <maven.compiler.source>11</maven.compiler.source>
-        <maven.compiler.target>11</maven.compiler.target>
         <datasource.driverClassName>org.postgresql.Driver</datasource.driverClassName>
         <datasource.url>jdbc:postgresql://54.209.111.128:5432/vocabularyv5</datasource.url>
         <datasource.username>USER</datasource.username>


### PR DESCRIPTION
Fixes #1815. Modifies both the build and the runtime stages to ensure that no Java 11 binary files are created at build time. 