### PR TITLE
Added OpenTelemetry Java Agent for auto-instrumentation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,9 @@ WORKDIR /code
 
 ARG MAVEN_PROFILE=webapi-docker
 
+ARG OPENTELEMETRY_JAVA_AGENT_VERSION=1.16.0
+RUN curl -LSsO https://github.com/open-telemetry/opentelemetry-java-instrumentation/releases/download/v${OPENTELEMETRY_JAVA_AGENT_VERSION}/opentelemetry-javaagent.jar
+
 # Download dependencies
 COPY pom.xml /code/
 RUN mkdir .git \
@@ -41,6 +44,8 @@ ENV DEFAULT_JAVA_OPTS="-Djava.security.egd=file:///dev/./urandom"
 
 # set working directory to a fixed WebAPI directory
 WORKDIR /var/lib/ohdsi/webapi
+
+COPY --from=builder /code/opentelemetry-javaagent.jar .
 
 # deploy the just built OHDSI WebAPI war file
 # copy resources in order of fewest changes to most changes.

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ WORKDIR /code
 
 ARG MAVEN_PROFILE=webapi-docker
 
-ARG OPENTELEMETRY_JAVA_AGENT_VERSION=1.16.0
+ARG OPENTELEMETRY_JAVA_AGENT_VERSION=1.17.0
 RUN curl -LSsO https://github.com/open-telemetry/opentelemetry-java-instrumentation/releases/download/v${OPENTELEMETRY_JAVA_AGENT_VERSION}/opentelemetry-javaagent.jar
 
 # Download dependencies


### PR DESCRIPTION
This adds the https://github.com/open-telemetry/opentelemetry-java-instrumentation agent jar to the container to allow tracing and metrics export without any code changes.

It can be enabled by setting the following environment variables:

```console
      JAVA_OPTS: "-javaagent:/var/lib/ohdsi/webapi/opentelemetry-javaagent.jar"
      OTEL_TRACES_EXPORTER: "jaeger"
      OTEL_METRICS_EXPORTER: "prometheus"
      OTEL_LOGS_EXPORTER: "none"
      OTEL_SERVICE_NAME: "ohdsi-webapi"
      OTEL_EXPORTER_JAEGER_ENDPOINT: "http://jaeger:14250"
```

see https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/sdk-environment-variables.md for details on the settings.

Here's a complete Docker Compose setup:

```yaml
services:
  db:
    image: docker.io/library/postgres:14.5@sha256:f8816ada742348e1adfcec5c2a180b675bf6e4a294e0feb68bd70179451e1242
    environment:
      POSTGRES_PASSWORD: postgres
      POSTGRES_DB: ohdsi

  jaeger:
    image: docker.io/jaegertracing/all-in-one:1.37@sha256:60ab2e6b0682f79a4e42b2bd2526ac4de80a3a7a1ef136c71dc0cb85e9c50f46
    ports:
      - 127.0.0.1:16686:16686

  webapi:
    image: docker.io/library/webapi:latest
    ports:
      - 127.0.0.1:8080:8080
      - 127.0.0.1:9464:9464
    environment:
      DATASOURCE_DRIVERCLASSNAME: org.postgresql.Driver
      DATASOURCE_OHDSI_SCHEMA: ohdsi
      DATASOURCE_PASSWORD: postgres
      DATASOURCE_URL: jdbc:postgresql://db:5432/ohdsi
      DATASOURCE_USERNAME: postgres
      FLYWAY_DATASOURCE_DRIVERCLASSNAME: org.postgresql.Driver
      FLYWAY_DATASOURCE_PASSWORD: postgres
      FLYWAY_DATASOURCE_URL: jdbc:postgresql://db:5432/ohdsi
      FLYWAY_DATASOURCE_USERNAME: postgres
      FLYWAY_PLACEHOLDERS_OHDSISCHEMA: ohdsi
      FLYWAY_SCHEMAS: ohdsi
      SECURITY_CORS_ENABLED: "false"
      SPRING_BATCH_REPOSITORY_TABLEPREFIX: ohdsi.BATCH_
      SPRING_JPA_PROPERTIES_HIBERNATE_DEFAULT_SCHEMA: ohdsi
      SPRING_JPA_PROPERTIES_HIBERNATE_DIALECT: org.hibernate.dialect.PostgreSQLDialect
      JAVA_OPTS: "-javaagent:/var/lib/ohdsi/webapi/opentelemetry-javaagent.jar"
      OTEL_TRACES_EXPORTER: "jaeger"
      OTEL_METRICS_EXPORTER: "prometheus"
      OTEL_LOGS_EXPORTER: "none"
      OTEL_SERVICE_NAME: "ohdsi-webapi"
      OTEL_EXPORTER_JAEGER_ENDPOINT: "http://jaeger:14250"

```

- View traces at <http://localhost:16686/>
![image](https://user-images.githubusercontent.com/5307555/185493155-411d612f-549a-48f0-b338-c1253e44f494.png)

- see metrics in prometheus format at <http://localhost:9464/>
![image](https://user-images.githubusercontent.com/5307555/185493504-46ffdb16-0272-4e04-9c3c-4a5ad20802a0.png)


Closes #2066 