### PR TITLE
Issue 2049 add maven settings to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,10 @@ WORKDIR /code
 
 ARG MAVEN_PROFILE=webapi-docker
 
+# Copy maven settings, containing repository configurations
+RUN mkdir -p /root/.m2
+COPY WebAPIConfig/settings.xml /root/.m2
+
 # Download dependencies
 COPY pom.xml /code/
 RUN mkdir .git \


### PR DESCRIPTION
Addresses issue #2049 

Copies the maven settings file from project directory `WebAPIConfig/settings.xml` to the default location in the builder `~/.m2/settings.xml`