### PR TITLE
Bump Hydra version - fixes #2162

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
     <bouncycastle.version>1.69</bouncycastle.version>
     <shiro.version>1.9.1</shiro.version>
     <dom4j.version>2.1.3</dom4j.version>
-    <hydra.version>0.3.0</hydra.version>
+    <hydra.version>0.4.0-SNAPSHOT</hydra.version>
     <featureExtraction.version>3.2.0</featureExtraction.version>
     <tomcat.embed.version>8.5.82</tomcat.embed.version>
 


### PR DESCRIPTION
Updates the Hydra reference to use a patch for the PLP skeleton. 