### PR TITLE
Use temp tables for security migration scripts.

### DIFF
--- a/src/main/resources/db/migration/postgresql/V2.7.0.20190211182000__permissions-fixes.sql
+++ b/src/main/resources/db/migration/postgresql/V2.7.0.20190211182000__permissions-fixes.sql
@@ -1,44 +1,54 @@
-ALTER TABLE ${ohdsiSchema}.sec_permission ADD COLUMN for_role_id INTEGER;
+CREATE TEMP TABLE temp_migration (
+  from_perm_id int,
+  new_value character varying(255)
+);
 
-INSERT INTO ${ohdsiSchema}.sec_permission (id, value, for_role_id)
-SELECT nextval('${ohdsiSchema}.sec_permission_id_seq'), REPLACE(new_perms.val, '%s', REPLACE(REPLACE(value, 'source:', ''), ':access', '')), role_id
+INSERT INTO temp_migration (from_perm_id, new_value)
+SELECT sp.id as from_id,
+  REPLACE(CAST(new_perms.val AS VARCHAR(255)), '%s', REPLACE(REPLACE(value, 'source:', ''), ':access', '')) as new_value
 FROM ${ohdsiSchema}.sec_permission sp
-  JOIN ${ohdsiSchema}.sec_role_permission srp on sp.id = srp.permission_id
-  CROSS JOIN (
-    SELECT 'vocabulary:%s:*:get' val
-    UNION ALL
-    SELECT 'vocabulary:%s:included-concepts:count:post'
-    UNION ALL
-    SELECT 'vocabulary:%s:resolveConceptSetExpression:post'
-    UNION ALL
-    SELECT 'vocabulary:%s:lookup:identifiers:post'
-    UNION ALL
-    SELECT 'vocabulary:%s:lookup:identifiers:ancestors:post'
-    UNION ALL
-    SELECT 'vocabulary:%s:lookup:mapped:post'
-    UNION ALL
-    SELECT 'vocabulary:%s:compare:post'
-    UNION ALL
-    SELECT 'vocabulary:%s:optimize:post'
-    UNION ALL
-    SELECT 'cdmresults:%s:*:get'
-    UNION ALL
-    SELECT 'cdmresults:%s:*:*:get'
-    UNION ALL
-    SELECT 'cdmresults:%s:conceptRecordCount:post'
-    UNION ALL
-    SELECT 'cohortresults:%s:*:*:get'
-    UNION ALL
-    SELECT 'cohortresults:%s:*:*:*:get'
-  ) new_perms
+CROSS JOIN (
+  SELECT 'vocabulary:%s:*:get' val
+  UNION ALL
+  SELECT 'vocabulary:%s:included-concepts:count:post'
+  UNION ALL
+  SELECT 'vocabulary:%s:resolveConceptSetExpression:post'
+  UNION ALL
+  SELECT 'vocabulary:%s:lookup:identifiers:post'
+  UNION ALL
+  SELECT 'vocabulary:%s:lookup:identifiers:ancestors:post'
+  UNION ALL
+  SELECT 'vocabulary:%s:lookup:mapped:post'
+  UNION ALL
+  SELECT 'vocabulary:%s:compare:post'
+  UNION ALL
+  SELECT 'vocabulary:%s:optimize:post'
+  UNION ALL
+  SELECT 'cdmresults:%s:*:get'
+  UNION ALL
+  SELECT 'cdmresults:%s:*:*:get'
+  UNION ALL
+  SELECT 'cdmresults:%s:conceptRecordCount:post'
+  UNION ALL
+  SELECT 'cohortresults:%s:*:*:get'
+  UNION ALL
+  SELECT 'cohortresults:%s:*:*:*:get'
+) new_perms
 WHERE sp.value LIKE 'source:%:access';
 
-INSERT INTO ${ohdsiSchema}.sec_role_permission (id, role_id, permission_id)
-SELECT nextval('${ohdsiSchema}.sec_role_permission_sequence'), sp.for_role_id, sp.id
-FROM ${ohdsiSchema}.sec_permission sp
-WHERE sp.for_role_id IS NOT NULL;
+INSERT INTO ${ohdsiSchema}.sec_permission (id, value)
+SELECT nextval('${ohdsiSchema}.sec_permission_id_seq'), new_value
+FROM temp_migration;
 
