### PR TITLE
Remove non-SSL repositories from POM.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -481,7 +481,7 @@
     <repository>
       <id>ohdsi</id>
       <name>repo.ohdsi.org</name>
-      <url>http://repo.ohdsi.org:8085/nexus/content/groups/public</url>
+      <url>https://repo.ohdsi.org/nexus/content/groups/public</url>
     </repository>
   </repositories>
 
@@ -491,9 +491,9 @@
       <url>https://repo.maven.apache.org/maven2</url>
     </pluginRepository>
     <pluginRepository>
-      <id>miredot</id>
-      <name>MireDot Releases</name>
-      <url>http://nexus.qmino.com/content/repositories/miredot</url>
+      <id>ohdsi</id>
+      <name>repo.ohdsi.org</name>
+      <url>https://repo.ohdsi.org/nexus/content/groups/public</url>
     </pluginRepository>
   </pluginRepositories>
 


### PR DESCRIPTION
With Maven v3.8, there is a default rule applied which will block all HTTP related traffic.  This PR will reset the nexus URLs to use HTTPS and remove the `nexus.qmino.com` repository since this is proxied via `https://repo.ohdsi.org/nexus/content/groups/public`.
