### PR TITLE
Possible memory leak in auditTrail #2192 - exclude WebAPI/info calls

### DIFF
--- a/src/main/java/org/ohdsi/webapi/audittrail/AuditTrailAspect.java
+++ b/src/main/java/org/ohdsi/webapi/audittrail/AuditTrailAspect.java
@@ -49,13 +49,17 @@ public class AuditTrailAspect {
     @Pointcut("execution(public * org.ohdsi.webapi.service.VocabularyService.getInfo(..))")
     public void vocabularyServiceGetInfoPointcut() {
     }
+    @Pointcut("execution(public * org.ohdsi.webapi.info.InfoService.getInfo(..))")
+    public void webapiGetInfoPointcut() {
+    }
 
     @Around("(restGetPointcut() || restPostPointcut() || restPutPointcut() || restDeletePointcut() || irResource())" +
             " && " +
             // exclude system calls
             "!notificationsPointcut() && " +
             "!executionenginePointcut() && " +
-            "!vocabularyServiceGetInfoPointcut()")
+            "!vocabularyServiceGetInfoPointcut() && " +
+            "!webapiGetInfoPointcut()")
     public Object auditLog(final ProceedingJoinPoint joinPoint) throws Throwable {
         final HttpServletRequest request = getHttpServletRequest();
 


### PR DESCRIPTION
Excluide /info calls from AuditTrail processing. Do not close the task - it requires additional research on possible memory leaks.