-ALTER TABLE ${ohdsiSchema}.sec_permission DROP COLUMN for_role_id;
+INSERT INTO ${ohdsiSchema}.sec_role_permission (id,role_id, permission_id)
+SELECT nextval('${ohdsiSchema}.sec_role_permission_sequence'),
+  srp.role_id,
+  sp.id as permission_id
+FROM temp_migration m
+JOIN ${ohdsiSchema}.sec_permission sp on m.new_value = sp.value
+JOIN ${ohdsiSchema}.sec_role_permission srp on m.from_perm_id = srp.permission_id;
+
+drop table temp_migration;
 
 INSERT INTO ${ohdsiSchema}.sec_permission(id, value, description)
     VALUES
@@ -50,14 +60,14 @@ INSERT INTO ${ohdsiSchema}.sec_permission(id, value, description)
     (nextval('${ohdsiSchema}.sec_permission_id_seq'), 'job:type:*:name:*:get' , 'Get IR info');
 
 INSERT INTO ${ohdsiSchema}.sec_role_permission(id, role_id, permission_id)
-  SELECT nextval('${ohdsiSchema}.sec_role_permission_sequence'), sr.id, sp.id
-  FROM ${ohdsiSchema}.sec_permission SP, ${ohdsiSchema}.sec_role sr
-  WHERE sp.value IN (
-    'conceptset:*:expression:get',
-    'conceptset:*:generationinfo:get',
-    'cohortdefinition:*:check:get',
-    'sqlrender:translate:post',
-    'ir:*:info',
-    'job:type:*:name:*:get'
-  )
-  AND sr.name IN ('Atlas users');
+SELECT nextval('${ohdsiSchema}.sec_role_permission_sequence'), sr.id, sp.id
+FROM ${ohdsiSchema}.sec_permission SP, ${ohdsiSchema}.sec_role sr
+WHERE sp.value IN (
+  'conceptset:*:expression:get',
+  'conceptset:*:generationinfo:get',
+  'cohortdefinition:*:check:get',
+  'sqlrender:translate:post',
+  'ir:*:info',
+  'job:type:*:name:*:get'
+)
+AND sr.name IN ('Atlas users');

--- a/src/main/resources/db/migration/postgresql/V2.7.0.20190214145000__permissions-fixes-3.sql
+++ b/src/main/resources/db/migration/postgresql/V2.7.0.20190214145000__permissions-fixes-3.sql
@@ -1,9 +1,12 @@
-ALTER TABLE ${ohdsiSchema}.sec_permission ADD COLUMN for_role_id INTEGER;
+CREATE TEMP TABLE temp_migration (
+  from_perm_id int,
+  new_value character varying(255)
+);
 
-INSERT INTO ${ohdsiSchema}.sec_permission (id, value, for_role_id)
-SELECT nextval('${ohdsiSchema}.sec_permission_id_seq'), REPLACE(new_perms.val, '%s', REPLACE(REPLACE(value, 'source:', ''), ':access', '')), role_id
+INSERT INTO temp_migration (from_perm_id, new_value)
+SELECT sp.id as from_id,
+	REPLACE(CAST(new_perms.val AS VARCHAR(255)), '%s', REPLACE(REPLACE(value, 'source:', ''), ':access', '')) as new_value
 FROM ${ohdsiSchema}.sec_permission sp
-  JOIN ${ohdsiSchema}.sec_role_permission srp on sp.id = srp.permission_id
   CROSS JOIN (
     SELECT 'vocabulary:%s:concept:*:get' val
     UNION ALL
@@ -23,9 +26,16 @@ FROM ${ohdsiSchema}.sec_permission sp
   ) new_perms
 WHERE sp.value LIKE 'source:%:access';
 
-INSERT INTO ${ohdsiSchema}.sec_role_permission (id, role_id, permission_id)
-SELECT nextval('${ohdsiSchema}.sec_role_permission_sequence'), sp.for_role_id, sp.id
-FROM ${ohdsiSchema}.sec_permission sp
-WHERE sp.for_role_id IS NOT NULL;
+INSERT INTO ${ohdsiSchema}.sec_permission (id, value)
+SELECT nextval('${ohdsiSchema}.sec_permission_id_seq'), new_value
+FROM temp_migration;
 
