### PR TITLE
fix ple on bq

### DIFF
--- a/src/main/resources/resources/estimation/r/runAnalysis.R
+++ b/src/main/resources/resources/estimation/r/runAnalysis.R
@@ -40,6 +40,8 @@ tryCatch({
         connectionDetails$password <- function() Sys.getenv("DBMS_PASSWORD")
         connectionDetails$connectionString <- function() Sys.getenv("CONNECTION_STRING")
 
+        options(sqlRenderTempEmulationSchema = resultsDatabaseSchema)
+
         outputFolder <- file.path(getwd(), 'results')
         dir.create(outputFolder)
 

--- a/src/main/resources/resources/prediction/r/runAnalysis.R
+++ b/src/main/resources/resources/prediction/r/runAnalysis.R
@@ -37,8 +37,6 @@ tryCatch({
         connectionDetails$password <- function() Sys.getenv("DBMS_PASSWORD")
         connectionDetails$connectionString <- function() Sys.getenv("CONNECTION_STRING")
 
-        options(sqlRenderTempEmulationSchema = resultsDatabaseSchema)
-
         outputFolder <- file.path(getwd(), 'results')
         dir.create(outputFolder)
 

--- a/src/main/resources/resources/prediction/r/runAnalysis.R
+++ b/src/main/resources/resources/prediction/r/runAnalysis.R
@@ -37,6 +37,8 @@ tryCatch({
         connectionDetails$password <- function() Sys.getenv("DBMS_PASSWORD")
         connectionDetails$connectionString <- function() Sys.getenv("CONNECTION_STRING")
 
+        options(sqlRenderTempEmulationSchema = resultsDatabaseSchema)
+
         outputFolder <- file.path(getwd(), 'results')
         dir.create(outputFolder)
 


### PR DESCRIPTION
parameter `sqlRenderTempEmulationSchema `was added to `runAnalysis.R` script because `CohortMethod/DataLoadingSaving.R` does not use `oracleTempSchema` parameter any more
fixes #1933