### PR TITLE
Bump up several libraries

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -705,15 +705,14 @@
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-cache</artifactId>
     </dependency>
-    <dependency>
-      <groupId>javax.cache</groupId>
-      <artifactId>cache-api</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.ehcache</groupId>
-      <artifactId>ehcache</artifactId>
-      <version>3.8.1</version>
-    </dependency>
+<!--    <dependency>-->
+<!--      <groupId>javax.cache</groupId>-->
+<!--      <artifactId>cache-api</artifactId>-->
+<!--    </dependency>-->
+<!--    <dependency>-->
+<!--      <groupId>org.ehcache</groupId>-->
+<!--      <artifactId>ehcache</artifactId>-->
+<!--    </dependency>-->
     <dependency>
       <groupId>org.hibernate</groupId>
       <artifactId>hibernate-core</artifactId>
@@ -790,7 +789,7 @@
     <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-lang3</artifactId>
-      <version>3.9</version>
+      <version>3.12.0</version>
     </dependency>
     <dependency>
       <groupId>org.flywaydb</groupId>
@@ -801,11 +800,6 @@
       <groupId>org.apache.httpcomponents</groupId>
       <artifactId>httpclient</artifactId>
       <version>4.5.13</version>
-    </dependency>
-    <dependency>
-      <groupId>commons-httpclient</groupId>
-      <artifactId>commons-httpclient</artifactId>
-      <version>3.1</version>
     </dependency>
     <dependency>
       <groupId>org.springframework.batch</groupId>
@@ -851,7 +845,7 @@
     <dependency>
       <groupId>com.microsoft.sqlserver</groupId>
       <artifactId>mssql-jdbc</artifactId>
-      <version>9.2.1.jre8</version>
+      <version>10.2.1.jre8</version>
     </dependency>
     <dependency>
       <groupId>com.microsoft.azure</groupId>
@@ -1022,12 +1016,12 @@
     <dependency>
       <groupId>com.zaxxer</groupId>
       <artifactId>HikariCP</artifactId>
-      <version>3.3.1</version>
+      <version>4.0.3</version>
     </dependency>
     <dependency>
       <groupId>com.google.code.gson</groupId>
       <artifactId>gson</artifactId>
-      <version>2.8.9</version>
+      <version>2.9.0</version>
     </dependency>
     <dependency>
       <groupId>org.jasypt</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -705,14 +705,6 @@
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-cache</artifactId>
     </dependency>
-<!--    <dependency>-->
-<!--      <groupId>javax.cache</groupId>-->
-<!--      <artifactId>cache-api</artifactId>-->
-<!--    </dependency>-->
-<!--    <dependency>-->
-<!--      <groupId>org.ehcache</groupId>-->
-<!--      <artifactId>ehcache</artifactId>-->
-<!--    </dependency>-->
     <dependency>
       <groupId>org.hibernate</groupId>
       <artifactId>hibernate-core</artifactId>


### PR DESCRIPTION
Removed the following unused libraries:
- org.ehcache:ehcache 3.8.1
- javax.cache:cache-api 1.0.0
- commons-httpclient:commons-httpclient 3.1

Upgraded the following to versions provided by SPring Boot 2.7 
-- org.apache.commons:commons-lang3 3.9 -> 3.12.0
-- com.google.code.gson:gson 2.8.9 -> 2.9.0
-- com.zaxxer:HikariCP 3.3.1 -> 4.0.3
-- com.microsoft.sqlserver:mssql-jdbc 9.2.1.jre8 -> 10.2.1.jre8