-ALTER TABLE ${ohdsiSchema}.sec_permission DROP COLUMN for_role_id;
+INSERT INTO ${ohdsiSchema}.sec_role_permission (id,role_id, permission_id)
+SELECT nextval('${ohdsiSchema}.sec_role_permission_sequence'),
+  srp.role_id,
+  sp.id as permission_id
+FROM temp_migration m
+JOIN ${ohdsiSchema}.sec_permission sp on m.new_value = sp.value
+JOIN ${ohdsiSchema}.sec_role_permission srp on m.from_perm_id = srp.permission_id;
+
+drop table temp_migration;

--- a/src/main/resources/db/migration/postgresql/V2.7.0.20190215113000__permissions-fixes-4.sql
+++ b/src/main/resources/db/migration/postgresql/V2.7.0.20190215113000__permissions-fixes-4.sql
@@ -1,28 +1,38 @@
-ALTER TABLE ${ohdsiSchema}.sec_permission ADD COLUMN for_role_id INTEGER;
+CREATE TEMP TABLE temp_migration (
+  from_perm_id int,
+  new_value character varying(255)
+);
 
-INSERT INTO ${ohdsiSchema}.sec_permission (id, value, for_role_id)
-SELECT nextval('${ohdsiSchema}.sec_permission_id_seq'), REPLACE(CAST(new_perms.val AS VARCHAR), '%s', REPLACE(REPLACE(value, 'cohortdefinition:*:generate:', ''), ':get', '')), role_id
+INSERT INTO temp_migration (from_perm_id, new_value)
+SELECT sp.id as from_id,
+  REPLACE(CAST(new_perms.val AS VARCHAR(255)), '%s', REPLACE(REPLACE(value, 'source:', ''), ':access', '')) as new_value
 FROM ${ohdsiSchema}.sec_permission sp
-  JOIN ${ohdsiSchema}.sec_role_permission srp on sp.id = srp.permission_id
-  CROSS JOIN (
-    SELECT 'vocabulary:%s:search:post' val
-  ) new_perms
-WHERE sp.value LIKE 'cohortdefinition:*:generate:%:get';
+CROSS JOIN (
+  SELECT 'vocabulary:%s:search:post' val
+) new_perms
+WHERE sp.value LIKE 'source:%:access';
 
-INSERT INTO ${ohdsiSchema}.sec_role_permission (id, role_id, permission_id)
-SELECT nextval('${ohdsiSchema}.sec_role_permission_sequence'), sp.for_role_id, sp.id
-FROM ${ohdsiSchema}.sec_permission sp
-WHERE sp.for_role_id IS NOT NULL;
+INSERT INTO ${ohdsiSchema}.sec_permission (id, value)
+SELECT nextval('${ohdsiSchema}.sec_permission_id_seq'), new_value
+FROM temp_migration;
 
-ALTER TABLE ${ohdsiSchema}.sec_permission DROP COLUMN for_role_id;
+INSERT INTO ${ohdsiSchema}.sec_role_permission (id,role_id, permission_id)
+SELECT nextval('${ohdsiSchema}.sec_role_permission_sequence'),
+  srp.role_id,
+  sp.id as permission_id
+FROM temp_migration m
+JOIN ${ohdsiSchema}.sec_permission sp on m.new_value = sp.value
+JOIN ${ohdsiSchema}.sec_role_permission srp on m.from_perm_id = srp.permission_id;
+
+drop table temp_migration;
 
 INSERT INTO ${ohdsiSchema}.sec_permission(id, value, description)
     VALUES (nextval('${ohdsiSchema}.sec_permission_id_seq'), 'cohortdefinition:*:check:post', 'Fix cohort definition');
 
 INSERT INTO ${ohdsiSchema}.sec_role_permission(id, role_id, permission_id)
-  SELECT nextval('${ohdsiSchema}.sec_role_permission_sequence'), sr.id, sp.id
-  FROM ${ohdsiSchema}.sec_permission SP, ${ohdsiSchema}.sec_role sr
-  WHERE sp.value IN (
-    'cohortdefinition:*:check:post'
-  )
-  AND sr.name IN ('Atlas users');
+SELECT nextval('${ohdsiSchema}.sec_role_permission_sequence'), sr.id, sp.id
+FROM ${ohdsiSchema}.sec_permission SP, ${ohdsiSchema}.sec_role sr
+WHERE sp.value IN (
+  'cohortdefinition:*:check:post'
+)
+AND sr.name IN ('Atlas users');

