### PR TITLE
Issue 2007 cache warm job name fix

### DIFF
--- a/src/main/java/org/ohdsi/webapi/service/CDMResultsService.java
+++ b/src/main/java/org/ohdsi/webapi/service/CDMResultsService.java
@@ -544,6 +544,6 @@ public class CDMResultsService extends AbstractDaoService implements Initializin
     }
 
     private String getWarmCacheJobName(String sourceKey) {
-        return "warming " + sourceKey + " cache";
+        return String.format("warming cache: %s", sourceKey).substring(0, 100); // job name in batch_job_instance is varchar(100)
     }
 }


### PR DESCRIPTION
Fixes #2007 

If job name contains less than 100 symbols, use sources keys. Otherwise: use source ids.