### PR TITLE
set default value for source.is_cache_enabled column to `false`

### DIFF
--- a/src/main/resources/db/migration/postgresql/V2.12.1.202210120000__alter_source_set_cache_enabled_default.sql
+++ b/src/main/resources/db/migration/postgresql/V2.12.1.202210120000__alter_source_set_cache_enabled_default.sql
@@ -1,0 +1,1 @@
+ALTER TABLE ${ohdsiSchema}.source ALTER COLUMN is_cache_enabled SET DEFAULT false;


### PR DESCRIPTION
Closes #2131 

Two questions:

1. should the migration be versioned as v2.12.1 or v2.13.0?
1. out-of-scope, but while building the container image I noticed the `openjdk:8-jre-slim` base image is deprecated: <https://hub.docker.com/_/openjdk>
    > This image is officially deprecated and all users are recommended to find and use suitable replacements ASAP. 

    I switched to `eclipse-temurin:8-jre` and it seems to run fine. Since this PR is just one line so far, should I update the image as well while I'm at it?