--- a/src/main/resources/db/migration/postgresql/V2.7.0.20190220113500__permissions-fixes-ir-profile.sql
+++ b/src/main/resources/db/migration/postgresql/V2.7.0.20190220113500__permissions-fixes-ir-profile.sql
@@ -1,41 +1,48 @@
-DELETE
-FROM ${ohdsiSchema}.sec_role_permission
+DELETE FROM ${ohdsiSchema}.sec_role_permission
 WHERE permission_id IN (SELECT id FROM ${ohdsiSchema}.sec_permission WHERE value NOT IN ('user:me:get'))
 AND role_id = (SELECT id FROM ${ohdsiSchema}.sec_role WHERE name = 'public');
 
-DELETE
-FROM ${ohdsiSchema}.sec_role_permission
+DELETE FROM ${ohdsiSchema}.sec_role_permission
 WHERE permission_id IN (SELECT id FROM ${ohdsiSchema}.sec_permission WHERE value IN ('ir:*:execute:*:get', 'ir:*:execute:*:delete', '*:person:*:get'))
 AND role_id = (SELECT id FROM ${ohdsiSchema}.sec_role WHERE name = 'Atlas users');
 
-ALTER TABLE ${ohdsiSchema}.sec_permission ADD COLUMN for_role_id INTEGER;
+CREATE TEMP TABLE temp_migration (
+  from_perm_id int,
+  new_value character varying(255)
+);
 
-INSERT INTO ${ohdsiSchema}.sec_permission (id, value, for_role_id)
-SELECT nextval('${ohdsiSchema}.sec_permission_id_seq'),
-  REPLACE(CAST(new_perms.val AS VARCHAR), '%s', REPLACE(REPLACE(value, 'cohortdefinition:*:generate:', ''), ':get', '')), role_id
+INSERT INTO temp_migration (from_perm_id, new_value)
+SELECT sp.id as from_id,
+  REPLACE(CAST(new_perms.val AS VARCHAR(255)), '%s', REPLACE(REPLACE(value, 'source:', ''), ':access', '')) as new_value
 FROM ${ohdsiSchema}.sec_permission sp
-  JOIN ${ohdsiSchema}.sec_role_permission srp on sp.id = srp.permission_id
-  CROSS JOIN (
-    SELECT 'ir:*:execute:%s:get' val
-    UNION ALL
-    SELECT 'ir:*:execute:%s:delete'
-    UNION ALL
-    SELECT '%s:person:*:get'
-  ) new_perms
-WHERE sp.value LIKE 'cohortdefinition:*:generate:%:get' AND sp.value <> 'cohortdefinition:*:generate:*:get';
+CROSS JOIN (
+  SELECT 'ir:*:execute:%s:get' val
+  UNION ALL
+  SELECT 'ir:*:execute:%s:delete'
+  UNION ALL
+  SELECT '%s:person:*:get'
+) new_perms
+WHERE sp.value LIKE 'source:%:access';
 
-INSERT INTO ${ohdsiSchema}.sec_role_permission (id, role_id, permission_id)
-SELECT nextval('${ohdsiSchema}.sec_role_permission_sequence'), sp.for_role_id, sp.id
-FROM ${ohdsiSchema}.sec_permission sp
-WHERE sp.for_role_id IS NOT NULL;
+INSERT INTO ${ohdsiSchema}.sec_permission (id, value)
+SELECT nextval('${ohdsiSchema}.sec_permission_id_seq'), new_value
+FROM temp_migration;
 
-ALTER TABLE ${ohdsiSchema}.sec_permission DROP COLUMN for_role_id;
+INSERT INTO ${ohdsiSchema}.sec_role_permission (id,role_id, permission_id)
+SELECT nextval('${ohdsiSchema}.sec_role_permission_sequence'),
+  srp.role_id,
+  sp.id as permission_id
+FROM temp_migration m
+JOIN ${ohdsiSchema}.sec_permission sp on m.new_value = sp.value
+JOIN ${ohdsiSchema}.sec_role_permission srp on m.from_perm_id = srp.permission_id;
+
+drop table temp_migration;
 
 -- Allow Atlas users to see list of sources
 INSERT INTO ${ohdsiSchema}.sec_role_permission(id, role_id, permission_id)
