### PR TITLE
R multi thread evaluation

### DIFF
--- a/src/main/resources/resources/estimation/r/runAnalysis.R
+++ b/src/main/resources/resources/estimation/r/runAnalysis.R
@@ -35,6 +35,10 @@ tryCatch({
                                                                         password = pwd,
                                                                         pathToDriver = driversPath)
 
+        connectionDetails$user <- function() Sys.getenv("DBMS_USERNAME")
+        connectionDetails$password <- function() Sys.getenv("DBMS_PASSWORD")
+        connectionDetails$connectionString <- function() Sys.getenv("CONNECTION_STRING")
+
         outputFolder <- file.path(getwd(), 'results')
         dir.create(outputFolder)
 

--- a/src/main/resources/resources/estimation/r/runAnalysis.R
+++ b/src/main/resources/resources/estimation/r/runAnalysis.R
@@ -35,6 +35,7 @@ tryCatch({
                                                                         password = pwd,
                                                                         pathToDriver = driversPath)
 
+        # Evaluating can't use global environment in child threads
         connectionDetails$user <- function() Sys.getenv("DBMS_USERNAME")
         connectionDetails$password <- function() Sys.getenv("DBMS_PASSWORD")
         connectionDetails$connectionString <- function() Sys.getenv("CONNECTION_STRING")

--- a/src/main/resources/resources/prediction/r/runAnalysis.R
+++ b/src/main/resources/resources/prediction/r/runAnalysis.R
@@ -32,6 +32,10 @@ tryCatch({
                                                                         password = pwd,
                                                                         pathToDriver = driversPath)
 
+        connectionDetails$user <- function() Sys.getenv("DBMS_USERNAME")
+        connectionDetails$password <- function() Sys.getenv("DBMS_PASSWORD")
+        connectionDetails$connectionString <- function() Sys.getenv("CONNECTION_STRING")
+
         outputFolder <- file.path(getwd(), 'results')
         dir.create(outputFolder)
 

--- a/src/main/resources/resources/prediction/r/runAnalysis.R
+++ b/src/main/resources/resources/prediction/r/runAnalysis.R
@@ -50,8 +50,7 @@ tryCatch({
                 createValidationPackage = F,
                 packageResults = T,
                 minCellCount = 5,
-                cdmVersion = 5,
-                createShiny = T)
+                cdmVersion = 5)
         # To run PLP Viewer shiny app call:
         # PatientLevelPrediction::viewMultiplePlp(outputFolder)
 }, finally = {

--- a/src/main/resources/resources/prediction/r/runAnalysis.R
+++ b/src/main/resources/resources/prediction/r/runAnalysis.R
@@ -32,6 +32,7 @@ tryCatch({
                                                                         password = pwd,
                                                                         pathToDriver = driversPath)
 
+        # Evaluating can't use global environment in child threads
         connectionDetails$user <- function() Sys.getenv("DBMS_USERNAME")
         connectionDetails$password <- function() Sys.getenv("DBMS_PASSWORD")
         connectionDetails$connectionString <- function() Sys.getenv("CONNECTION_STRING")


### PR DESCRIPTION
Now the variables are evaluated correctly in child threads
Previously it was impossible because child threads cannot access global environment