### PR TITLE
 BATCH_JOB_EXECUTION_PARAMS error when restart atlas #2038

### DIFF
--- a/src/main/java/org/ohdsi/webapi/service/CDMResultsService.java
+++ b/src/main/java/org/ohdsi/webapi/service/CDMResultsService.java
@@ -117,13 +117,13 @@ public class CDMResultsService extends AbstractDaoService implements Initializin
 
     @Value("${cache.jobs.count:3}")
     private int cacheJobsCount;
-    
+
     @Autowired
     private ApplicationContext applicationContext;
 
     @Autowired
     private AchillesCacheService cacheService;
-    
+
     @Autowired
     private CDMCacheService cdmCacheService;
 
@@ -432,7 +432,7 @@ public class CDMResultsService extends AbstractDaoService implements Initializin
 
             if (counter++ >= bucketSizes[bucketIndex] - 1) {
                 createJob(sourceIds.stream().map(String::valueOf).collect(Collectors.joining(",")),
-                        String.join(", ", sourceKeys),
+                        String.join(",", sourceKeys),
                         jobSteps);
                 
                 bucketIndex++;
@@ -507,7 +507,10 @@ public class CDMResultsService extends AbstractDaoService implements Initializin
     private JobExecutionResource createJob(String sourceKey, int sourceId, String jobName, SimpleJobBuilder stepBuilder) {
         return jobService.runJob(stepBuilder.build(), new JobParametersBuilder()
                 .addString(Constants.Params.JOB_NAME, jobName)
-                .addString(Constants.Params.SOURCE_KEY, sourceKey)
+
+                // batch_job_execution_params.string_val is varchar(250). too many source keys can exceed 250 symbols
+                .addString(Constants.Params.SOURCE_KEY, sourceKey.substring(0, 250))
+
                 .addString(Constants.Params.SOURCE_ID, String.valueOf(sourceId))
                 .toJobParameters());
     }


### PR DESCRIPTION
Fixes #2038.

It is a quick fix. Caching should be reworked in the future, espetially org.ohdsi.webapi.service.CDMResultsService and "buckets" logic which causes these bugs.