-  SELECT nextval('${ohdsiSchema}.sec_role_permission_sequence'), sr.id, sp.id
-  FROM ${ohdsiSchema}.sec_permission SP, ${ohdsiSchema}.sec_role sr
-  WHERE sp.value IN (
-    'configuration:edit:ui'
-  )
-  AND sr.name IN ('Atlas users');
+SELECT nextval('${ohdsiSchema}.sec_role_permission_sequence'), sr.id, sp.id
+FROM ${ohdsiSchema}.sec_permission SP, ${ohdsiSchema}.sec_role sr
+WHERE sp.value IN (
+  'configuration:edit:ui'
+)
+AND sr.name IN ('Atlas users');

--- a/src/main/resources/db/migration/postgresql/V2.7.0.20190222113000__permissions-fixes-source-codes-import.sql
+++ b/src/main/resources/db/migration/postgresql/V2.7.0.20190222113000__permissions-fixes-source-codes-import.sql
@@ -1,17 +1,27 @@
-ALTER TABLE ${ohdsiSchema}.sec_permission ADD COLUMN for_role_id INTEGER;
+CREATE TEMP TABLE temp_migration (
+  from_perm_id int,
+  new_value character varying(255)
+);
 
-INSERT INTO ${ohdsiSchema}.sec_permission (id, value, for_role_id)
-SELECT nextval('${ohdsiSchema}.sec_permission_id_seq'), REPLACE(CAST(new_perms.val AS VARCHAR(255)), '%s', REPLACE(REPLACE(value, 'cohortdefinition:*:generate:', ''), ':get', '')), role_id
+INSERT INTO temp_migration (from_perm_id, new_value)
+SELECT sp.id as from_id,
+  REPLACE(CAST(new_perms.val AS VARCHAR(255)), '%s', REPLACE(REPLACE(value, 'source:', ''), ':access', '')) as new_value
 FROM ${ohdsiSchema}.sec_permission sp
-  JOIN ${ohdsiSchema}.sec_role_permission srp on sp.id = srp.permission_id
-  CROSS JOIN (
-    SELECT 'vocabulary:%s:lookup:sourcecodes:post' val
-  ) new_perms
-WHERE sp.value LIKE 'cohortdefinition:*:generate:%:get';
+CROSS JOIN (
+  SELECT 'vocabulary:%s:lookup:sourcecodes:post' val
+) new_perms
+WHERE sp.value LIKE 'source:%:access';
 
-INSERT INTO ${ohdsiSchema}.sec_role_permission (id, role_id, permission_id)
-SELECT nextval('${ohdsiSchema}.sec_role_permission_sequence'), sp.for_role_id, sp.id
-FROM ${ohdsiSchema}.sec_permission sp
-WHERE sp.for_role_id IS NOT NULL;
+INSERT INTO ${ohdsiSchema}.sec_permission (id, value)
+SELECT nextval('${ohdsiSchema}.sec_permission_id_seq'), new_value
+FROM temp_migration;
 
-ALTER TABLE ${ohdsiSchema}.sec_permission DROP COLUMN for_role_id;
+INSERT INTO ${ohdsiSchema}.sec_role_permission (id,role_id, permission_id)
+SELECT nextval('${ohdsiSchema}.sec_role_permission_sequence'),
+  srp.role_id,
+  sp.id as permission_id
+FROM temp_migration m
+JOIN ${ohdsiSchema}.sec_permission sp on m.new_value = sp.value
+JOIN ${ohdsiSchema}.sec_role_permission srp on m.from_perm_id = srp.permission_id;
+
+drop table temp_migration;

--- a/src/main/resources/db/migration/postgresql/V2.7.0.20190304131519__standardize-permissions-cc.sql
+++ b/src/main/resources/db/migration/postgresql/V2.7.0.20190304131519__standardize-permissions-cc.sql
@@ -7,21 +7,31 @@ delete from ${ohdsiSchema}.sec_permission where
     value like 'cohort-characterization:%:generation:*:post' or
     value like 'cohort-characterization:%:generation:*:delete';
 
