### PR TITLE
Use JDK 11 base image to support building for ARM

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM maven:3.6-jdk-8 as builder
+FROM maven:3.6-jdk-11 as builder
 
 WORKDIR /code
 


### PR DESCRIPTION
Building the container image on ARM currently fails: https://github.com/OHDSI/WebAPI/actions/runs/853505145 since there is no ARM variant of the maven:3.6-jdk-8 image available.

This PR changes the builder image to 3.8-jdk-11, which does have an ARM manifest. I've built and pushed the resulting image to https://hub.docker.com/layers/chgl/ohdsi-webapi/2.10.0-SNAPSHOT/images/sha256-31aa8181914bb4f37728c777885cbf75a7be145977ddf1b23bae554b908f7af2?context=explore

A brief test seems to show that this does work without triggering #1815 