### PR TITLE
Dependencies update before 2.11 release

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -18,15 +18,18 @@
     <waffle.version>2.2.1</waffle.version>
     <jna.version>5.5.0</jna.version>
     <hibernate.version>5.4.2.Final</hibernate.version>
-    <postgresql.version>42.2.18</postgresql.version>
+    <postgresql.version>42.2.25</postgresql.version>
     <bouncycastle.version>1.68</bouncycastle.version>
     <shiro.version>1.8.0</shiro.version>
     <dom4j.version>2.1.3</dom4j.version>
     <hydra.version>0.2.0</hydra.version>
+    <featureExtraction.version>3.1.0</featureExtraction.version>
+    
+    <commons-fileupload.version>1.3.3</commons-fileupload.version>
 
     <circe.version>1.9.4</circe.version>
     <jersey.version>2.14</jersey.version>
-    <SqlRender.version>1.7.0</SqlRender.version>
+    <SqlRender.version>1.8.3</SqlRender.version>
     <hive-jdbc.version>3.1.2</hive-jdbc.version>
     <pac4j.version>4.0.0</pac4j.version>
     <jackson.version>2.10.5</jackson.version>
@@ -190,7 +193,7 @@
     <server.ssl.key-password></server.ssl.key-password>
     <server.servlet.context-path>/WebAPI</server.servlet.context-path>
 
-    <arachne.version>1.17.1</arachne.version>
+    <arachne.version>1.17.2</arachne.version>
     <jersey-media-multipart.version>2.25.1</jersey-media-multipart.version>
     <execution.invalidation.period>600000</execution.invalidation.period>
     <execution.invalidation.maxage.hours>12</execution.invalidation.maxage.hours>
@@ -245,8 +248,8 @@
     <cache.inspection.period>3600000</cache.inspection.period>
 
     <!-- Build info -->
-    <buildinfo.atlas.milestone.id>39</buildinfo.atlas.milestone.id>
-    <buildinfo.webapi.milestone.id>39</buildinfo.webapi.milestone.id>
+    <buildinfo.atlas.milestone.id>41</buildinfo.atlas.milestone.id>
+    <buildinfo.webapi.milestone.id>42</buildinfo.webapi.milestone.id>
     <buildinfo.atlas.release.tag>*</buildinfo.atlas.release.tag>
     <buildinfo.webapi.release.tag>*</buildinfo.webapi.release.tag>
 
@@ -766,6 +769,14 @@
         </exclusion>        
       </exclusions>
     </dependency>
+    
+    <!-- overriding commons-fileupload version from the plug-in above -->
+    <dependency>
+      <groupId>commons-fileupload</groupId>
+      <artifactId>commons-fileupload</artifactId>
+      <version>${commons-fileupload.version}</version>    
+    </dependency>    
+    
     <dependency>
       <groupId>org.postgresql</groupId>
       <artifactId>postgresql</artifactId>
@@ -926,7 +937,7 @@
     <dependency>
       <groupId>org.ohdsi</groupId>
       <artifactId>featureExtraction</artifactId>
-      <version>3.1.0</version>
+      <version>${featureExtraction.version}</version>
       <exclusions>
         <exclusion>
           <groupId>org.ohdsi.sql</groupId>
@@ -1080,7 +1091,7 @@
     <dependency>
       <groupId>org.ohdsi</groupId>
       <artifactId>SkeletonCohortCharacterization</artifactId>
-      <version>1.2.0</version>
+      <version>1.2.1</version>
       <exclusions>
         <exclusion>
           <groupId>org.ohdsi</groupId>


### PR DESCRIPTION
- SqlRender, PostgreSQL JDBC driver, commons-fileupload, SkeletonCohortCharacterization dependency versions bumped
- ARACHNE version 1.17.2
- milestone IDs changed
- as soon as featureExtraction 3.1.1 is available (the artifact seems to be broken at this moment) a separate commit will be necessary
- as soon as StandardizedAnalysisAPI 1.4.0 is released and available a separate commit will be necessary