-alter table ${ohdsiSchema}.sec_permission add for_role_id int;
+CREATE TEMP TABLE temp_migration (
+  from_perm_id int,
+  new_value character varying(255)
+);
 
-INSERT INTO ${ohdsiSchema}.sec_permission (id, value, for_role_id)
-  SELECT nextval('${ohdsiSchema}.sec_permission_id_seq'), REPLACE(CAST(new_perms.val AS VARCHAR(255)), '%s', REPLACE(REPLACE(value, 'source:', ''), ':access', '')), role_id
+INSERT INTO temp_migration (from_perm_id, new_value)
+SELECT sp.id as from_id,
+  REPLACE(CAST(new_perms.val AS VARCHAR(255)), '%s', REPLACE(REPLACE(value, 'source:', ''), ':access', '')) as new_value
 FROM ${ohdsiSchema}.sec_permission sp
-JOIN ${ohdsiSchema}.sec_role_permission srp on sp.id = srp.permission_id
 CROSS JOIN (
   SELECT 'cohort-characterization:*:generation:%s:post' val UNION ALL
   SELECT 'cohort-characterization:*:generation:%s:delete' val
 ) new_perms
 WHERE sp.value LIKE 'source:%:access';
 
-INSERT INTO ${ohdsiSchema}.sec_role_permission (id, role_id, permission_id)
-  SELECT nextval('${ohdsiSchema}.sec_role_permission_sequence'), sp.for_role_id, sp.id
-  FROM ${ohdsiSchema}.sec_permission sp
-  WHERE sp.for_role_id IS NOT NULL;
+INSERT INTO ${ohdsiSchema}.sec_permission (id, value)
+SELECT nextval('${ohdsiSchema}.sec_permission_id_seq'), new_value
+FROM temp_migration;
 
-alter table ${ohdsiSchema}.sec_permission drop column for_role_id;
+INSERT INTO ${ohdsiSchema}.sec_role_permission (id,role_id, permission_id)
+SELECT nextval('${ohdsiSchema}.sec_role_permission_sequence'),
+  srp.role_id,
+  sp.id as permission_id
+FROM temp_migration m
+JOIN ${ohdsiSchema}.sec_permission sp on m.new_value = sp.value
+JOIN ${ohdsiSchema}.sec_role_permission srp on m.from_perm_id = srp.permission_id;
+
+drop table temp_migration;

--- a/src/main/resources/db/migration/postgresql/V2.7.0.20190304162609__standardize-permissions-ir.sql
+++ b/src/main/resources/db/migration/postgresql/V2.7.0.20190304162609__standardize-permissions-ir.sql
@@ -25,20 +25,30 @@ delete from ${ohdsiSchema}.sec_role_permission where
   permission_id in (select id from ${ohdsiSchema}.sec_permission where value like 'ir:%:report:*:get');
 delete from ${ohdsiSchema}.sec_permission where value like 'ir:%:report:*:get';
 
-alter table ${ohdsiSchema}.sec_permission add for_role_id int;
+CREATE TEMP TABLE temp_migration (
+  from_perm_id int,
+  new_value character varying(255)
+);
 
-INSERT INTO ${ohdsiSchema}.sec_permission (id, value, for_role_id)
-  SELECT nextval('${ohdsiSchema}.sec_permission_id_seq'), REPLACE(CAST(new_perms.val AS VARCHAR(255)), '%s', REPLACE(REPLACE(value, 'source:', ''), ':access', '')), role_id
-  FROM ${ohdsiSchema}.sec_permission sp
-    JOIN ${ohdsiSchema}.sec_role_permission srp on sp.id = srp.permission_id
-    CROSS JOIN (
-                 SELECT 'ir:*:report:%s:get' val
-               ) new_perms
-  WHERE sp.value LIKE 'source:%:access';
+INSERT INTO temp_migration (from_perm_id, new_value)
+SELECT sp.id as from_id,
+  REPLACE(CAST(new_perms.val AS VARCHAR(255)), '%s', REPLACE(REPLACE(value, 'source:', ''), ':access', '')) as new_value
+FROM ${ohdsiSchema}.sec_permission sp
+CROSS JOIN (
+  SELECT 'ir:*:report:%s:get' val
+) new_perms
+WHERE sp.value LIKE 'source:%:access';
 
