### PR TITLE
Switch to Eclipse Temurin Java base image due to openjdk deprecation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,8 +28,8 @@ RUN mvn package \
     && jar -xf WebAPI.war \
     && rm WebAPI.war
 
-# OHDSI WebAPI and ATLAS web application running as a Spring Boot application with Java 11
-FROM openjdk:8-jre-slim
+# OHDSI WebAPI and ATLAS web application running as a Spring Boot application with Java 8
+FROM index.docker.io/library/eclipse-temurin:8-jre
 
 MAINTAINER Lee Evans - www.ltscomputingllc.com
 


### PR DESCRIPTION
Follow-up from https://github.com/OHDSI/WebAPI/pull/2133#issue-1406583486

Because the openjdk image is deprecated (https://hub.docker.com/_/openjdk), this switches the base image to an OpenJDK image build by Eclipse Temurin.