### PR TITLE
Changing Java version 11 to 8 in the docker settings is recommended.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,7 @@ RUN mvn package \
     && jar -xf WebAPI.war \
     && rm WebAPI.war
 
-# OHDSI WebAPI and ATLAS web application running as a Spring Boot application with Java 11
+# OHDSI WebAPI and ATLAS web application running as a Spring Boot application with Java 8
 FROM openjdk:8-jre-slim
 
 MAINTAINER Lee Evans - www.ltscomputingllc.com

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM maven:3.6-jdk-11 as builder
+FROM maven:3.6-jdk-8 as builder
 
 WORKDIR /code
 
@@ -26,7 +26,7 @@ RUN mvn package \
     && rm WebAPI.war
 
 # OHDSI WebAPI and ATLAS web application running as a Spring Boot application with Java 11
-FROM openjdk:11-jre-slim
+FROM openjdk:8-jre-slim
 
 MAINTAINER Lee Evans - www.ltscomputingllc.com
 

--- a/pom.xml
+++ b/pom.xml
@@ -1179,8 +1179,6 @@
         <maven.gitcommitid.skip>true</maven.gitcommitid.skip>
         <miredot.phase>none</miredot.phase>
         <skipTests>true</skipTests>
-        <maven.compiler.source>8</maven.compiler.source>
-        <maven.compiler.target>8</maven.compiler.target>
         <datasource.driverClassName>org.postgresql.Driver</datasource.driverClassName>
         <datasource.url>jdbc:postgresql://54.209.111.128:5432/vocabularyv5</datasource.url>
         <datasource.username>USER</datasource.username>

--- a/pom.xml
+++ b/pom.xml
@@ -1179,8 +1179,8 @@
         <maven.gitcommitid.skip>true</maven.gitcommitid.skip>
         <miredot.phase>none</miredot.phase>
         <skipTests>true</skipTests>
-        <maven.compiler.source>11</maven.compiler.source>
-        <maven.compiler.target>11</maven.compiler.target>
+        <maven.compiler.source>8</maven.compiler.source>
+        <maven.compiler.target>8</maven.compiler.target>
         <datasource.driverClassName>org.postgresql.Driver</datasource.driverClassName>
         <datasource.url>jdbc:postgresql://54.209.111.128:5432/vocabularyv5</datasource.url>
         <datasource.username>USER</datasource.username>


### PR DESCRIPTION
I am using Atlas and WebAPI version 2.8.2 because of SQL Server compatibility.

I ran into a problem with the Java version while running in docker.

Changing Java version 11 to 8 in the docker settings is recommended.