-INSERT INTO ${ohdsiSchema}.sec_role_permission (id, role_id, permission_id)
-  SELECT nextval('${ohdsiSchema}.sec_role_permission_sequence'), sp.for_role_id, sp.id
-  FROM ${ohdsiSchema}.sec_permission sp
-  WHERE sp.for_role_id IS NOT NULL;
+INSERT INTO ${ohdsiSchema}.sec_permission (id, value)
+SELECT nextval('${ohdsiSchema}.sec_permission_id_seq'), new_value
+FROM temp_migration;
 
-alter table ${ohdsiSchema}.sec_permission drop column for_role_id;
+INSERT INTO ${ohdsiSchema}.sec_role_permission (id,role_id, permission_id)
+SELECT nextval('${ohdsiSchema}.sec_role_permission_sequence'),
+  srp.role_id,
+  sp.id as permission_id
+FROM temp_migration m
+JOIN ${ohdsiSchema}.sec_permission sp on m.new_value = sp.value
+JOIN ${ohdsiSchema}.sec_role_permission srp on m.from_perm_id = srp.permission_id;
+
+drop table temp_migration;

--- a/src/main/resources/db/migration/postgresql/V2.7.0.20190305123620__ir-executioninfo-permissions.sql
+++ b/src/main/resources/db/migration/postgresql/V2.7.0.20190305123620__ir-executioninfo-permissions.sql
@@ -1,17 +1,27 @@
-ALTER TABLE ${ohdsiSchema}.sec_permission ADD for_role_id INTEGER;
+CREATE TEMP TABLE temp_migration (
+  from_perm_id int,
+  new_value character varying(255)
+);
 
-INSERT INTO ${ohdsiSchema}.sec_permission (id, value, for_role_id)
-  SELECT nextval('${ohdsiSchema}.sec_permission_id_seq'), REPLACE(CAST(new_perms.val AS VARCHAR), '%s', REPLACE(REPLACE(value, 'source:', ''), ':access', '')), role_id
+INSERT INTO temp_migration (from_perm_id, new_value)
+SELECT sp.id as from_id,
+  REPLACE(CAST(new_perms.val AS VARCHAR(255)), '%s', REPLACE(REPLACE(value, 'source:', ''), ':access', '')) as new_value
 FROM ${ohdsiSchema}.sec_permission sp
-JOIN ${ohdsiSchema}.sec_role_permission srp on sp.id = srp.permission_id
 CROSS JOIN (
   SELECT 'ir:*:info:%s:get' val
 ) new_perms
 WHERE sp.value LIKE 'source:%:access';
 
-INSERT INTO ${ohdsiSchema}.sec_role_permission (id, role_id, permission_id)
-  SELECT nextval('${ohdsiSchema}.sec_role_permission_sequence'), sp.for_role_id, sp.id
-FROM ${ohdsiSchema}.sec_permission sp
-WHERE sp.for_role_id IS NOT NULL;
+INSERT INTO ${ohdsiSchema}.sec_permission (id, value)
+SELECT nextval('${ohdsiSchema}.sec_permission_id_seq'), new_value
+FROM temp_migration;
 
-ALTER TABLE ${ohdsiSchema}.sec_permission DROP COLUMN for_role_id;
+INSERT INTO ${ohdsiSchema}.sec_role_permission (id,role_id, permission_id)
+SELECT nextval('${ohdsiSchema}.sec_role_permission_sequence'),
+  srp.role_id,
+  sp.id as permission_id
+FROM temp_migration m
+JOIN ${ohdsiSchema}.sec_permission sp on m.new_value = sp.value
+JOIN ${ohdsiSchema}.sec_role_permission srp on m.from_perm_id = srp.permission_id;
+
+drop table temp_migration;

--- a/src/main/resources/db/migration/postgresql/V2.7.2.20190528153600__fix-ir-report-perms.sql
+++ b/src/main/resources/db/migration/postgresql/V2.7.2.20190528153600__fix-ir-report-perms.sql
@@ -1,5 +1,3 @@
---alter table ${ohdsiSchema}.sec_permission add for_role_id int;
-
 CREATE TEMP TABLE temp_migration (
   from_perm_id int,
   new_value character varying(255)
@@ -7,10 +5,10 @@ CREATE TEMP TABLE temp_migration (
 
 INSERT INTO temp_migration (from_perm_id, new_value)
 SELECT sp.id as from_id,
-	REPLACE(CAST(new_perms.val AS VARCHAR(255)), '%s', REPLACE(REPLACE(value, 'source:', ''), ':access', '')) as new_value
+  REPLACE(CAST(new_perms.val AS VARCHAR(255)), '%s', REPLACE(REPLACE(value, 'source:', ''), ':access', '')) as new_value
 FROM ${ohdsiSchema}.sec_permission sp
 CROSS JOIN (
-	SELECT 'ir:%s:info:*:delete' val
+  SELECT 'ir:%s:info:*:delete' val
 ) new_perms
 WHERE sp.value LIKE 'source:%:access';
 

--- a/src/main/resources/db/migration/postgresql/V2.7.2.20190528153600__fix-ir-report-perms.sql
+++ b/src/main/resources/db/migration/postgresql/V2.7.2.20190528153600__fix-ir-report-perms.sql
@@ -1,17 +1,29 @@
-alter table ${ohdsiSchema}.sec_permission add for_role_id int;
+--alter table ${ohdsiSchema}.sec_permission add for_role_id int;
 
-INSERT INTO ${ohdsiSchema}.sec_permission (id, value, for_role_id)
-  SELECT nextval('${ohdsiSchema}.sec_permission_id_seq'), REPLACE(CAST(new_perms.val AS VARCHAR(255)), '%s', REPLACE(REPLACE(value, 'source:', ''), ':access', '')), role_id
-  FROM ${ohdsiSchema}.sec_permission sp
-    JOIN ${ohdsiSchema}.sec_role_permission srp on sp.id = srp.permission_id
-    CROSS JOIN (
-                 SELECT 'ir:%s:info:*:delete' val
-               ) new_perms
-  WHERE sp.value LIKE 'source:%:access';
+CREATE TEMP TABLE temp_migration (
+  from_perm_id int,
+  new_value character varying(255)
+);
 
-INSERT INTO ${ohdsiSchema}.sec_role_permission (id, role_id, permission_id)
-  SELECT nextval('${ohdsiSchema}.sec_role_permission_sequence'), sp.for_role_id, sp.id
-  FROM ${ohdsiSchema}.sec_permission sp
-  WHERE sp.for_role_id IS NOT NULL;
+INSERT INTO temp_migration (from_perm_id, new_value)
+SELECT sp.id as from_id,
+	REPLACE(CAST(new_perms.val AS VARCHAR(255)), '%s', REPLACE(REPLACE(value, 'source:', ''), ':access', '')) as new_value
+FROM ${ohdsiSchema}.sec_permission sp
+CROSS JOIN (
+	SELECT 'ir:%s:info:*:delete' val
+) new_perms
+WHERE sp.value LIKE 'source:%:access';
 
-alter table ${ohdsiSchema}.sec_permission drop column for_role_id;
+INSERT INTO ${ohdsiSchema}.sec_permission (id, value)
+SELECT nextval('${ohdsiSchema}.sec_permission_id_seq'), new_value
+FROM temp_migration;
+
+INSERT INTO ${ohdsiSchema}.sec_role_permission (id,role_id, permission_id)
+SELECT nextval('${ohdsiSchema}.sec_role_permission_sequence'),
+  srp.role_id,
+  sp.id as permission_id
+FROM temp_migration m
+JOIN ${ohdsiSchema}.sec_permission sp on m.new_value = sp.value
+JOIN ${ohdsiSchema}.sec_role_permission srp on m.from_perm_id = srp.permission_id;
+
+drop table temp_migration;


### PR DESCRIPTION
Fixes #2141.

The problem with the existing migrations was that if you had multiple roles assigned to the given permission, the old way of adding 'for_role_id' in the table and then inserting new permissions into it led to duplicate permission keys because > 1 role would result in multiple rows being inserted into the table.

The new approach stores the new permission 'key' with the permission_id that the permission came form, and inserts the single permission once, but then the multiple roles based on the original permission id.

