### PR TITLE
Switch isNumeric() to anayisID test when casting.

### DIFF
--- a/src/main/resources/resources/cdmresults/sql/report/condition/drilldown/ageAtFirstOccurrence.sql
+++ b/src/main/resources/resources/cdmresults/sql/report/condition/drilldown/ageAtFirstOccurrence.sql
@@ -11,9 +11,9 @@ SELECT
 FROM @results_database_schema.achilles_results_dist ard1
 INNER JOIN
 @vocab_database_schema.concept c1
-ON CAST(CASE WHEN isNumeric(ard1.stratum_1) = 1 THEN ard1.stratum_1 ELSE null END AS INT) = c1.concept_id
+ON CAST(CASE WHEN ard1.analysis_id = 406 THEN ard1.stratum_1 ELSE null END AS INT) = c1.concept_id
 INNER JOIN
 @vocab_database_schema.concept c2
-ON CAST(CASE WHEN isNumeric(ard1.stratum_2) = 1 THEN ard1.stratum_2 ELSE null END AS INT) = c2.concept_id
+ON CAST(CASE WHEN ard1.analysis_id = 406 THEN ard1.stratum_2 ELSE null END AS INT) = c2.concept_id
 WHERE ard1.analysis_id = 406
 AND c1.concept_id = @conceptId

--- a/src/main/resources/resources/cdmresults/sql/report/condition/drilldown/prevalenceByGenderAgeYear.sql
+++ b/src/main/resources/resources/cdmresults/sql/report/condition/drilldown/prevalenceByGenderAgeYear.sql
@@ -1,17 +1,18 @@
 SELECT
   c1.concept_id                                                          AS concept_id,
   c1.concept_name                                                        AS concept_name,
-  CONCAT(cast(CAST(CASE WHEN isNumeric(num_stratum_4) = 1 THEN num_stratum_4 ELSE null END AS INT) * 10 AS VARCHAR(11)), 
-          '-', cast((CAST(CASE WHEN isNumeric(num_stratum_4) = 1 THEN num_stratum_4 ELSE null END AS INT) + 1) * 10 - 1 AS VARCHAR(11))) AS trellis_name,
+  CONCAT(cast(CAST(CASE WHEN num_analysis_id = 404 THEN num_stratum_4 ELSE null END AS INT) * 10 AS VARCHAR(11)), 
+          '-', cast((CAST(CASE WHEN num_analysis_id = 404 THEN num_stratum_4 ELSE null END AS INT) + 1) * 10 - 1 AS VARCHAR(11))) AS trellis_name,
   --age decile
   c2.concept_name                                                        AS series_name,
   --gender
-  CAST(CASE WHEN isNumeric(num_stratum_2) = 1 THEN num_stratum_2 ELSE null END AS INT)                                             AS x_calendar_year,
+  CAST(CASE WHEN num_analysis_id = 404 THEN num_stratum_2 ELSE null END AS INT)                                             AS x_calendar_year,
   -- calendar year, note, there could be blanks
   ROUND(1000 * (1.0 * num_count_value / denom_count_value),
         5)                                                               AS y_prevalence_1000_pp --prevalence, per 1000 persons
 FROM (
        SELECT
+         num.analysis_id   AS num_analysis_id,
          num.stratum_1     AS num_stratum_1,
          num.stratum_2     AS num_stratum_2,
          num.stratum_3     AS num_stratum_3,
@@ -35,9 +36,9 @@ FROM (
               AND num.stratum_4 = denom.stratum_3
      ) tmp
   INNER JOIN @vocab_database_schema.concept c1
-ON CAST(CASE WHEN isNumeric(num_stratum_1) = 1 THEN num_stratum_1 ELSE null END AS INT) = c1.concept_id
+ON CAST(CASE WHEN num_analysis_id = 404 THEN num_stratum_1 ELSE null END AS INT) = c1.concept_id
 INNER JOIN @vocab_database_schema.concept c2
-ON CAST(CASE WHEN isNumeric(num_stratum_3) = 1 THEN num_stratum_3 ELSE null END AS INT) = c2.concept_id
+ON CAST(CASE WHEN num_analysis_id = 404 THEN num_stratum_3 ELSE null END AS INT) = c2.concept_id
 WHERE c1.concept_id = @conceptId
 ORDER BY c1.concept_id,
 num_stratum_2

--- a/src/main/resources/resources/cdmresults/sql/report/condition/drilldown/prevalenceByMonth.sql
+++ b/src/main/resources/resources/cdmresults/sql/report/condition/drilldown/prevalenceByMonth.sql
@@ -6,14 +6,14 @@ SELECT
   round(1000 * (1.0 * num.count_value / denom.count_value), 5) AS y_prevalence_1000_pp --prevalence, per 1000 persons
 FROM
   (SELECT
-     CAST(CASE WHEN isNumeric(stratum_1) = 1 THEN stratum_1 ELSE null END AS BIGINT) stratum_1,
-     CAST(CASE WHEN isNumeric(stratum_2) = 1 THEN stratum_2 ELSE null END AS INT) stratum_2,
+     CAST(CASE WHEN analysis_id = 402 THEN stratum_1 ELSE null END AS BIGINT) stratum_1,
+     CAST(CASE WHEN analysis_id = 402 THEN stratum_2 ELSE null END AS INT) stratum_2,
      count_value
    FROM
      @results_database_schema.achilles_results WHERE analysis_id = 402 GROUP BY analysis_id, stratum_1, stratum_2, count_value) num
   INNER JOIN
   (SELECT
-     CAST(stratum_1 AS INT) stratum_1,
+     CAST(CASE WHEN analysis_id = 117 THEN stratum_1 ELSE null END AS INT) stratum_1,
      count_value
    FROM
      @results_database_schema.achilles_results WHERE analysis_id = 117 GROUP BY analysis_id, stratum_1, count_value) denom

--- a/src/main/resources/resources/cdmresults/sql/report/condition/drilldownsummary/ageAtFirstOccurrence.sql
+++ b/src/main/resources/resources/cdmresults/sql/report/condition/drilldownsummary/ageAtFirstOccurrence.sql
@@ -11,8 +11,8 @@ SELECT
 FROM @results_database_schema.achilles_results_dist ard1
 INNER JOIN
 @vocab_database_schema.concept c1
-ON CAST(CASE WHEN isNumeric(ard1.stratum_1) = 1 THEN ard1.stratum_1 ELSE null END AS INT) = c1.concept_id
+ON CAST(CASE WHEN ard1.analysis_id = 406 THEN ard1.stratum_1 ELSE null END AS INT) = c1.concept_id
 INNER JOIN
 @vocab_database_schema.concept c2
-ON CAST(CASE WHEN isNumeric(ard1.stratum_2) = 1 THEN ard1.stratum_2 ELSE null END AS INT) = c2.concept_id
+ON CAST(CASE WHEN ard1.analysis_id = 406 THEN ard1.stratum_2 ELSE null END AS INT) = c2.concept_id
 WHERE ard1.analysis_id = 406

--- a/src/main/resources/resources/cdmresults/sql/report/condition/drilldownsummary/prevalenceByGenderAgeYear.sql
+++ b/src/main/resources/resources/cdmresults/sql/report/condition/drilldownsummary/prevalenceByGenderAgeYear.sql
@@ -1,17 +1,18 @@
 SELECT
   c1.concept_id                                                          AS concept_id,
   c1.concept_name                                                        AS concept_name,
-  CONCAT(cast(CAST(CASE WHEN isNumeric(num_stratum_4) = 1 THEN num_stratum_4 ELSE null END AS INT) * 10 AS VARCHAR(11)), 
-          '-', cast((CAST(CASE WHEN isNumeric(num_stratum_4) = 1 THEN num_stratum_4 ELSE null END AS INT) + 1) * 10 - 1 AS VARCHAR(11))) AS trellis_name,
+  CONCAT(cast(CAST(CASE WHEN num_analysis_id = 404 THEN num_stratum_4 ELSE null END AS INT) * 10 AS VARCHAR(11)), 
+          '-', cast((CAST(CASE WHEN num_analysis_id = 404 THEN num_stratum_4 ELSE null END AS INT) + 1) * 10 - 1 AS VARCHAR(11))) AS trellis_name,
   --age decile
   c2.concept_name                                                        AS series_name,
   --gender
-  CAST(CASE WHEN isNumeric(num_stratum_2) = 1 THEN num_stratum_2 ELSE null END AS INT)                                             AS x_calendar_year,
+  CAST(CASE WHEN num_analysis_id = 404 THEN num_stratum_2 ELSE null END AS INT)                                             AS x_calendar_year,
   -- calendar year, note, there could be blanks
   ROUND(1000 * (1.0 * num_count_value / denom_count_value),
         5)                                                               AS y_prevalence_1000_pp --prevalence, per 1000 persons
 FROM (
        SELECT
+         num.analysis_id   AS num_analysis_id,
          num.stratum_1     AS num_stratum_1,
          num.stratum_2     AS num_stratum_2,
          num.stratum_3     AS num_stratum_3,
@@ -35,8 +36,8 @@ FROM (
               AND num.stratum_4 = denom.stratum_3
      ) tmp
   INNER JOIN @vocab_database_schema.concept c1
-ON CAST(CASE WHEN isNumeric(num_stratum_1) = 1 THEN num_stratum_1 ELSE null END AS INT) = c1.concept_id
+ON CAST(CASE WHEN num_analysis_id = 404 THEN num_stratum_1 ELSE null END AS INT) = c1.concept_id
 INNER JOIN @vocab_database_schema.concept c2
-ON CAST(CASE WHEN isNumeric(num_stratum_3) = 1 THEN num_stratum_3 ELSE null END AS INT) = c2.concept_id
+ON CAST(CASE WHEN num_analysis_id = 404 THEN num_stratum_3 ELSE null END AS INT) = c2.concept_id
 ORDER BY c1.concept_id,
 num_stratum_2

--- a/src/main/resources/resources/cdmresults/sql/report/condition/drilldownsummary/prevalenceByMonth.sql
+++ b/src/main/resources/resources/cdmresults/sql/report/condition/drilldownsummary/prevalenceByMonth.sql
@@ -6,14 +6,14 @@ SELECT
   round(1000 * (1.0 * num.count_value / denom.count_value), 5) AS y_prevalence_1000_pp --prevalence, per 1000 persons
 FROM
   (SELECT
-     CAST(CASE WHEN isNumeric(stratum_1) = 1 THEN stratum_1 ELSE null END AS BIGINT) stratum_1,
-     CAST(CASE WHEN isNumeric(stratum_2) = 1 THEN stratum_2 ELSE null END AS INT) stratum_2,
+     CAST(CASE WHEN analysis_id = 402 THEN stratum_1 ELSE null END AS BIGINT) stratum_1,
+     CAST(CASE WHEN analysis_id = 402 THEN stratum_2 ELSE null END AS INT) stratum_2,
      count_value
    FROM
      @results_database_schema.achilles_results WHERE analysis_id = 402 GROUP BY analysis_id, stratum_1, stratum_2, count_value) num
   INNER JOIN
   (SELECT
-     CAST(stratum_1 AS INT) stratum_1,
+     CAST(CASE WHEN analysis_id = 117 THEN stratum_1 ELSE null END AS INT) stratum_1,
      count_value
    FROM
      @results_database_schema.achilles_results WHERE analysis_id = 117 GROUP BY analysis_id, stratum_1, count_value) denom

--- a/src/main/resources/resources/cdmresults/sql/report/condition/treemap.sql
+++ b/src/main/resources/resources/cdmresults/sql/report/condition/treemap.sql
@@ -18,7 +18,7 @@ FROM (SELECT *
     ON ar1.stratum_1 = ar2.stratum_1
   INNER JOIN
   @results_database_schema.concept_hierarchy concept_hierarchy
-    ON CAST(CASE WHEN isNumeric(ar1.stratum_1) = 1 THEN ar1.stratum_1 ELSE null END AS INT) = concept_hierarchy.concept_id
+    ON CAST(CASE WHEN ar1.analysis_id = 400 THEN ar1.stratum_1 ELSE null END AS INT) = concept_hierarchy.concept_id
     AND concept_hierarchy.treemap='Condition'
 ,
   (SELECT count_value

--- a/src/main/resources/resources/cdmresults/sql/report/conditionera/drilldown/ageAtFirstOccurrence.sql
+++ b/src/main/resources/resources/cdmresults/sql/report/conditionera/drilldown/ageAtFirstOccurrence.sql
@@ -10,9 +10,9 @@ SELECT
   ard1.max_value    AS max_value
 FROM @results_database_schema.achilles_results_dist ard1
 INNER JOIN @vocab_database_schema.concept c1
-ON CAST(CASE WHEN isNumeric(ard1.stratum_1) = 1 THEN ard1.stratum_1 ELSE null END AS INT) = c1.concept_id
+ON CAST(CASE WHEN ard1.analysis_id = 1006 THEN ard1.stratum_1 ELSE null END AS INT) = c1.concept_id
 INNER JOIN @vocab_database_schema.concept c2
-ON CAST(CASE WHEN isNumeric(ard1.stratum_2) = 1 THEN ard1.stratum_2 ELSE null END AS INT) = c2.concept_id
+ON CAST(CASE WHEN ard1.analysis_id = 1006 THEN ard1.stratum_2 ELSE null END AS INT) = c2.concept_id
 WHERE ard1.analysis_id = 1006
 AND c1.concept_id = @conceptId
 AND ard1.count_value > 0

--- a/src/main/resources/resources/cdmresults/sql/report/conditionera/drilldown/lengthOfEra.sql
+++ b/src/main/resources/resources/cdmresults/sql/report/conditionera/drilldown/lengthOfEra.sql
@@ -9,7 +9,7 @@ SELECT
   ard1.p90_value    AS p90_value,
   ard1.max_value    AS max_value
 FROM @results_database_schema.achilles_results_dist ard1
-INNER JOIN @vocab_database_schema.concept c1 ON CAST(CASE WHEN isNumeric(ard1.stratum_1) = 1 THEN ard1.stratum_1 ELSE null END AS INT) = c1.concept_id
+INNER JOIN @vocab_database_schema.concept c1 ON CAST(CASE WHEN ard1.analysis_id = 1007 THEN ard1.stratum_1 ELSE null END AS INT) = c1.concept_id
 WHERE ard1.analysis_id = 1007 AND ard1.count_value > 0
 AND c1.concept_id = @conceptId
 

--- a/src/main/resources/resources/cdmresults/sql/report/conditionera/drilldown/prevalenceByGenderAgeYear.sql
+++ b/src/main/resources/resources/cdmresults/sql/report/conditionera/drilldown/prevalenceByGenderAgeYear.sql
@@ -1,16 +1,17 @@
 SELECT
   c1.concept_id                                                          AS concept_id,
-  CONCAT(cast(CAST(CASE WHEN isNumeric(num_stratum_4) = 1 THEN num_stratum_4 ELSE null END AS INT) * 10 AS VARCHAR(11)), 
-          '-', cast((CAST(CASE WHEN isNumeric(num_stratum_4) = 1 THEN num_stratum_4 ELSE null END AS INT) + 1) * 10 - 1 AS VARCHAR(11))) AS trellis_name,
+  CONCAT(cast(CAST(CASE WHEN num_analysis_id = 1004 THEN num_stratum_4 ELSE null END AS INT) * 10 AS VARCHAR(11)), 
+          '-', cast((CAST(CASE WHEN num_analysis_id = 1004 THEN num_stratum_4 ELSE null END AS INT) + 1) * 10 - 1 AS VARCHAR(11))) AS trellis_name,
   --age decile
   c2.concept_name                                                        AS series_name,
   --gender
-  CAST(CASE WHEN isNumeric(num_stratum_2) = 1 THEN num_stratum_2 ELSE null END AS INT)                                             AS x_calendar_year,
+  CAST(CASE WHEN num_analysis_id = 1004 THEN num_stratum_2 ELSE null END AS INT)                                             AS x_calendar_year,
   -- calendar year, note, there could be blanks
   ROUND(1000 * (1.0 * num_count_value / denom_count_value),
         5)                                                               AS y_prevalence_1000_pp --prevalence, per 1000 persons
 FROM (
        SELECT
+         num.analysis_id   AS num_analysis_id,
          num.stratum_1     AS num_stratum_1,
          num.stratum_2     AS num_stratum_2,
          num.stratum_3     AS num_stratum_3,
@@ -34,9 +35,9 @@ FROM (
               AND num.stratum_4 = denom.stratum_3
      ) tmp
   INNER JOIN @vocab_database_schema.concept c1
-ON CAST(CASE WHEN isNumeric(num_stratum_1) = 1 THEN num_stratum_1 ELSE null END AS INT) = c1.concept_id
+ON CAST(CASE WHEN num_analysis_id = 1004 THEN num_stratum_1 ELSE null END AS INT) = c1.concept_id
 INNER JOIN @vocab_database_schema.concept c2
-ON CAST(CASE WHEN isNumeric(num_stratum_3) = 1 THEN num_stratum_3 ELSE null END AS INT) = c2.concept_id
+ON CAST(CASE WHEN num_analysis_id = 1004 THEN num_stratum_3 ELSE null END AS INT) = c2.concept_id
 WHERE c1.concept_id = @conceptId
 ORDER BY c1.concept_id,
 num_stratum_2

--- a/src/main/resources/resources/cdmresults/sql/report/conditionera/drilldown/prevalenceByMonth.sql
+++ b/src/main/resources/resources/cdmresults/sql/report/conditionera/drilldown/prevalenceByMonth.sql
@@ -11,5 +11,5 @@ FROM
     ON num.stratum_2 = denom.stratum_1
   --calendar year
   INNER JOIN
-  @vocab_database_schema.concept c1 ON CAST(CASE WHEN isNumeric(num.stratum_1) = 1 THEN num.stratum_1 ELSE null END AS INT) = c1.concept_id
+  @vocab_database_schema.concept c1 ON CAST(CASE WHEN analysis_id = 1002 THEN num.stratum_1 ELSE null END AS INT) = c1.concept_id
 WHERE c1.concept_id = @conceptId

--- a/src/main/resources/resources/cdmresults/sql/report/conditionera/drilldownsummary/ageAtFirstOccurrence.sql
+++ b/src/main/resources/resources/cdmresults/sql/report/conditionera/drilldownsummary/ageAtFirstOccurrence.sql
@@ -10,8 +10,8 @@ SELECT
   ard1.max_value    AS max_value
 FROM @results_database_schema.achilles_results_dist ard1
 INNER JOIN @vocab_database_schema.concept c1
-ON CAST(CASE WHEN isNumeric(ard1.stratum_1) = 1 THEN ard1.stratum_1 ELSE null END AS INT) = c1.concept_id
+ON CAST(CASE WHEN ard1.analysis_id = 1006 THEN ard1.stratum_1 ELSE null END AS INT) = c1.concept_id
 INNER JOIN @vocab_database_schema.concept c2
-ON CAST(CASE WHEN isNumeric(ard1.stratum_2) = 1 THEN ard1.stratum_2 ELSE null END AS INT) = c2.concept_id
+ON CAST(CASE WHEN ard1.analysis_id = 1006 THEN ard1.stratum_2 ELSE null END AS INT) = c2.concept_id
 WHERE ard1.analysis_id = 1006
 AND ard1.count_value > 0

--- a/src/main/resources/resources/cdmresults/sql/report/conditionera/drilldownsummary/lengthOfEra.sql
+++ b/src/main/resources/resources/cdmresults/sql/report/conditionera/drilldownsummary/lengthOfEra.sql
@@ -9,7 +9,7 @@ SELECT
   ard1.p90_value    AS p90_value,
   ard1.max_value    AS max_value
 FROM @results_database_schema.achilles_results_dist ard1
-INNER JOIN @vocab_database_schema.concept c1 ON CAST(CASE WHEN isNumeric(ard1.stratum_1) = 1 THEN ard1.stratum_1 ELSE null END AS INT) = c1.concept_id
+INNER JOIN @vocab_database_schema.concept c1 ON CAST(CASE WHEN ard1.analysis_id = 1007 THEN ard1.stratum_1 ELSE null END AS INT) = c1.concept_id
 WHERE ard1.analysis_id = 1007 AND ard1.count_value > 0
 
 

--- a/src/main/resources/resources/cdmresults/sql/report/conditionera/drilldownsummary/prevalenceByGenderAgeYear.sql
+++ b/src/main/resources/resources/cdmresults/sql/report/conditionera/drilldownsummary/prevalenceByGenderAgeYear.sql
@@ -1,16 +1,17 @@
 SELECT
   c1.concept_id                                                          AS concept_id,
-  CONCAT(cast(CAST(CASE WHEN isNumeric(num_stratum_4) = 1 THEN num_stratum_4 ELSE null END AS INT) * 10 AS VARCHAR(11)), 
-          '-', cast((CAST(CASE WHEN isNumeric(num_stratum_4) = 1 THEN num_stratum_4 ELSE null END AS INT) + 1) * 10 - 1 AS VARCHAR(11))) AS trellis_name,
+  CONCAT(cast(CAST(CASE WHEN num_analysis_id = 1004 THEN num_stratum_4 ELSE null END AS INT) * 10 AS VARCHAR(11)), 
+          '-', cast((CAST(CASE WHEN num_analysis_id = 1004 THEN num_stratum_4 ELSE null END AS INT) + 1) * 10 - 1 AS VARCHAR(11))) AS trellis_name,
   --age decile
   c2.concept_name                                                        AS series_name,
   --gender
-  CAST(CASE WHEN isNumeric(num_stratum_2) = 1 THEN num_stratum_2 ELSE null END AS INT)                                             AS x_calendar_year,
+  CAST(CASE WHEN num_analysis_id = 1004 THEN num_stratum_2 ELSE null END AS INT)                                             AS x_calendar_year,
   -- calendar year, note, there could be blanks
   ROUND(1000 * (1.0 * num_count_value / denom_count_value),
         5)                                                               AS y_prevalence_1000_pp --prevalence, per 1000 persons
 FROM (
        SELECT
+         num.analysis_id   AS num_analysis_id,
          num.stratum_1     AS num_stratum_1,
          num.stratum_2     AS num_stratum_2,
          num.stratum_3     AS num_stratum_3,
@@ -34,8 +35,8 @@ FROM (
               AND num.stratum_4 = denom.stratum_3
      ) tmp
   INNER JOIN @vocab_database_schema.concept c1
-ON CAST(CASE WHEN isNumeric(num_stratum_1) = 1 THEN num_stratum_1 ELSE null END AS INT) = c1.concept_id
+ON CAST(CASE WHEN num_analysis_id = 1004 THEN num_stratum_1 ELSE null END AS INT) = c1.concept_id
 INNER JOIN @vocab_database_schema.concept c2
-ON CAST(CASE WHEN isNumeric(num_stratum_3) = 1 THEN num_stratum_3 ELSE null END AS INT) = c2.concept_id
+ON CAST(CASE WHEN num_analysis_id = 1004 THEN num_stratum_3 ELSE null END AS INT) = c2.concept_id
 ORDER BY c1.concept_id,
 num_stratum_2

--- a/src/main/resources/resources/cdmresults/sql/report/conditionera/drilldownsummary/prevalenceByMonth.sql
+++ b/src/main/resources/resources/cdmresults/sql/report/conditionera/drilldownsummary/prevalenceByMonth.sql
@@ -11,4 +11,4 @@ FROM
     ON num.stratum_2 = denom.stratum_1
   --calendar year
   INNER JOIN
-  @vocab_database_schema.concept c1 ON CAST(CASE WHEN isNumeric(num.stratum_1) = 1 THEN num.stratum_1 ELSE null END AS INT) = c1.concept_id
+  @vocab_database_schema.concept c1 ON CAST(CASE WHEN num.analysis_id = 1002 THEN num.stratum_1 ELSE null END AS INT) = c1.concept_id

--- a/src/main/resources/resources/cdmresults/sql/report/conditionera/treemap.sql
+++ b/src/main/resources/resources/cdmresults/sql/report/conditionera/treemap.sql
@@ -20,7 +20,7 @@ FROM (SELECT *
     ON ar1.stratum_1 = ar2.stratum_1
   INNER JOIN
   @results_database_schema.concept_hierarchy concept_hierarchy
-    ON CAST(CASE WHEN isNumeric(ar1.stratum_1) = 1 THEN ar1.stratum_1 ELSE null END AS INT) = concept_hierarchy.concept_id
+    ON CAST(CASE WHEN ar1.analysis_id = 1000 THEN ar1.stratum_1 ELSE null END AS INT) = concept_hierarchy.concept_id
     AND concept_hierarchy.treemap='Condition'
   ,
   (SELECT count_value

--- a/src/main/resources/resources/cdmresults/sql/report/datadensity/recordsperperson.sql
+++ b/src/main/resources/resources/cdmresults/sql/report/datadensity/recordsperperson.sql
@@ -67,4 +67,4 @@ FROM
 INNER JOIN
 ( SELECT * FROM @results_database_schema.achilles_results WHERE analysis_id = 117) denom
 ON t1.stratum_1 = denom.stratum_1
-ORDER BY series_Name, CAST(CASE WHEN isNumeric(t1.stratum_1) = 1 THEN t1.stratum_1 ELSE null END AS INT)
+ORDER BY series_Name, CAST(t1.stratum_1 AS INT)

--- a/src/main/resources/resources/cdmresults/sql/report/datadensity/totalrecords.sql
+++ b/src/main/resources/resources/cdmresults/sql/report/datadensity/totalrecords.sql
@@ -64,4 +64,4 @@ FROM
       count_value
     FROM @results_database_schema.achilles_results WHERE analysis_id = 1820
   ) t1
-ORDER BY series_Name, CAST(CASE WHEN isNumeric(stratum_1) = 1 THEN stratum_1 ELSE null END AS INT)
+ORDER BY series_Name, CAST(stratum_1 AS INT)

--- a/src/main/resources/resources/cdmresults/sql/report/death/sqlAgeAtDeath.sql
+++ b/src/main/resources/resources/cdmresults/sql/report/death/sqlAgeAtDeath.sql
@@ -9,5 +9,5 @@ SELECT
   ard1.max_value    AS max_Value
 FROM @results_database_schema.achilles_results_dist ard1
 INNER JOIN
-@vocab_database_schema.concept c2 ON CAST(CASE WHEN isNumeric(ard1.stratum_1) = 1 THEN ard1.stratum_1 ELSE null END AS INT) = c2.concept_id
+@vocab_database_schema.concept c2 ON CAST(CASE WHEN ard1.analysis_id = 506 THEN ard1.stratum_1 ELSE null END AS INT) = c2.concept_id
 WHERE ard1.analysis_id = 506

--- a/src/main/resources/resources/cdmresults/sql/report/death/sqlDeathByType.sql
+++ b/src/main/resources/resources/cdmresults/sql/report/death/sqlDeathByType.sql
@@ -3,5 +3,5 @@ SELECT
   c2.concept_name AS conceptName,
   ar1.count_value AS countValue
 FROM @results_database_schema.achilles_results ar1
-INNER JOIN @vocab_database_schema.concept c2 ON CAST(CASE WHEN isNumeric(ar1.stratum_1) = 1 THEN ar1.stratum_1 ELSE null END AS INT) = c2.concept_id
+INNER JOIN @vocab_database_schema.concept c2 ON CAST(CASE WHEN ar1.analysis_id = 505 THEN ar1.stratum_1 ELSE null END AS INT) = c2.concept_id
 WHERE ar1.analysis_id = 505

--- a/src/main/resources/resources/cdmresults/sql/report/death/sqlPrevalenceByGenderAgeYear.sql
+++ b/src/main/resources/resources/cdmresults/sql/report/death/sqlPrevalenceByGenderAgeYear.sql
@@ -1,7 +1,7 @@
 SELECT
   CONCAT(
-    cast(cast(CASE WHEN isNumeric(num.stratum_3) = 1 THEN num.stratum_3 ELSE null END AS INT) * 10 AS VARCHAR(11)), '-',
-    cast((cast(CASE WHEN isNumeric(num.stratum_3) = 1 THEN num.stratum_3 ELSE null END AS INT) + 1) * 10 - 1 AS VARCHAR(11))
+    cast(cast(CASE WHEN num.analysis_id = 504 THEN num.stratum_3 ELSE null END AS INT) * 10 AS VARCHAR(11)), '-',
+    cast((cast(CASE WHEN num.analysis_id = 504 THEN num.stratum_3 ELSE null END AS INT) + 1) * 10 - 1 AS VARCHAR(11))
   ) AS trellis_Name,
   --age decile
   c2.concept_name                                              AS series_Name,
@@ -10,10 +10,10 @@ SELECT
   -- calendar year, note, there could be blanks
   ROUND(1000 * (1.0 * num.count_value / denom.count_value), 5) AS y_Prevalence_1000Pp --prevalence, per 1000 persons
 FROM
-  (SELECT stratum_1, stratum_2, stratum_3, count_value
+  (SELECT analysis_id, stratum_1, stratum_2, stratum_3, count_value
 		FROM @results_database_schema.achilles_results
 		WHERE analysis_id = 504
-		GROUP BY stratum_1, stratum_2, stratum_3, count_value
+		GROUP BY analysis_id, stratum_1, stratum_2, stratum_3, count_value
 	) num
   INNER JOIN (
 		SELECT stratum_1, stratum_2, stratum_3, count_value
@@ -24,6 +24,6 @@ FROM
        AND num.stratum_2 = denom.stratum_2 --gender
        AND num.stratum_3 = denom.stratum_3
   --age decile
-  INNER JOIN @vocab_database_schema.concept c2 ON CAST(CASE WHEN isNumeric(num.stratum_2) = 1 THEN num.stratum_2 ELSE null END AS BIGINT) = c2.concept_id
+  INNER JOIN @vocab_database_schema.concept c2 ON CAST(CASE WHEN num.analysis_id = 504 THEN num.stratum_2 ELSE null END AS BIGINT) = c2.concept_id
 WHERE c2.concept_id IN (8507, 8532)
 

--- a/src/main/resources/resources/cdmresults/sql/report/drug/drilldown/ageAtFirstOccurrence.sql
+++ b/src/main/resources/resources/cdmresults/sql/report/drug/drilldown/ageAtFirstOccurrence.sql
@@ -11,10 +11,10 @@ SELECT
 FROM @results_database_schema.achilles_results_dist ard1
 INNER JOIN
 @vocab_database_schema.concept c1
-ON CAST(CASE WHEN isNumeric(ard1.stratum_1) = 1 THEN ard1.stratum_1 ELSE null END AS INT) = c1.concept_id
+ON CAST(CASE WHEN ard1.analysis_id = 706 THEN ard1.stratum_1 ELSE null END AS INT) = c1.concept_id
 INNER JOIN
 @vocab_database_schema.concept c2
-ON CAST(CASE WHEN isNumeric(ard1.stratum_2) = 1 THEN ard1.stratum_2 ELSE null END AS INT) = c2.concept_id
+ON CAST(CASE WHEN ard1.analysis_id = 706 THEN ard1.stratum_2 ELSE null END AS INT) = c2.concept_id
 WHERE ard1.analysis_id = 706
 AND ard1.count_value > 0
 AND c1.concept_id = @conceptId

--- a/src/main/resources/resources/cdmresults/sql/report/drug/drilldown/daysSupplyDistribution.sql
+++ b/src/main/resources/resources/cdmresults/sql/report/drug/drilldown/daysSupplyDistribution.sql
@@ -11,7 +11,7 @@ SELECT
 FROM @results_database_schema.achilles_results_dist ard1
 INNER JOIN
 @vocab_database_schema.concept c1
-ON CAST(CASE WHEN isNumeric(ard1.stratum_1) = 1 THEN ard1.stratum_1 ELSE null END AS INT) = c1.concept_id
+ON CAST(CASE WHEN ard1.analysis_id = 715 THEN ard1.stratum_1 ELSE null END AS INT) = c1.concept_id
 WHERE ard1.analysis_id = 715
 AND ard1.count_value > 0
 AND c1.concept_id = @conceptId

--- a/src/main/resources/resources/cdmresults/sql/report/drug/drilldown/frequencyDistribution.sql
+++ b/src/main/resources/resources/cdmresults/sql/report/drug/drilldown/frequencyDistribution.sql
@@ -5,8 +5,8 @@ SELECT
 	num.stratum_2								AS x_count
 FROM 
 	(SELECT count_value FROM @results_database_schema.achilles_results WHERE analysis_id = 1) denom,
-	(SELECT CAST(CASE WHEN isNumeric(stratum_1) = 1 THEN stratum_1 ELSE null END AS INT) stratum_1, 
-	        CAST(CASE WHEN isNumeric(stratum_2) = 1 THEN stratum_2 ELSE null END AS INT) stratum_2, count_value 
+	(SELECT CAST(CASE WHEN analysis_id = 791 THEN stratum_1 ELSE null END AS INT) stratum_1, 
+	        CAST(CASE WHEN analysis_id = 791 THEN stratum_2 ELSE null END AS INT) stratum_2, count_value 
 		FROM @results_database_schema.achilles_results
 		WHERE analysis_id = 791) num
 	INNER JOIN @vocab_database_schema.concept c1 ON num.stratum_1 = c1.concept_id

--- a/src/main/resources/resources/cdmresults/sql/report/drug/drilldown/prevalenceByGenderAgeYear.sql
+++ b/src/main/resources/resources/cdmresults/sql/report/drug/drilldown/prevalenceByGenderAgeYear.sql
@@ -1,16 +1,17 @@
 SELECT
   c1.concept_id                                                          AS concept_id,
   c1.concept_name                                                        AS concept_name,
-  CONCAT(cast(CAST(CASE WHEN isNumeric(num_stratum_4) = 1 THEN num_stratum_4 ELSE null END AS INT) * 10 AS VARCHAR(11)), 
-          '-', cast((CAST(CASE WHEN isNumeric(num_stratum_4) = 1 THEN num_stratum_4 ELSE null END AS INT) + 1) * 10 - 1 AS VARCHAR(11))) AS trellis_name,
+  CONCAT(cast(CAST(CASE WHEN num_analysis_id = 704 THEN num_stratum_4 ELSE null END AS INT) * 10 AS VARCHAR(11)), 
+          '-', cast((CAST(CASE WHEN num_analysis_id = 704 THEN num_stratum_4 ELSE null END AS INT) + 1) * 10 - 1 AS VARCHAR(11))) AS trellis_name,
   --age decile
   c2.concept_name                                                        AS series_name,
   --gender
-  CAST(CASE WHEN isNumeric(num_stratum_2) = 1 THEN num_stratum_2 ELSE null END AS INT) AS x_calendar_year,
+  CAST(CASE WHEN num_analysis_id = 704 THEN num_stratum_2 ELSE null END AS INT) AS x_calendar_year,
   -- calendar year, note, there could be blanks
   ROUND(1000 * (1.0 * num_count_value / denom_count_value), 5) AS y_prevalence_1000_pp --prevalence, per 1000 persons
 FROM (
        SELECT
+         num.analysis_id   AS num_analysis_id,
          num.stratum_1     AS num_stratum_1,
          num.stratum_2     AS num_stratum_2,
          num.stratum_3     AS num_stratum_3,
@@ -34,7 +35,7 @@ FROM (
               AND num.stratum_4 = denom.stratum_3
      ) tmp
   INNER JOIN @vocab_database_schema.concept c1
-ON CAST(CASE WHEN isNumeric(num_stratum_1) = 1 THEN num_stratum_1 ELSE null END AS INT) = c1.concept_id
+ON CAST(CASE WHEN num_analysis_id = 704 THEN num_stratum_1 ELSE null END AS INT) = c1.concept_id
 INNER JOIN @vocab_database_schema.concept c2
-ON CAST(CASE WHEN isNumeric(num_stratum_3) = 1 THEN num_stratum_3 ELSE null END AS INT) = c2.concept_id
+ON CAST(CASE WHEN num_analysis_id = 704 THEN num_stratum_3 ELSE null END AS INT) = c2.concept_id
 WHERE c1.concept_id = @conceptId

--- a/src/main/resources/resources/cdmresults/sql/report/drug/drilldown/prevalenceByMonth.sql
+++ b/src/main/resources/resources/cdmresults/sql/report/drug/drilldown/prevalenceByMonth.sql
@@ -13,5 +13,5 @@ FROM
   --calendar year
   INNER JOIN
   @vocab_database_schema.concept c1
-ON CAST(CASE WHEN isNumeric(num.stratum_1) = 1 THEN num.stratum_1 ELSE null END AS INT) = c1.concept_id
+ON CAST(CASE WHEN num.analysis_id = 702 THEN num.stratum_1 ELSE null END AS INT) = c1.concept_id
 WHERE c1.concept_id = @conceptId

--- a/src/main/resources/resources/cdmresults/sql/report/drug/drilldown/quantityDistribution.sql
+++ b/src/main/resources/resources/cdmresults/sql/report/drug/drilldown/quantityDistribution.sql
@@ -11,7 +11,7 @@ SELECT
 FROM @results_database_schema.achilles_results_dist ard1
 INNER JOIN
 @vocab_database_schema.concept c1
-ON CAST(CASE WHEN isNumeric(ard1.stratum_1) = 1 THEN ard1.stratum_1 ELSE null END AS INT) = c1.concept_id
+ON CAST(CASE WHEN ard1.analysis_id = 717 THEN ard1.stratum_1 ELSE null END AS INT) = c1.concept_id
 WHERE ard1.analysis_id = 717
 AND ard1.count_value > 0
 AND c1.concept_id = @conceptId

--- a/src/main/resources/resources/cdmresults/sql/report/drug/drilldown/refillsDistribution.sql
+++ b/src/main/resources/resources/cdmresults/sql/report/drug/drilldown/refillsDistribution.sql
@@ -11,7 +11,7 @@ SELECT
 FROM @results_database_schema.achilles_results_dist ard1
 INNER JOIN
 @vocab_database_schema.concept c1
-ON CAST(CASE WHEN isNumeric(ard1.stratum_1) = 1 THEN ard1.stratum_1 ELSE null END AS INT) = c1.concept_id
+ON CAST(CASE WHEN ard1.analysis_id = 716 THEN ard1.stratum_1 ELSE null END AS INT) = c1.concept_id
 WHERE ard1.analysis_id = 716
 AND ard1.count_value > 0
 AND c1.concept_id = @conceptId

--- a/src/main/resources/resources/cdmresults/sql/report/drug/drilldownsummary/ageAtFirstOccurrence.sql
+++ b/src/main/resources/resources/cdmresults/sql/report/drug/drilldownsummary/ageAtFirstOccurrence.sql
@@ -11,9 +11,9 @@ SELECT
 FROM @results_database_schema.achilles_results_dist ard1
 INNER JOIN
 @vocab_database_schema.concept c1
-ON CAST(CASE WHEN isNumeric(ard1.stratum_1) = 1 THEN ard1.stratum_1 ELSE null END AS INT) = c1.concept_id
+ON CAST(CASE WHEN ard1.analysis_id = 706 THEN ard1.stratum_1 ELSE null END AS INT) = c1.concept_id
 INNER JOIN
 @vocab_database_schema.concept c2
-ON CAST(CASE WHEN isNumeric(ard1.stratum_2) = 1 THEN ard1.stratum_2 ELSE null END AS INT) = c2.concept_id
+ON CAST(CASE WHEN ard1.analysis_id = 706 THEN ard1.stratum_2 ELSE null END AS INT) = c2.concept_id
 WHERE ard1.analysis_id = 706
 AND ard1.count_value > 0

--- a/src/main/resources/resources/cdmresults/sql/report/drug/drilldownsummary/daysSupplyDistribution.sql
+++ b/src/main/resources/resources/cdmresults/sql/report/drug/drilldownsummary/daysSupplyDistribution.sql
@@ -11,6 +11,6 @@ SELECT
 FROM @results_database_schema.achilles_results_dist ard1
 INNER JOIN
 @vocab_database_schema.concept c1
-ON CAST(CASE WHEN isNumeric(ard1.stratum_1) = 1 THEN ard1.stratum_1 ELSE null END AS INT) = c1.concept_id
+ON CAST(CASE WHEN ard1.analysis_id = 715 THEN ard1.stratum_1 ELSE null END AS INT) = c1.concept_id
 WHERE ard1.analysis_id = 715
 AND ard1.count_value > 0

--- a/src/main/resources/resources/cdmresults/sql/report/drug/drilldownsummary/frequencyDistribution.sql
+++ b/src/main/resources/resources/cdmresults/sql/report/drug/drilldownsummary/frequencyDistribution.sql
@@ -5,8 +5,8 @@ SELECT
 	num.stratum_2								AS x_count
 FROM 
 	(SELECT count_value FROM @results_database_schema.achilles_results WHERE analysis_id = 1) denom,
-	(SELECT CAST(CASE WHEN isNumeric(stratum_1) = 1 THEN stratum_1 ELSE null END AS INT) stratum_1, 
-	        CAST(CASE WHEN isNumeric(stratum_2) = 1 THEN stratum_2 ELSE null END AS INT) stratum_2, count_value 
+	(SELECT CAST(CASE WHEN analysis_id = 791 THEN stratum_1 ELSE null END AS INT) stratum_1, 
+	        CAST(CASE WHEN analysis_id = 791 THEN stratum_2 ELSE null END AS INT) stratum_2, count_value 
 		FROM @results_database_schema.achilles_results
 		WHERE analysis_id = 791) num
 	INNER JOIN @vocab_database_schema.concept c1 ON num.stratum_1 = c1.concept_id

--- a/src/main/resources/resources/cdmresults/sql/report/drug/drilldownsummary/prevalenceByGenderAgeYear.sql
+++ b/src/main/resources/resources/cdmresults/sql/report/drug/drilldownsummary/prevalenceByGenderAgeYear.sql
@@ -1,16 +1,17 @@
 SELECT
   c1.concept_id                                                          AS concept_id,
   c1.concept_name                                                        AS concept_name,
-  CONCAT(cast(CAST(CASE WHEN isNumeric(num_stratum_4) = 1 THEN num_stratum_4 ELSE null END AS INT) * 10 AS VARCHAR(11)), 
-          '-', cast((CAST(CASE WHEN isNumeric(num_stratum_4) = 1 THEN num_stratum_4 ELSE null END AS INT) + 1) * 10 - 1 AS VARCHAR(11))) AS trellis_name,
+  CONCAT(cast(CAST(CASE WHEN num_analysis_id = 704 THEN num_stratum_4 ELSE null END AS INT) * 10 AS VARCHAR(11)), 
+          '-', cast((CAST(CASE WHEN num_analysis_id = 704 THEN num_stratum_4 ELSE null END AS INT) + 1) * 10 - 1 AS VARCHAR(11))) AS trellis_name,
   --age decile
   c2.concept_name                                                        AS series_name,
   --gender
-  CAST(CASE WHEN isNumeric(num_stratum_2) = 1 THEN num_stratum_2 ELSE null END AS INT) AS x_calendar_year,
+  CAST(CASE WHEN num_analysis_id = 704 THEN num_stratum_2 ELSE null END AS INT) AS x_calendar_year,
   -- calendar year, note, there could be blanks
   ROUND(1000 * (1.0 * num_count_value / denom_count_value), 5) AS y_prevalence_1000_pp --prevalence, per 1000 persons
 FROM (
        SELECT
+         num.analysis_id   AS num_analysis_id,
          num.stratum_1     AS num_stratum_1,
          num.stratum_2     AS num_stratum_2,
          num.stratum_3     AS num_stratum_3,
@@ -34,6 +35,6 @@ FROM (
               AND num.stratum_4 = denom.stratum_3
      ) tmp
   INNER JOIN @vocab_database_schema.concept c1
-ON CAST(CASE WHEN isNumeric(num_stratum_1) = 1 THEN num_stratum_1 ELSE null END AS INT) = c1.concept_id
+ON CAST(CASE WHEN num_analysis_id = 704 THEN num_stratum_1 ELSE null END AS INT) = c1.concept_id
 INNER JOIN @vocab_database_schema.concept c2
-ON CAST(CASE WHEN isNumeric(num_stratum_3) = 1 THEN num_stratum_3 ELSE null END AS INT) = c2.concept_id
+ON CAST(CASE WHEN num_analysis_id = 704 THEN num_stratum_3 ELSE null END AS INT) = c2.concept_id

--- a/src/main/resources/resources/cdmresults/sql/report/drug/drilldownsummary/prevalenceByMonth.sql
+++ b/src/main/resources/resources/cdmresults/sql/report/drug/drilldownsummary/prevalenceByMonth.sql
@@ -13,4 +13,4 @@ FROM
   --calendar year
   INNER JOIN
   @vocab_database_schema.concept c1
-ON CAST(CASE WHEN isNumeric(num.stratum_1) = 1 THEN num.stratum_1 ELSE null END AS INT) = c1.concept_id
+ON CAST(CASE WHEN num.analysis_id = 702 THEN num.stratum_1 ELSE null END AS INT) = c1.concept_id

--- a/src/main/resources/resources/cdmresults/sql/report/drug/drilldownsummary/quantityDistribution.sql
+++ b/src/main/resources/resources/cdmresults/sql/report/drug/drilldownsummary/quantityDistribution.sql
@@ -11,6 +11,6 @@ SELECT
 FROM @results_database_schema.achilles_results_dist ard1
 INNER JOIN
 @vocab_database_schema.concept c1
-ON CAST(CASE WHEN isNumeric(ard1.stratum_1) = 1 THEN ard1.stratum_1 ELSE null END AS INT) = c1.concept_id
+ON CAST(CASE WHEN ard1.analysis_id = 717 THEN ard1.stratum_1 ELSE null END AS INT) = c1.concept_id
 WHERE ard1.analysis_id = 717
 AND ard1.count_value > 0

--- a/src/main/resources/resources/cdmresults/sql/report/drug/drilldownsummary/refillsDistribution.sql
+++ b/src/main/resources/resources/cdmresults/sql/report/drug/drilldownsummary/refillsDistribution.sql
@@ -11,6 +11,6 @@ SELECT
 FROM @results_database_schema.achilles_results_dist ard1
 INNER JOIN
 @vocab_database_schema.concept c1
-ON CAST(CASE WHEN isNumeric(ard1.stratum_1) = 1 THEN ard1.stratum_1 ELSE null END AS INT) = c1.concept_id
+ON CAST(CASE WHEN ard1.analysis_id = 716 THEN ard1.stratum_1 ELSE null END AS INT) = c1.concept_id
 WHERE ard1.analysis_id = 716
 AND ard1.count_value > 0

--- a/src/main/resources/resources/cdmresults/sql/report/drug/treemap.sql
+++ b/src/main/resources/resources/cdmresults/sql/report/drug/treemap.sql
@@ -18,7 +18,7 @@ FROM (SELECT *
     ON ar1.stratum_1 = ar2.stratum_1
   INNER JOIN
   @results_database_schema.concept_hierarchy concept_hierarchy
-    ON CAST(CASE WHEN isNumeric(ar1.stratum_1) = 1 THEN ar1.stratum_1 ELSE null END AS INT) = concept_hierarchy.concept_id
+    ON CAST(CASE WHEN ar1.analysis_id = 700 THEN ar1.stratum_1 ELSE null END AS INT) = concept_hierarchy.concept_id
   AND concept_hierarchy.treemap='Drug'
   ,
   (SELECT count_value

--- a/src/main/resources/resources/cdmresults/sql/report/drugera/drilldown/ageAtFirstOccurrence.sql
+++ b/src/main/resources/resources/cdmresults/sql/report/drugera/drilldown/ageAtFirstOccurrence.sql
@@ -11,10 +11,10 @@ SELECT
 FROM @results_database_schema.achilles_results_dist ard1
 INNER JOIN
 @vocab_database_schema.concept c1
-ON CAST(CASE WHEN isNumeric(ard1.stratum_1) = 1 THEN ard1.stratum_1 ELSE null END AS INT) = c1.concept_id
+ON CAST(CASE WHEN ard1.analysis_id = 906 THEN ard1.stratum_1 ELSE null END AS INT) = c1.concept_id
 INNER JOIN
 @vocab_database_schema.concept c2
-ON CAST(CASE WHEN isNumeric(ard1.stratum_2) = 1 THEN ard1.stratum_2 ELSE null END AS INT) = c2.concept_id
+ON CAST(CASE WHEN ard1.analysis_id = 906 THEN ard1.stratum_2 ELSE null END AS INT) = c2.concept_id
 WHERE ard1.analysis_id = 906
 AND ard1.count_value > 0
 AND c1.concept_id = @conceptId

--- a/src/main/resources/resources/cdmresults/sql/report/drugera/drilldown/lengthOfEra.sql
+++ b/src/main/resources/resources/cdmresults/sql/report/drugera/drilldown/lengthOfEra.sql
@@ -11,7 +11,7 @@ SELECT
 FROM @results_database_schema.achilles_results_dist ard1
 INNER JOIN
 @vocab_database_schema.concept c1
-ON CAST(CASE WHEN isNumeric(ard1.stratum_1) = 1 THEN ard1.stratum_1 ELSE null END AS INT) = c1.concept_id
+ON CAST(CASE WHEN ard1.analysis_id = 907 THEN ard1.stratum_1 ELSE null END AS INT) = c1.concept_id
 WHERE ard1.analysis_id = 907
 AND ard1.count_value > 0
 AND c1.concept_id = @conceptId

--- a/src/main/resources/resources/cdmresults/sql/report/drugera/drilldown/prevalenceByGenderAgeYear.sql
+++ b/src/main/resources/resources/cdmresults/sql/report/drugera/drilldown/prevalenceByGenderAgeYear.sql
@@ -1,17 +1,18 @@
 SELECT
   c1.concept_id                                                          AS concept_id,
-  CONCAT(cast(CAST(CASE WHEN isNumeric(num_stratum_4) = 1 THEN num_stratum_4 ELSE null END AS INT) * 10 AS VARCHAR(11)), 
-        '-', cast((CAST(CASE WHEN isNumeric(num_stratum_4) = 1 THEN num_stratum_4 ELSE null END AS INT) + 1) * 10 - 1 AS
+  CONCAT(cast(CAST(CASE WHEN num_analysis_id = 904 THEN num_stratum_4 ELSE null END AS INT) * 10 AS VARCHAR(11)), 
+        '-', cast((CAST(CASE WHEN num_analysis_id = 904 THEN num_stratum_4 ELSE null END AS INT) + 1) * 10 - 1 AS
                                                                 VARCHAR(11))) AS trellis_name,
   --age decile
   c2.concept_name                                                        AS series_name,
   --gender
-  CAST(CASE WHEN isNumeric(num_stratum_2) = 1 THEN num_stratum_2 ELSE null END AS INT)                                             AS x_calendar_year,
+  CAST(CASE WHEN num_analysis_id = 904 THEN num_stratum_2 ELSE null END AS INT)                                             AS x_calendar_year,
   -- calendar year, note, there could be blanks
   ROUND(1000 * (1.0 * num_count_value / denom_count_value),
         5)                                                               AS y_prevalence_1000_pp --prevalence, per 1000 persons
 FROM (
        SELECT
+         num.analysis_id   AS num_analysis_id,
          num.stratum_1     AS num_stratum_1,
          num.stratum_2     AS num_stratum_2,
          num.stratum_3     AS num_stratum_3,
@@ -35,8 +36,7 @@ FROM (
               AND num.stratum_4 = denom.stratum_3
      ) tmp
   INNER JOIN @vocab_database_schema.concept c1
-ON CAST(CASE WHEN isNumeric(num_stratum_1) = 1 THEN num_stratum_1 ELSE null END AS INT) = c1.concept_id
+ON CAST(CASE WHEN num_analysis_id = 904 THEN num_stratum_1 ELSE null END AS INT) = c1.concept_id
 INNER JOIN @vocab_database_schema.concept c2
-ON CAST(CASE WHEN isNumeric(num_stratum_3) = 1 THEN num_stratum_3 ELSE null END AS INT)= c2.concept_id
+ON CAST(CASE WHEN num_analysis_id = 904 THEN num_stratum_3 ELSE null END AS INT)= c2.concept_id
 WHERE c1.concept_id = @conceptId
-

--- a/src/main/resources/resources/cdmresults/sql/report/drugera/drilldown/prevalenceByMonth.sql
+++ b/src/main/resources/resources/cdmresults/sql/report/drugera/drilldown/prevalenceByMonth.sql
@@ -11,5 +11,5 @@ FROM
     ON num.stratum_2 = denom.stratum_1
   INNER JOIN
   @vocab_database_schema.concept c1
-ON CAST(CASE WHEN isNumeric(num.stratum_1) = 1 THEN num.stratum_1 ELSE null END AS INT) = c1.concept_id
+ON CAST(CASE WHEN num.analysis_id = 902 THEN num.stratum_1 ELSE null END AS INT) = c1.concept_id
 WHERE c1.concept_id = @conceptId

--- a/src/main/resources/resources/cdmresults/sql/report/drugera/drilldownsummary/ageAtFirstOccurrence.sql
+++ b/src/main/resources/resources/cdmresults/sql/report/drugera/drilldownsummary/ageAtFirstOccurrence.sql
@@ -11,9 +11,9 @@ SELECT
 FROM @results_database_schema.achilles_results_dist ard1
 INNER JOIN
 @vocab_database_schema.concept c1
-ON CAST(CASE WHEN isNumeric(ard1.stratum_1) = 1 THEN ard1.stratum_1 ELSE null END AS INT) = c1.concept_id
+ON CAST(CASE WHEN ard1.analysis_id = 906 THEN ard1.stratum_1 ELSE null END AS INT) = c1.concept_id
 INNER JOIN
 @vocab_database_schema.concept c2
-ON CAST(CASE WHEN isNumeric(ard1.stratum_2) = 1 THEN ard1.stratum_2 ELSE null END AS INT) = c2.concept_id
+ON CAST(CASE WHEN ard1.analysis_id = 906 THEN ard1.stratum_2 ELSE null END AS INT) = c2.concept_id
 WHERE ard1.analysis_id = 906
 AND ard1.count_value > 0

--- a/src/main/resources/resources/cdmresults/sql/report/drugera/drilldownsummary/lengthOfEra.sql
+++ b/src/main/resources/resources/cdmresults/sql/report/drugera/drilldownsummary/lengthOfEra.sql
@@ -11,6 +11,6 @@ SELECT
 FROM @results_database_schema.achilles_results_dist ard1
 INNER JOIN
 @vocab_database_schema.concept c1
-ON CAST(CASE WHEN isNumeric(ard1.stratum_1) = 1 THEN ard1.stratum_1 ELSE null END AS INT) = c1.concept_id
+ON CAST(CASE WHEN ard1.analysis_id = 907 THEN ard1.stratum_1 ELSE null END AS INT) = c1.concept_id
 WHERE ard1.analysis_id = 907
 AND ard1.count_value > 0

--- a/src/main/resources/resources/cdmresults/sql/report/drugera/drilldownsummary/prevalenceByGenderAgeYear.sql
+++ b/src/main/resources/resources/cdmresults/sql/report/drugera/drilldownsummary/prevalenceByGenderAgeYear.sql
@@ -1,17 +1,18 @@
 SELECT
   c1.concept_id                                                          AS concept_id,
-  CONCAT(cast(CAST(CASE WHEN isNumeric(num_stratum_4) = 1 THEN num_stratum_4 ELSE null END AS INT) * 10 AS VARCHAR(11)), 
-        '-', cast((CAST(CASE WHEN isNumeric(num_stratum_4) = 1 THEN num_stratum_4 ELSE null END AS INT) + 1) * 10 - 1 AS
+  CONCAT(cast(CAST(CASE WHEN num_analysis_id = 904 THEN num_stratum_4 ELSE null END AS INT) * 10 AS VARCHAR(11)), 
+        '-', cast((CAST(CASE WHEN num_analysis_id = 904 THEN num_stratum_4 ELSE null END AS INT) + 1) * 10 - 1 AS
                                                                 VARCHAR(11))) AS trellis_name,
   --age decile
   c2.concept_name                                                        AS series_name,
   --gender
-  CAST(CASE WHEN isNumeric(num_stratum_2) = 1 THEN num_stratum_2 ELSE null END AS INT)                                             AS x_calendar_year,
+  CAST(CASE WHEN num_analysis_id = 904 THEN num_stratum_2 ELSE null END AS INT)                                             AS x_calendar_year,
   -- calendar year, note, there could be blanks
   ROUND(1000 * (1.0 * num_count_value / denom_count_value),
         5)                                                               AS y_prevalence_1000_pp --prevalence, per 1000 persons
 FROM (
        SELECT
+         num.analysis_id   AS num_analysis_id,
          num.stratum_1     AS num_stratum_1,
          num.stratum_2     AS num_stratum_2,
          num.stratum_3     AS num_stratum_3,
@@ -35,7 +36,7 @@ FROM (
               AND num.stratum_4 = denom.stratum_3
      ) tmp
   INNER JOIN @vocab_database_schema.concept c1
-ON CAST(CASE WHEN isNumeric(num_stratum_1) = 1 THEN num_stratum_1 ELSE null END AS INT) = c1.concept_id
+ON CAST(CASE WHEN num_analysis_id = 904 THEN num_stratum_1 ELSE null END AS INT) = c1.concept_id
 INNER JOIN @vocab_database_schema.concept c2
-ON CAST(CASE WHEN isNumeric(num_stratum_3) = 1 THEN num_stratum_3 ELSE null END AS INT)= c2.concept_id
+ON CAST(CASE WHEN num_analysis_id = 904 THEN num_stratum_3 ELSE null END AS INT)= c2.concept_id
 

--- a/src/main/resources/resources/cdmresults/sql/report/drugera/drilldownsummary/prevalenceByMonth.sql
+++ b/src/main/resources/resources/cdmresults/sql/report/drugera/drilldownsummary/prevalenceByMonth.sql
@@ -11,4 +11,4 @@ FROM
     ON num.stratum_2 = denom.stratum_1
   INNER JOIN
   @vocab_database_schema.concept c1
-ON CAST(CASE WHEN isNumeric(num.stratum_1) = 1 THEN num.stratum_1 ELSE null END AS INT) = c1.concept_id
+ON CAST(CASE WHEN num.analysis_id = 902 THEN num.stratum_1 ELSE null END AS INT) = c1.concept_id

--- a/src/main/resources/resources/cdmresults/sql/report/drugera/treemap.sql
+++ b/src/main/resources/resources/cdmresults/sql/report/drugera/treemap.sql
@@ -19,7 +19,7 @@ FROM (SELECT *
     ON ar1.stratum_1 = ar2.stratum_1
   INNER JOIN
   @results_database_schema.concept_hierarchy concept_hierarchy
-    ON CAST(CASE WHEN isNumeric(ar1.stratum_1) = 1 THEN ar1.stratum_1 ELSE null END AS INT) = concept_hierarchy.concept_id
+    ON CAST(CASE WHEN ar1.analysis_id = 900 THEN ar1.stratum_1 ELSE null END AS INT) = concept_hierarchy.concept_id
   AND concept_hierarchy.treemap='Drug Era'
   ,
   (SELECT count_value

--- a/src/main/resources/resources/cdmresults/sql/report/measurement/drilldown/ageAtFirstOccurrence.sql
+++ b/src/main/resources/resources/cdmresults/sql/report/measurement/drilldown/ageAtFirstOccurrence.sql
@@ -9,7 +9,7 @@ SELECT
   ard1.p90_value    AS p90_value,
   ard1.max_value    AS max_value
 FROM @results_database_schema.achilles_results_dist ard1
-INNER JOIN @vocab_database_schema.concept c1 ON CAST(CASE WHEN isNumeric(ard1.stratum_1) = 1 THEN ard1.stratum_1 ELSE null END AS INT) = c1.concept_id
-INNER JOIN @vocab_database_schema.concept c2 ON CAST(CASE WHEN isNumeric(ard1.stratum_2) = 1 THEN ard1.stratum_2 ELSE null END AS INT) = c2.concept_id
+INNER JOIN @vocab_database_schema.concept c1 ON CAST(CASE WHEN ard1.analysis_id = 1806 THEN ard1.stratum_1 ELSE null END AS INT) = c1.concept_id
+INNER JOIN @vocab_database_schema.concept c2 ON CAST(CASE WHEN ard1.analysis_id = 1806 THEN ard1.stratum_2 ELSE null END AS INT) = c2.concept_id
 WHERE ard1.analysis_id = 1806
 AND c1.concept_id = @conceptId

--- a/src/main/resources/resources/cdmresults/sql/report/measurement/drilldown/frequencyDistribution.sql
+++ b/src/main/resources/resources/cdmresults/sql/report/measurement/drilldown/frequencyDistribution.sql
@@ -5,8 +5,8 @@ SELECT
 	num.stratum_2								AS x_count
 FROM 
 	(SELECT count_value FROM @results_database_schema.achilles_results WHERE analysis_id = 1) denom,
-	(SELECT CAST(CASE WHEN isNumeric(stratum_1) = 1 THEN stratum_1 ELSE null END AS INT) stratum_1, 
-	        CAST(CASE WHEN isNumeric(stratum_2) = 1 THEN stratum_2 ELSE null END AS INT) stratum_2, count_value 
+	(SELECT CAST(CASE WHEN analysis_id = 1891 THEN stratum_1 ELSE null END AS INT) stratum_1, 
+	        CAST(CASE WHEN analysis_id = 1891 THEN stratum_2 ELSE null END AS INT) stratum_2, count_value 
 		FROM @results_database_schema.achilles_results
 		WHERE analysis_id = 1891) num
 	INNER JOIN @vocab_database_schema.concept c1 ON num.stratum_1 = c1.concept_id

--- a/src/main/resources/resources/cdmresults/sql/report/measurement/drilldown/lowerLimitDistribution.sql
+++ b/src/main/resources/resources/cdmresults/sql/report/measurement/drilldown/lowerLimitDistribution.sql
@@ -8,8 +8,8 @@ select c1.concept_id as concept_id,
        ard1.p90_value as P90_value,
        ard1.max_value as max_value
 from (
-       select cast(CASE WHEN isNumeric(stratum_1) = 1 THEN stratum_1 ELSE null END as int) stratum_1, 
-              cast(CASE WHEN isNumeric(stratum_2) = 1 THEN stratum_2 ELSE null END as int) stratum_2, 
+       select cast(CASE WHEN analysis_id = 1816 THEN stratum_1 ELSE null END as int) stratum_1, 
+              cast(CASE WHEN analysis_id = 1816 THEN stratum_2 ELSE null END as int) stratum_2, 
               min_value, p10_value, p25_value, median_value, p75_value, p90_value, max_value
        FROM @results_database_schema.achilles_results_dist
        where analysis_id = 1816 and count_value > 0

--- a/src/main/resources/resources/cdmresults/sql/report/measurement/drilldown/measurementValueDistribution.sql
+++ b/src/main/resources/resources/cdmresults/sql/report/measurement/drilldown/measurementValueDistribution.sql
@@ -8,8 +8,8 @@ select c1.concept_id as concept_id,
        ard1.p90_value as P90_value,
        ard1.max_value as max_value
 from (
-       select cast(CASE WHEN isNumeric(stratum_1) = 1 THEN stratum_1 ELSE null END as int) stratum_1, 
-              cast(CASE WHEN isNumeric(stratum_2) = 1 THEN stratum_2 ELSE null END as int) stratum_2, 
+       select cast(CASE WHEN analysis_id = 1815 THEN stratum_1 ELSE null END as int) stratum_1, 
+              cast(CASE WHEN analysis_id = 1815 THEN stratum_2 ELSE null END as int) stratum_2, 
               min_value, p10_value, p25_value, median_value, p75_value, p90_value, max_value
        FROM @results_database_schema.achilles_results_dist
        where analysis_id = 1815 and count_value > 0

--- a/src/main/resources/resources/cdmresults/sql/report/measurement/drilldown/prevalenceByGenderAgeYear.sql
+++ b/src/main/resources/resources/cdmresults/sql/report/measurement/drilldown/prevalenceByGenderAgeYear.sql
@@ -1,18 +1,19 @@
 SELECT
   c1.concept_id                                                          AS concept_id,
   c1.concept_name                                                        AS concept_name,
-  CONCAT(cast(CAST(CASE WHEN isNumeric(num_stratum_4) = 1 THEN num_stratum_4 ELSE null END AS INT) * 10 AS VARCHAR(11)), 
-          '-', cast((CAST(CASE WHEN isNumeric(num_stratum_4) = 1 THEN num_stratum_4 ELSE null END AS INT) + 1) * 10 - 1 AS
+  CONCAT(cast(CAST(CASE WHEN num_analysis_id = 1804 THEN num_stratum_4 ELSE null END AS INT) * 10 AS VARCHAR(11)), 
+          '-', cast((CAST(CASE WHEN num_analysis_id = 1804 THEN num_stratum_4 ELSE null END AS INT) + 1) * 10 - 1 AS
                                                                 VARCHAR(11))) AS trellis_name,
   --age decile
   c2.concept_name                                                        AS series_name,
   --gender
-  CAST(CASE WHEN isNumeric(num_stratum_2) = 1 THEN num_stratum_2 ELSE null END AS INT)                                             AS x_calendar_year,
+  CAST(CASE WHEN num_analysis_id = 1804 THEN num_stratum_2 ELSE null END AS INT)                                             AS x_calendar_year,
   -- calendar year, note, there could be blanks
   ROUND(1000 * (1.0 * num_count_value / denom_count_value),
         5)                                                               AS y_prevalence_1000_pp --prevalence, per 1000 persons
 FROM (
        SELECT
+         num.analysis_id   AS num_analysis_id
          num.stratum_1     AS num_stratum_1,
          num.stratum_2     AS num_stratum_2,
          num.stratum_3     AS num_stratum_3,
@@ -36,8 +37,8 @@ FROM (
               AND num.stratum_4 = denom.stratum_3
      ) tmp
   INNER JOIN @vocab_database_schema.concept c1
-ON CAST(CASE WHEN isNumeric(num_stratum_1) = 1 THEN num_stratum_1 ELSE null END AS INT) = c1.concept_id
+ON CAST(CASE WHEN num_analysis_id = 1804 THEN num_stratum_1 ELSE null END AS INT) = c1.concept_id
 INNER JOIN @vocab_database_schema.concept c2
-ON CAST(CASE WHEN isNumeric(num_stratum_3) = 1 THEN num_stratum_3 ELSE null END AS INT) = c2.concept_id
+ON CAST(CASE WHEN num_analysis_id = 1804 THEN num_stratum_3 ELSE null END AS INT) = c2.concept_id
 WHERE c1.concept_id = @conceptId
 

--- a/src/main/resources/resources/cdmresults/sql/report/measurement/drilldown/prevalenceByMonth.sql
+++ b/src/main/resources/resources/cdmresults/sql/report/measurement/drilldown/prevalenceByMonth.sql
@@ -12,6 +12,6 @@ FROM
   (SELECT *
    FROM @results_database_schema.achilles_results WHERE analysis_id = 117) denom ON num.stratum_2 = denom.stratum_1
   --calendar year
-  INNER JOIN @vocab_database_schema.concept c1 ON CAST(CASE WHEN isNumeric(num.stratum_1) = 1 THEN num.stratum_1 ELSE null END AS INT) = c1.concept_id
+  INNER JOIN @vocab_database_schema.concept c1 ON CAST(CASE WHEN num.analysis_id = 1802 THEN num.stratum_1 ELSE null END AS INT) = c1.concept_id
 WHERE c1.concept_id = @conceptId
 

--- a/src/main/resources/resources/cdmresults/sql/report/measurement/drilldown/recordsByUnit.sql
+++ b/src/main/resources/resources/cdmresults/sql/report/measurement/drilldown/recordsByUnit.sql
@@ -4,8 +4,8 @@ select c1.concept_id as measurement_concept_id,
        c2.concept_name as concept_name,
        ar1.count_value as count_value
 from (
-       select cast(CASE WHEN isNumeric(stratum_1) = 1 THEN stratum_1 ELSE '0' END as int) stratum_1,
-              cast(CASE WHEN isNumeric(stratum_2) = 1 THEN stratum_2 ELSE '0' END as int) stratum_2, count_value
+       select cast(CASE WHEN analysis_id = 1807 THEN stratum_1 ELSE '0' END as int) stratum_1,
+              cast(CASE WHEN analysis_id = 1807 THEN stratum_2 ELSE '0' END as int) stratum_2, count_value
        from @results_database_schema.achilles_results
        where analysis_id = 1807
        group by analysis_id, stratum_1, stratum_2, count_value

--- a/src/main/resources/resources/cdmresults/sql/report/measurement/drilldown/upperLimitDistribution.sql
+++ b/src/main/resources/resources/cdmresults/sql/report/measurement/drilldown/upperLimitDistribution.sql
@@ -8,8 +8,8 @@ select c1.concept_id as concept_id,
        ard1.p90_value as P90_value,
        ard1.max_value as max_value
 from (
-       select cast(CASE WHEN isNumeric(stratum_1) = 1 THEN stratum_1 ELSE null END as int) stratum_1, 
-              cast(CASE WHEN isNumeric(stratum_2) = 1 THEN stratum_2 ELSE null END as int) stratum_2, 
+       select cast(CASE WHEN analysis_id = 1817 THEN stratum_1 ELSE null END as int) stratum_1, 
+              cast(CASE WHEN analysis_id = 1817 THEN stratum_2 ELSE null END as int) stratum_2, 
               min_value, p10_value, p25_value, median_value, p75_value, p90_value, max_value
        FROM @results_database_schema.achilles_results_dist
        where analysis_id = 1817 and count_value > 0

--- a/src/main/resources/resources/cdmresults/sql/report/measurement/drilldown/valuesRelativeToNorm.sql
+++ b/src/main/resources/resources/cdmresults/sql/report/measurement/drilldown/valuesRelativeToNorm.sql
@@ -4,8 +4,8 @@ select c1.concept_id as MEASUREMENT_CONCEPT_ID,
        CONCAT(c2.concept_name, ': ', ar1.stratum_3) as concept_name,
        ar1.count_value as count_value
 from (
-       select cast(CASE WHEN isNumeric(stratum_1) = 1 THEN stratum_1 ELSE null END as int) stratum_1, 
-              cast(CASE WHEN isNumeric(stratum_2) = 1 THEN stratum_2 ELSE null END as int) stratum_2, stratum_3, count_value
+       select cast(CASE WHEN analysis_id = 1818 THEN stratum_1 ELSE null END as int) stratum_1, 
+              cast(CASE WHEN analysis_id = 1818 THEN stratum_2 ELSE null END as int) stratum_2, stratum_3, count_value
        FROM @results_database_schema.achilles_results
        where analysis_id = 1818
        GROUP BY analysis_id, stratum_1, stratum_2, stratum_3, count_value

--- a/src/main/resources/resources/cdmresults/sql/report/measurement/drilldownsummary/ageAtFirstOccurrence.sql
+++ b/src/main/resources/resources/cdmresults/sql/report/measurement/drilldownsummary/ageAtFirstOccurrence.sql
@@ -9,6 +9,6 @@ SELECT
   ard1.p90_value    AS p90_value,
   ard1.max_value    AS max_value
 FROM @results_database_schema.achilles_results_dist ard1
-INNER JOIN @vocab_database_schema.concept c1 ON CAST(CASE WHEN isNumeric(ard1.stratum_1) = 1 THEN ard1.stratum_1 ELSE null END AS INT) = c1.concept_id
-INNER JOIN @vocab_database_schema.concept c2 ON CAST(CASE WHEN isNumeric(ard1.stratum_2) = 1 THEN ard1.stratum_2 ELSE null END AS INT) = c2.concept_id
+INNER JOIN @vocab_database_schema.concept c1 ON CAST(CASE WHEN ard1.analysis_id = 1806 THEN ard1.stratum_1 ELSE null END AS INT) = c1.concept_id
+INNER JOIN @vocab_database_schema.concept c2 ON CAST(CASE WHEN ard1.analysis_id = 1806 THEN ard1.stratum_2 ELSE null END AS INT) = c2.concept_id
 WHERE ard1.analysis_id = 1806

--- a/src/main/resources/resources/cdmresults/sql/report/measurement/drilldownsummary/frequencyDistribution.sql
+++ b/src/main/resources/resources/cdmresults/sql/report/measurement/drilldownsummary/frequencyDistribution.sql
@@ -5,8 +5,8 @@ SELECT
 	num.stratum_2								AS x_count
 FROM 
 	(SELECT count_value FROM @results_database_schema.achilles_results WHERE analysis_id = 1) denom,
-	(SELECT CAST(CASE WHEN isNumeric(stratum_1) = 1 THEN stratum_1 ELSE null END AS INT) stratum_1, 
-	        CAST(CASE WHEN isNumeric(stratum_2) = 1 THEN stratum_2 ELSE null END AS INT) stratum_2, count_value 
+	(SELECT CAST(CASE WHEN analysis_id = 1891 THEN stratum_1 ELSE null END AS INT) stratum_1, 
+	        CAST(CASE WHEN analysis_id = 1891 THEN stratum_2 ELSE null END AS INT) stratum_2, count_value 
 		FROM @results_database_schema.achilles_results
 		WHERE analysis_id = 1891) num
 	INNER JOIN @vocab_database_schema.concept c1 ON num.stratum_1 = c1.concept_id

--- a/src/main/resources/resources/cdmresults/sql/report/measurement/drilldownsummary/lowerLimitDistribution.sql
+++ b/src/main/resources/resources/cdmresults/sql/report/measurement/drilldownsummary/lowerLimitDistribution.sql
@@ -8,8 +8,8 @@ select c1.concept_id as concept_id,
        ard1.p90_value as P90_value,
        ard1.max_value as max_value
 from (
-       select cast(CASE WHEN isNumeric(stratum_1) = 1 THEN stratum_1 ELSE null END as int) stratum_1, 
-              cast(CASE WHEN isNumeric(stratum_2) = 1 THEN stratum_2 ELSE null END as int) stratum_2, 
+       select cast(CASE WHEN analysis_id = 1816 THEN stratum_1 ELSE null END as int) stratum_1, 
+              cast(CASE WHEN analysis_id = 1816 THEN stratum_2 ELSE null END as int) stratum_2, 
               min_value, p10_value, p25_value, median_value, p75_value, p90_value, max_value
        FROM @results_database_schema.achilles_results_dist
        where analysis_id = 1816 and count_value > 0

--- a/src/main/resources/resources/cdmresults/sql/report/measurement/drilldownsummary/measurementValueDistribution.sql
+++ b/src/main/resources/resources/cdmresults/sql/report/measurement/drilldownsummary/measurementValueDistribution.sql
@@ -8,8 +8,8 @@ select c1.concept_id as concept_id,
        ard1.p90_value as P90_value,
        ard1.max_value as max_value
 from (
-       select cast(CASE WHEN isNumeric(stratum_1) = 1 THEN stratum_1 ELSE null END as int) stratum_1, 
-              cast(CASE WHEN isNumeric(stratum_2) = 1 THEN stratum_2 ELSE null END as int) stratum_2, 
+       select cast(CASE WHEN analysis_id = 1815 THEN stratum_1 ELSE null END as int) stratum_1, 
+              cast(CASE WHEN analysis_id = 1815 THEN stratum_2 ELSE null END as int) stratum_2, 
               min_value, p10_value, p25_value, median_value, p75_value, p90_value, max_value
        FROM @results_database_schema.achilles_results_dist
        where analysis_id = 1815 and count_value > 0

--- a/src/main/resources/resources/cdmresults/sql/report/measurement/drilldownsummary/prevalenceByGenderAgeYear.sql
+++ b/src/main/resources/resources/cdmresults/sql/report/measurement/drilldownsummary/prevalenceByGenderAgeYear.sql
@@ -1,18 +1,19 @@
 SELECT
   c1.concept_id                                                          AS concept_id,
   c1.concept_name                                                        AS concept_name,
-  CONCAT(cast(CAST(CASE WHEN isNumeric(num_stratum_4) = 1 THEN num_stratum_4 ELSE null END AS INT) * 10 AS VARCHAR(11)), 
-          '-', cast((CAST(CASE WHEN isNumeric(num_stratum_4) = 1 THEN num_stratum_4 ELSE null END AS INT) + 1) * 10 - 1 AS
+  CONCAT(cast(CAST(CASE WHEN num_analysis_id = 1804 THEN num_stratum_4 ELSE null END AS INT) * 10 AS VARCHAR(11)), 
+          '-', cast((CAST(CASE WHEN num_analysis_id = 1804 THEN num_stratum_4 ELSE null END AS INT) + 1) * 10 - 1 AS
                                                                 VARCHAR(11))) AS trellis_name,
   --age decile
   c2.concept_name                                                        AS series_name,
   --gender
-  CAST(CASE WHEN isNumeric(num_stratum_2) = 1 THEN num_stratum_2 ELSE null END AS INT)                                             AS x_calendar_year,
+  CAST(CASE WHEN num_analysis_id = 1804 THEN num_stratum_2 ELSE null END AS INT)                                             AS x_calendar_year,
   -- calendar year, note, there could be blanks
   ROUND(1000 * (1.0 * num_count_value / denom_count_value),
         5)                                                               AS y_prevalence_1000_pp --prevalence, per 1000 persons
 FROM (
        SELECT
+         num.analysis_id   AS num_analysis_id,
          num.stratum_1     AS num_stratum_1,
          num.stratum_2     AS num_stratum_2,
          num.stratum_3     AS num_stratum_3,
@@ -36,7 +37,7 @@ FROM (
               AND num.stratum_4 = denom.stratum_3
      ) tmp
   INNER JOIN @vocab_database_schema.concept c1
-ON CAST(CASE WHEN isNumeric(num_stratum_1) = 1 THEN num_stratum_1 ELSE null END AS INT) = c1.concept_id
+ON CAST(CASE WHEN num_analysis_id = 1804 THEN num_stratum_1 ELSE null END AS INT) = c1.concept_id
 INNER JOIN @vocab_database_schema.concept c2
-ON CAST(CASE WHEN isNumeric(num_stratum_3) = 1 THEN num_stratum_3 ELSE null END AS INT) = c2.concept_id
+ON CAST(CASE WHEN num_analysis_id = 1804 THEN num_stratum_3 ELSE null END AS INT) = c2.concept_id
 

--- a/src/main/resources/resources/cdmresults/sql/report/measurement/drilldownsummary/prevalenceByMonth.sql
+++ b/src/main/resources/resources/cdmresults/sql/report/measurement/drilldownsummary/prevalenceByMonth.sql
@@ -12,5 +12,5 @@ FROM
   (SELECT *
    FROM @results_database_schema.achilles_results WHERE analysis_id = 117) denom ON num.stratum_2 = denom.stratum_1
   --calendar year
-  INNER JOIN @vocab_database_schema.concept c1 ON CAST(CASE WHEN isNumeric(num.stratum_1) = 1 THEN num.stratum_1 ELSE null END AS INT) = c1.concept_id
+  INNER JOIN @vocab_database_schema.concept c1 ON CAST(CASE WHEN num.analysis_id = 1802 THEN num.stratum_1 ELSE null END AS INT) = c1.concept_id
 

--- a/src/main/resources/resources/cdmresults/sql/report/measurement/drilldownsummary/recordsByUnit.sql
+++ b/src/main/resources/resources/cdmresults/sql/report/measurement/drilldownsummary/recordsByUnit.sql
@@ -4,8 +4,8 @@ select c1.concept_id as measurement_concept_id,
        c2.concept_name as concept_name,
        ar1.count_value as count_value
 from (
-       select cast(CASE WHEN isNumeric(stratum_1) = 1 THEN stratum_1 ELSE '0' END as int) stratum_1,
-              cast(CASE WHEN isNumeric(stratum_2) = 1 THEN stratum_2 ELSE '0' END as int) stratum_2, count_value
+       select cast(CASE WHEN analysis_id = 1807 THEN stratum_1 ELSE '0' END as int) stratum_1,
+              cast(CASE WHEN analysis_id = 1807 THEN stratum_2 ELSE '0' END as int) stratum_2, count_value
        from @results_database_schema.achilles_results
        where analysis_id = 1807
        group by analysis_id, stratum_1, stratum_2, count_value

--- a/src/main/resources/resources/cdmresults/sql/report/measurement/drilldownsummary/upperLimitDistribution.sql
+++ b/src/main/resources/resources/cdmresults/sql/report/measurement/drilldownsummary/upperLimitDistribution.sql
@@ -8,8 +8,8 @@ select c1.concept_id as concept_id,
        ard1.p90_value as P90_value,
        ard1.max_value as max_value
 from (
-       select cast(CASE WHEN isNumeric(stratum_1) = 1 THEN stratum_1 ELSE null END as int) stratum_1, 
-              cast(CASE WHEN isNumeric(stratum_2) = 1 THEN stratum_2 ELSE null END as int) stratum_2, 
+       select cast(CASE WHEN analysis_id = 1817 THEN stratum_1 ELSE null END as int) stratum_1, 
+              cast(CASE WHEN analysis_id = 1817 THEN stratum_2 ELSE null END as int) stratum_2, 
               min_value, p10_value, p25_value, median_value, p75_value, p90_value, max_value
        FROM @results_database_schema.achilles_results_dist
        where analysis_id = 1817 and count_value > 0

--- a/src/main/resources/resources/cdmresults/sql/report/measurement/drilldownsummary/valuesRelativeToNorm.sql
+++ b/src/main/resources/resources/cdmresults/sql/report/measurement/drilldownsummary/valuesRelativeToNorm.sql
@@ -4,8 +4,8 @@ select c1.concept_id as MEASUREMENT_CONCEPT_ID,
        CONCAT(c2.concept_name, ': ', ar1.stratum_3) as concept_name,
        ar1.count_value as count_value
 from (
-       select cast(CASE WHEN isNumeric(stratum_1) = 1 THEN stratum_1 ELSE null END as int) stratum_1, 
-              cast(CASE WHEN isNumeric(stratum_2) = 1 THEN stratum_2 ELSE null END as int) stratum_2, stratum_3, count_value
+       select cast(CASE WHEN analysis_id = 1818 THEN stratum_1 ELSE null END as int) stratum_1, 
+              cast(CASE WHEN analysis_id = 1818 THEN stratum_2 ELSE null END as int) stratum_2, stratum_3, count_value
        FROM @results_database_schema.achilles_results
        where analysis_id = 1818
        GROUP BY analysis_id, stratum_1, stratum_2, stratum_3, count_value

--- a/src/main/resources/resources/cdmresults/sql/report/measurement/treemap.sql
+++ b/src/main/resources/resources/cdmresults/sql/report/measurement/treemap.sql
@@ -16,7 +16,7 @@ FROM (SELECT *
     ON ar1.stratum_1 = ar2.stratum_1
   INNER JOIN
   @results_database_schema.concept_hierarchy concept_hierarchy
-ON CAST(CASE WHEN isNumeric(ar1.stratum_1) = 1 THEN ar1.stratum_1 ELSE null END AS INT) = concept_hierarchy.concept_id
+ON CAST(CASE WHEN ar1.analysis_id = 1800 THEN ar1.stratum_1 ELSE null END AS INT) = concept_hierarchy.concept_id
    AND concept_hierarchy.treemap='Measurement'
  ,
   (SELECT count_value

--- a/src/main/resources/resources/cdmresults/sql/report/observation/drilldown/ageAtFirstOccurrence.sql
+++ b/src/main/resources/resources/cdmresults/sql/report/observation/drilldown/ageAtFirstOccurrence.sql
@@ -9,7 +9,7 @@ SELECT
   ard1.p90_value    AS p90_value,
   ard1.max_value    AS max_value
 FROM @results_database_schema.achilles_results_dist ard1
-INNER JOIN @vocab_database_schema.concept c1 ON CAST(CASE WHEN isNumeric(ard1.stratum_1) = 1 THEN ard1.stratum_1 ELSE null END AS INT) = c1.concept_id
-INNER JOIN @vocab_database_schema.concept c2 ON CAST(CASE WHEN isNumeric(ard1.stratum_2) = 1 THEN ard1.stratum_2 ELSE null END AS INT) = c2.concept_id
+INNER JOIN @vocab_database_schema.concept c1 ON CAST(CASE WHEN ard1.analysis_id = 806 THEN ard1.stratum_1 ELSE null END AS INT) = c1.concept_id
+INNER JOIN @vocab_database_schema.concept c2 ON CAST(CASE WHEN ard1.analysis_id = 806 THEN ard1.stratum_2 ELSE null END AS INT) = c2.concept_id
 WHERE ard1.analysis_id = 806
 AND c1.concept_id = @conceptId

--- a/src/main/resources/resources/cdmresults/sql/report/observation/drilldown/frequencyDistribution.sql
+++ b/src/main/resources/resources/cdmresults/sql/report/observation/drilldown/frequencyDistribution.sql
@@ -5,8 +5,8 @@ SELECT
 	num.stratum_2								AS x_count
 FROM 
 	(SELECT count_value FROM @results_database_schema.achilles_results WHERE analysis_id = 1) denom,
-	(SELECT CAST(CASE WHEN isNumeric(stratum_1) = 1 THEN stratum_1 ELSE null END AS INT) stratum_1, 
-	        CAST(CASE WHEN isNumeric(stratum_2) = 1 THEN stratum_2 ELSE null END AS INT) stratum_2, count_value 
+	(SELECT CAST(CASE WHEN analysis_id = 891 THEN stratum_1 ELSE null END AS INT) stratum_1, 
+	        CAST(CASE WHEN analysis_id = 891 THEN stratum_2 ELSE null END AS INT) stratum_2, count_value 
 		FROM @results_database_schema.achilles_results
 		WHERE analysis_id = 891) num
 	INNER JOIN @vocab_database_schema.concept c1 ON num.stratum_1 = c1.concept_id

--- a/src/main/resources/resources/cdmresults/sql/report/observation/drilldown/prevalenceByGenderAgeYear.sql
+++ b/src/main/resources/resources/cdmresults/sql/report/observation/drilldown/prevalenceByGenderAgeYear.sql
@@ -1,18 +1,19 @@
 SELECT
   c1.concept_id                                                          AS concept_id,
   c1.concept_name                                                        AS concept_name,
-  CONCAT(cast(CAST(CASE WHEN isNumeric(num_stratum_4) = 1 THEN num_stratum_4 ELSE null END AS INT) * 10 AS VARCHAR(11)), 
-         '-', cast((CAST(CASE WHEN isNumeric(num_stratum_4) = 1 THEN num_stratum_4 ELSE null END AS INT) + 1) * 10 - 1 AS
+  CONCAT(cast(CAST(CASE WHEN num_analysis_id = 804 THEN num_stratum_4 ELSE null END AS INT) * 10 AS VARCHAR(11)), 
+         '-', cast((CAST(CASE WHEN num_analysis_id = 804 THEN num_stratum_4 ELSE null END AS INT) + 1) * 10 - 1 AS
                                                                 VARCHAR(11))) AS trellis_name,
   --age decile
   c2.concept_name                                                        AS series_name,
   --gender
-  CAST(CASE WHEN isNumeric(num_stratum_2) = 1 THEN num_stratum_2 ELSE null END AS INT)                                             AS x_calendar_year,
+  CAST(CASE WHEN num_analysis_id = 804 THEN num_stratum_2 ELSE null END AS INT)                                             AS x_calendar_year,
   -- calendar year, note, there could be blanks
   ROUND(1000 * (1.0 * num_count_value / denom_count_value),
         5)                                                               AS y_prevalence_1000_pp --prevalence, per 1000 persons
 FROM (
        SELECT
+         num.analysis_id   AS num_analysis_id,
          num.stratum_1     AS num_stratum_1,
          num.stratum_2     AS num_stratum_2,
          num.stratum_3     AS num_stratum_3,
@@ -36,8 +37,8 @@ FROM (
               AND num.stratum_4 = denom.stratum_3
      ) tmp
   INNER JOIN @vocab_database_schema.concept c1
-ON CAST(CASE WHEN isNumeric(num_stratum_1) = 1 THEN num_stratum_1 ELSE null END AS INT) = c1.concept_id
+ON CAST(CASE WHEN num_analysis_id = 804 THEN num_stratum_1 ELSE null END AS INT) = c1.concept_id
 INNER JOIN @vocab_database_schema.concept c2
-ON CAST(CASE WHEN isNumeric(num_stratum_3) = 1 THEN num_stratum_3 ELSE null END AS INT) = c2.concept_id
+ON CAST(CASE WHEN num_analysis_id = 804 THEN num_stratum_3 ELSE null END AS INT) = c2.concept_id
 WHERE c1.concept_id = @conceptId
 

--- a/src/main/resources/resources/cdmresults/sql/report/observation/drilldown/prevalenceByMonth.sql
+++ b/src/main/resources/resources/cdmresults/sql/report/observation/drilldown/prevalenceByMonth.sql
@@ -12,6 +12,6 @@ FROM
   (SELECT *
    FROM @results_database_schema.achilles_results WHERE analysis_id = 117) denom ON num.stratum_2 = denom.stratum_1
   --calendar year
-  INNER JOIN @vocab_database_schema.concept c1 ON CAST(CASE WHEN isNumeric(num.stratum_1) = 1 THEN num.stratum_1 ELSE null END AS INT) = c1.concept_id
+  INNER JOIN @vocab_database_schema.concept c1 ON CAST(CASE WHEN num.analysis_id = 802 THEN num.stratum_1 ELSE null END AS INT) = c1.concept_id
 WHERE c1.concept_id = @conceptId
 

--- a/src/main/resources/resources/cdmresults/sql/report/observation/drilldownsummary/ageAtFirstOccurrence.sql
+++ b/src/main/resources/resources/cdmresults/sql/report/observation/drilldownsummary/ageAtFirstOccurrence.sql
@@ -9,6 +9,6 @@ SELECT
   ard1.p90_value    AS p90_value,
   ard1.max_value    AS max_value
 FROM @results_database_schema.achilles_results_dist ard1
-INNER JOIN @vocab_database_schema.concept c1 ON CAST(CASE WHEN isNumeric(ard1.stratum_1) = 1 THEN ard1.stratum_1 ELSE null END AS INT) = c1.concept_id
-INNER JOIN @vocab_database_schema.concept c2 ON CAST(CASE WHEN isNumeric(ard1.stratum_2) = 1 THEN ard1.stratum_2 ELSE null END AS INT) = c2.concept_id
+INNER JOIN @vocab_database_schema.concept c1 ON CAST(CASE WHEN ard1.analysis_id = 806 THEN ard1.stratum_1 ELSE null END AS INT) = c1.concept_id
+INNER JOIN @vocab_database_schema.concept c2 ON CAST(CASE WHEN ard1.analysis_id = 806 THEN ard1.stratum_2 ELSE null END AS INT) = c2.concept_id
 WHERE ard1.analysis_id = 806

--- a/src/main/resources/resources/cdmresults/sql/report/observation/drilldownsummary/frequencyDistribution.sql
+++ b/src/main/resources/resources/cdmresults/sql/report/observation/drilldownsummary/frequencyDistribution.sql
@@ -5,8 +5,8 @@ SELECT
 	num.stratum_2								AS x_count
 FROM 
 	(SELECT count_value FROM @results_database_schema.achilles_results WHERE analysis_id = 1) denom,
-	(SELECT CAST(CASE WHEN isNumeric(stratum_1) = 1 THEN stratum_1 ELSE null END AS INT) stratum_1, 
-	        CAST(CASE WHEN isNumeric(stratum_2) = 1 THEN stratum_2 ELSE null END AS INT) stratum_2, count_value 
+	(SELECT CAST(CASE WHEN analysis_id = 891 THEN stratum_1 ELSE null END AS INT) stratum_1, 
+	        CAST(CASE WHEN analysis_id = 891 THEN stratum_2 ELSE null END AS INT) stratum_2, count_value 
 		FROM @results_database_schema.achilles_results
 		WHERE analysis_id = 891) num
 	INNER JOIN @vocab_database_schema.concept c1 ON num.stratum_1 = c1.concept_id

--- a/src/main/resources/resources/cdmresults/sql/report/observation/drilldownsummary/prevalenceByGenderAgeYear.sql
+++ b/src/main/resources/resources/cdmresults/sql/report/observation/drilldownsummary/prevalenceByGenderAgeYear.sql
@@ -1,18 +1,19 @@
 SELECT
   c1.concept_id                                                          AS concept_id,
   c1.concept_name                                                        AS concept_name,
-  CONCAT(cast(CAST(CASE WHEN isNumeric(num_stratum_4) = 1 THEN num_stratum_4 ELSE null END AS INT) * 10 AS VARCHAR(11)), 
-         '-', cast((CAST(CASE WHEN isNumeric(num_stratum_4) = 1 THEN num_stratum_4 ELSE null END AS INT) + 1) * 10 - 1 AS
+  CONCAT(cast(CAST(CASE WHEN num_analysis_id = 804 THEN num_stratum_4 ELSE null END AS INT) * 10 AS VARCHAR(11)), 
+         '-', cast((CAST(CASE WHEN num_analysis_id = 804 THEN num_stratum_4 ELSE null END AS INT) + 1) * 10 - 1 AS
                                                                 VARCHAR(11))) AS trellis_name,
   --age decile
   c2.concept_name                                                        AS series_name,
   --gender
-  CAST(CASE WHEN isNumeric(num_stratum_2) = 1 THEN num_stratum_2 ELSE null END AS INT)                                             AS x_calendar_year,
+  CAST(CASE WHEN num_analysis_id = 804 THEN num_stratum_2 ELSE null END AS INT)                                             AS x_calendar_year,
   -- calendar year, note, there could be blanks
   ROUND(1000 * (1.0 * num_count_value / denom_count_value),
         5)                                                               AS y_prevalence_1000_pp --prevalence, per 1000 persons
 FROM (
        SELECT
+         num.analysis_id   AS num_analysis_id,
          num.stratum_1     AS num_stratum_1,
          num.stratum_2     AS num_stratum_2,
          num.stratum_3     AS num_stratum_3,
@@ -36,7 +37,7 @@ FROM (
               AND num.stratum_4 = denom.stratum_3
      ) tmp
   INNER JOIN @vocab_database_schema.concept c1
-ON CAST(CASE WHEN isNumeric(num_stratum_1) = 1 THEN num_stratum_1 ELSE null END AS INT) = c1.concept_id
+ON CAST(CASE WHEN num_analysis_id = 804 THEN num_stratum_1 ELSE null END AS INT) = c1.concept_id
 INNER JOIN @vocab_database_schema.concept c2
-ON CAST(CASE WHEN isNumeric(num_stratum_3) = 1 THEN num_stratum_3 ELSE null END AS INT) = c2.concept_id
+ON CAST(CASE WHEN num_analysis_id = 804 THEN num_stratum_3 ELSE null END AS INT) = c2.concept_id
 

--- a/src/main/resources/resources/cdmresults/sql/report/observation/drilldownsummary/prevalenceByMonth.sql
+++ b/src/main/resources/resources/cdmresults/sql/report/observation/drilldownsummary/prevalenceByMonth.sql
@@ -12,5 +12,5 @@ FROM
   (SELECT *
    FROM @results_database_schema.achilles_results WHERE analysis_id = 117) denom ON num.stratum_2 = denom.stratum_1
   --calendar year
-  INNER JOIN @vocab_database_schema.concept c1 ON CAST(CASE WHEN isNumeric(num.stratum_1) = 1 THEN num.stratum_1 ELSE null END AS INT) = c1.concept_id
+  INNER JOIN @vocab_database_schema.concept c1 ON CAST(CASE WHEN num.analysis_id = 802 THEN num.stratum_1 ELSE null END AS INT) = c1.concept_id
 

--- a/src/main/resources/resources/cdmresults/sql/report/observation/treemap.sql
+++ b/src/main/resources/resources/cdmresults/sql/report/observation/treemap.sql
@@ -16,7 +16,7 @@ FROM (SELECT *
     ON ar1.stratum_1 = ar2.stratum_1
   INNER JOIN
   @results_database_schema.concept_hierarchy concept_hierarchy
-  ON CAST(CASE WHEN isNumeric(ar1.stratum_1) = 1 THEN ar1.stratum_1 ELSE null END AS INT) = concept_hierarchy.concept_id
+  ON CAST(CASE WHEN ar1.analysis_id = 800 THEN ar1.stratum_1 ELSE null END AS INT) = concept_hierarchy.concept_id
   AND concept_hierarchy.treemap='Observation'
   ,
   (SELECT count_value

--- a/src/main/resources/resources/cdmresults/sql/report/observationperiod/ageatfirst.sql
+++ b/src/main/resources/resources/cdmresults/sql/report/observationperiod/ageatfirst.sql
@@ -1,5 +1,5 @@
 SELECT
-  cast(CASE WHEN isNumeric(ar1.stratum_1) = 1 THEN ar1.stratum_1 ELSE null END AS INT)                          AS intervalIndex,
+  cast(CASE WHEN ar1.analysis_id = 101 THEN ar1.stratum_1 ELSE null END AS INT)                          AS intervalIndex,
   ar1.count_value                                     AS countValue,
   round(1.0 * ar1.count_value / denom.count_value, 5) AS percentValue
 FROM

--- a/src/main/resources/resources/cdmresults/sql/report/observationperiod/agebygender.sql
+++ b/src/main/resources/resources/cdmresults/sql/report/observationperiod/agebygender.sql
@@ -8,5 +8,5 @@ SELECT
   ard1.p90_value    AS p90_value,
   ard1.max_value    AS max_value
 FROM @results_database_schema.achilles_results_dist ard1
-INNER JOIN @vocab_database_schema.concept c1 ON CAST(CASE WHEN isNumeric(ard1.stratum_1) = 1 THEN ard1.stratum_1 ELSE null END AS INT) = c1.concept_id
+INNER JOIN @vocab_database_schema.concept c1 ON CAST(CASE WHEN ard1.analysis_id = 104 THEN ard1.stratum_1 ELSE null END AS INT) = c1.concept_id
 WHERE ard1.analysis_id = 104

--- a/src/main/resources/resources/cdmresults/sql/report/observationperiod/cumulativeduration.sql
+++ b/src/main/resources/resources/cdmresults/sql/report/observationperiod/cumulativeduration.sql
@@ -3,14 +3,14 @@ SELECT
   xLengthOfObservation                                     AS xLengthOfObservation,
   round(1.0 * sum(ar2.count_value) / denom.count_value, 5) AS yPercentPersons
 FROM (SELECT ar.*,
-        cast(CASE WHEN isNumeric(stratum_1) = 1 THEN stratum_1 ELSE null END AS INT) * 30 AS xLengthOfObservation
+        cast(CASE WHEN analysis_id = 108 THEN stratum_1 ELSE null END AS INT) * 30 AS xLengthOfObservation
       FROM @results_database_schema.achilles_results ar WHERE analysis_id = 108) ar1
   INNER JOIN
   (
     SELECT *
     FROM @results_database_schema.achilles_results WHERE analysis_id = 108
-  ) ar2 ON ar1.analysis_id = ar2.analysis_id AND cast(CASE WHEN isNumeric(ar1.stratum_1) = 1 THEN 
-                                            ar1.stratum_1 ELSE null END AS INT) <= cast(CASE WHEN isNumeric(ar2.stratum_1) = 1 THEN ar2.stratum_1 ELSE null END AS INT)
+  ) ar2 ON ar1.analysis_id = ar2.analysis_id AND cast(CASE WHEN ar1.analysis_id = 108 THEN 
+                                            ar1.stratum_1 ELSE null END AS INT) <= cast(CASE WHEN ar2.analysis_id = 108 THEN ar2.stratum_1 ELSE null END AS INT)
   ,
   (
     SELECT count_value

--- a/src/main/resources/resources/cdmresults/sql/report/observationperiod/observationlength_data.sql
+++ b/src/main/resources/resources/cdmresults/sql/report/observationperiod/observationlength_data.sql
@@ -1,5 +1,5 @@
 SELECT
-  cast(CASE WHEN isNumeric(ar1.stratum_1) = 1 THEN ar1.stratum_1 ELSE null END AS INT)                          AS intervalIndex,
+  cast(CASE WHEN aa1.analysis_id = 108 THEN ar1.stratum_1 ELSE null END AS INT)                          AS intervalIndex,
   ar1.count_value                                     AS countValue,
   round(1.0 * ar1.count_value / denom.count_value, 5) AS percentValue
 FROM @results_database_schema.ACHILLES_analysis aa1

--- a/src/main/resources/resources/cdmresults/sql/report/observationperiod/observationlength_stats.sql
+++ b/src/main/resources/resources/cdmresults/sql/report/observationperiod/observationlength_stats.sql
@@ -1,10 +1,10 @@
 SELECT
-  min(cast(CASE WHEN isNumeric(ar1.stratum_1) = 1 THEN ar1.stratum_1 ELSE null END AS INT)) * 30 AS minValue,
-  max(cast(CASE WHEN isNumeric(ar1.stratum_1) = 1 THEN ar1.stratum_1 ELSE null END AS INT)) * 30 AS maxValue,
+  min(cast(CASE WHEN ar1.analysis_id = 108 THEN ar1.stratum_1 ELSE null END AS INT)) * 30 AS minValue,
+  max(cast(CASE WHEN ar1.analysis_id = 108 THEN ar1.stratum_1 ELSE null END AS INT)) * 30 AS maxValue,
   30                                   AS intervalSize
 FROM @results_database_schema.ACHILLES_analysis aa1
 INNER JOIN @results_database_schema.achilles_results ar1 ON aa1.analysis_id = ar1.analysis_id,
 (
 SELECT count_value FROM @results_database_schema.achilles_results WHERE analysis_id = 1
 ) denom
-WHERE aa1.analysis_id = 108
+WHERE ar1.analysis_id = 108

--- a/src/main/resources/resources/cdmresults/sql/report/observationperiod/observationlengthbyage.sql
+++ b/src/main/resources/resources/cdmresults/sql/report/observationperiod/observationlengthbyage.sql
@@ -1,7 +1,7 @@
 SELECT
   CONCAT(
-    cast(cast(CASE WHEN isNumeric(ard1.stratum_1) = 1 THEN ard1.stratum_1 ELSE null END AS INT) * 10 AS VARCHAR(11)), '-',
-    cast((cast(CASE WHEN isNumeric(ard1.stratum_1) = 1 THEN ard1.stratum_1 ELSE null END AS INT) + 1) * 10 - 1 AS VARCHAR(11))
+    cast(cast(CASE WHEN ard1.analysis_id = 107 THEN ard1.stratum_1 ELSE null END AS INT) * 10 AS VARCHAR(11)), '-',
+    cast((cast(CASE WHEN ard1.analysis_id = 107 THEN ard1.stratum_1 ELSE null END AS INT) + 1) * 10 - 1 AS VARCHAR(11))
   )                                                           AS category,
   ard1.min_value                                              AS min_value,
   ard1.p10_value                                              AS p10_value,

--- a/src/main/resources/resources/cdmresults/sql/report/observationperiod/observationlengthbygender.sql
+++ b/src/main/resources/resources/cdmresults/sql/report/observationperiod/observationlengthbygender.sql
@@ -8,5 +8,5 @@ SELECT
   ard1.p90_value    AS p90_value,
   ard1.max_value    AS max_value
 FROM @results_database_schema.achilles_results_dist ard1
-INNER JOIN @vocab_database_schema.concept c1 ON CAST(CASE WHEN isNumeric(ard1.stratum_1) = 1 THEN ard1.stratum_1 ELSE null END AS INT) = c1.concept_id
+INNER JOIN @vocab_database_schema.concept c1 ON CAST(CASE WHEN ard1.analysis_id = 106 THEN ard1.stratum_1 ELSE null END AS INT) = c1.concept_id
 WHERE ard1.analysis_id = 106

--- a/src/main/resources/resources/cdmresults/sql/report/observationperiod/observedbymonth.sql
+++ b/src/main/resources/resources/cdmresults/sql/report/observationperiod/observedbymonth.sql
@@ -1,5 +1,5 @@
 SELECT
-  cast(CASE WHEN isNumeric(ar1.stratum_1) = 1 THEN ar1.stratum_1 ELSE null END AS INT)                          AS monthYear,
+  cast(CASE WHEN ar1.analysis_id = 110 THEN ar1.stratum_1 ELSE null END AS INT)                          AS monthYear,
   ar1.count_value                                     AS countValue,
   round(1.0 * ar1.count_value / denom.count_value, 5) AS percentValue
 FROM (SELECT *

--- a/src/main/resources/resources/cdmresults/sql/report/observationperiod/observedbyyear_data.sql
+++ b/src/main/resources/resources/cdmresults/sql/report/observationperiod/observedbyyear_data.sql
@@ -1,5 +1,5 @@
 SELECT
-  cast(CASE WHEN isNumeric(ar1.stratum_1) = 1 THEN ar1.stratum_1 ELSE null END AS INT) - MinValue.MinValue      AS intervalIndex,
+  cast(CASE WHEN ar1.analysis_id = 109 THEN ar1.stratum_1 ELSE null END AS INT) - MinValue.MinValue      AS intervalIndex,
   ar1.count_value                                     AS countValue,
   round(1.0 * ar1.count_value / denom.count_value, 5) AS percentValue
 FROM
@@ -8,7 +8,7 @@ FROM
     FROM @results_database_schema.achilles_results WHERE analysis_id = 109
   ) ar1,
   (
-    SELECT min(cast(CASE WHEN isNumeric(stratum_1) = 1 THEN stratum_1 ELSE null END AS INT)) AS MinValue
+    SELECT min(cast(CASE WHEN analysis_id = 109 THEN stratum_1 ELSE null END AS INT)) AS MinValue
     FROM @results_database_schema.achilles_results WHERE analysis_id = 109
   ) MinValue,
   (

--- a/src/main/resources/resources/cdmresults/sql/report/observationperiod/observedbyyear_stats.sql
+++ b/src/main/resources/resources/cdmresults/sql/report/observationperiod/observedbyyear_stats.sql
@@ -1,6 +1,6 @@
 SELECT
-  min(cast(CASE WHEN isNumeric(ar1.stratum_1) = 1 THEN ar1.stratum_1 ELSE null END AS INT)) AS minValue,
-  max(cast(CASE WHEN isNumeric(ar1.stratum_1) = 1 THEN ar1.stratum_1 ELSE null END AS INT)) AS maxValue,
+  min(cast(CASE WHEN  ar1.analysis_id = 109 THEN ar1.stratum_1 ELSE null END AS INT)) AS minValue,
+  max(cast(CASE WHEN  ar1.analysis_id = 109 THEN ar1.stratum_1 ELSE null END AS INT)) AS maxValue,
   1                               AS intervalSize
 FROM @results_database_schema.achilles_results ar1
 WHERE ar1.analysis_id = 109

--- a/src/main/resources/resources/cdmresults/sql/report/person/yearofbirth_data.sql
+++ b/src/main/resources/resources/cdmresults/sql/report/person/yearofbirth_data.sql
@@ -1,10 +1,10 @@
 SELECT
-  cast(CASE WHEN isNumeric(ar1.stratum_1) = 1 THEN ar1.stratum_1 ELSE null END AS INT) - MinValue.MinValue      AS intervalIndex,
+  cast(CASE WHEN ar1.analysis_id = 3 THEN ar1.stratum_1 ELSE null END AS INT) - MinValue.MinValue      AS intervalIndex,
   ar1.count_value                                     AS countValue,
   round(1.0 * ar1.count_value / denom.count_value, 5) AS percentValue
 FROM (SELECT *
       FROM @results_database_schema.achilles_results WHERE analysis_id = 3) ar1,
-  (SELECT min(cast(CASE WHEN isNumeric(stratum_1) = 1 THEN stratum_1 ELSE null END AS INT)) AS MinValue
+  (SELECT min(cast(CASE WHEN analysis_id = 3 THEN stratum_1 ELSE null END AS INT)) AS MinValue
    FROM @results_database_schema.achilles_results WHERE analysis_id = 3) MinValue,
   (SELECT count_value
    FROM @results_database_schema.achilles_results WHERE analysis_id = 1) denom

--- a/src/main/resources/resources/cdmresults/sql/report/person/yearofbirth_stats.sql
+++ b/src/main/resources/resources/cdmresults/sql/report/person/yearofbirth_stats.sql
@@ -1,6 +1,6 @@
 SELECT
-  min(cast(CASE WHEN isNumeric(ar1.stratum_1) = 1 THEN ar1.stratum_1 ELSE null END AS INT)) AS minValue,
-  max(cast(CASE WHEN isNumeric(ar1.stratum_1) = 1 THEN ar1.stratum_1 ELSE null END AS INT)) AS maxValue,
+  min(cast(CASE WHEN ar1.analysis_id = 3 THEN ar1.stratum_1 ELSE null END AS INT)) AS minValue,
+  max(cast(CASE WHEN ar1.analysis_id = 3 THEN ar1.stratum_1 ELSE null END AS INT)) AS maxValue,
   1                               AS intervalSize
 FROM @results_database_schema.achilles_results ar1
 WHERE ar1.analysis_id = 3

--- a/src/main/resources/resources/cdmresults/sql/report/procedure/drilldown/ageAtFirstOccurrence.sql
+++ b/src/main/resources/resources/cdmresults/sql/report/procedure/drilldown/ageAtFirstOccurrence.sql
@@ -9,11 +9,9 @@ SELECT
   ard1.p90_value    AS p90_value,
   ard1.max_value    AS max_value
 FROM @results_database_schema.achilles_results_dist ard1
-INNER JOIN
-@vocab_database_schema.concept c1
-ON CAST(CASE WHEN isNumeric(ard1.stratum_1) = 1 THEN ard1.stratum_1 ELSE null END AS INT) = c1.concept_id
-INNER JOIN
-@vocab_database_schema.concept c2
-ON CAST(CASE WHEN isNumeric(ard1.stratum_2) = 1 THEN ard1.stratum_2 ELSE null END AS INT) = c2.concept_id
+INNER JOIN @vocab_database_schema.concept c1
+  ON CAST(CASE WHEN ard1.analysis_id = 606 THEN ard1.stratum_1 ELSE null END AS INT) = c1.concept_id
+INNER JOIN @vocab_database_schema.concept c2
+  ON CAST(CASE WHEN ard1.analysis_id = 606 THEN ard1.stratum_2 ELSE null END AS INT) = c2.concept_id
 WHERE ard1.analysis_id = 606
-AND c1.concept_id = @conceptId
+  AND c1.concept_id = @conceptId

--- a/src/main/resources/resources/cdmresults/sql/report/procedure/drilldown/frequencyDistribution.sql
+++ b/src/main/resources/resources/cdmresults/sql/report/procedure/drilldown/frequencyDistribution.sql
@@ -5,8 +5,8 @@ SELECT
 	num.stratum_2								AS x_count
 FROM 
 	(SELECT count_value FROM @results_database_schema.achilles_results WHERE analysis_id = 1) denom,
-	(SELECT CAST(CASE WHEN isNumeric(stratum_1) = 1 THEN stratum_1 ELSE null END AS INT) stratum_1, 
-	        CAST(CASE WHEN isNumeric(stratum_2) = 1 THEN stratum_2 ELSE null END AS INT) stratum_2, count_value 
+	(SELECT CAST(CASE WHEN analysis_id = 691 THEN stratum_1 ELSE null END AS INT) stratum_1, 
+	        CAST(CASE WHEN analysis_id = 691 THEN stratum_2 ELSE null END AS INT) stratum_2, count_value 
 		FROM @results_database_schema.achilles_results
 		WHERE analysis_id = 691) num
 	INNER JOIN @vocab_database_schema.concept c1 ON num.stratum_1 = c1.concept_id

--- a/src/main/resources/resources/cdmresults/sql/report/procedure/drilldown/prevalenceByGenderAgeYear.sql
+++ b/src/main/resources/resources/cdmresults/sql/report/procedure/drilldown/prevalenceByGenderAgeYear.sql
@@ -1,18 +1,19 @@
 SELECT
   c1.concept_id                                                          AS concept_id,
   c1.concept_name                                                        AS concept_name,
-  CONCAT(cast(CAST(CASE WHEN isNumeric(num_stratum_4) = 1 THEN num_stratum_4 ELSE null END AS INT) * 10 AS VARCHAR(11)), 
-         '-', cast((CAST(CASE WHEN isNumeric(num_stratum_4) = 1 THEN num_stratum_4 ELSE null END AS INT) + 1) * 10 - 1 AS
+  CONCAT(cast(CAST(CASE WHEN num_analysis_id = 604 THEN num_stratum_4 ELSE null END AS INT) * 10 AS VARCHAR(11)), 
+         '-', cast((CAST(CASE WHEN num_analysis_id = 604 THEN num_stratum_4 ELSE null END AS INT) + 1) * 10 - 1 AS
                                                                 VARCHAR(11))) AS trellis_name,
   --age decile
   c2.concept_name                                                        AS series_name,
   --gender
-  CAST(CASE WHEN isNumeric(num_stratum_2) = 1 THEN num_stratum_2 ELSE null END AS INT)                                             AS x_calendar_year,
+  CAST(CASE WHEN num_analysis_id = 604 THEN num_stratum_2 ELSE null END AS INT)                                             AS x_calendar_year,
   -- calendar year, note, there could be blanks
   ROUND(1000 * (1.0 * num_count_value / denom_count_value),
         5)                                                               AS y_prevalence_1000_pp --prevalence, per 1000 persons
 FROM (
        SELECT
+         num.analysis_id   AS num_analysis_id,
          num.stratum_1     AS num_stratum_1,
          num.stratum_2     AS num_stratum_2,
          num.stratum_3     AS num_stratum_3,
@@ -36,7 +37,7 @@ FROM (
               AND num.stratum_4 = denom.stratum_3
      ) tmp
   INNER JOIN @vocab_database_schema.concept c1
-ON CAST(CASE WHEN isNumeric(num_stratum_1) = 1 THEN num_stratum_1 ELSE null END AS INT) = c1.concept_id
+ON CAST(CASE WHEN num_analysis_id = 604 THEN num_stratum_1 ELSE null END AS INT) = c1.concept_id
 INNER JOIN @vocab_database_schema.concept c2
-ON CAST(CASE WHEN isNumeric(num_stratum_3) = 1 THEN num_stratum_3 ELSE null END AS INT) = c2.concept_id
+ON CAST(CASE WHEN num_analysis_id = 604 THEN num_stratum_3 ELSE null END AS INT) = c2.concept_id
 WHERE c1.concept_id = @conceptId

--- a/src/main/resources/resources/cdmresults/sql/report/procedure/drilldown/prevalenceByMonth.sql
+++ b/src/main/resources/resources/cdmresults/sql/report/procedure/drilldown/prevalenceByMonth.sql
@@ -5,7 +5,7 @@ SELECT
   -- calendar year, note, there could be blanks
   round(1000 * (1.0 * num.count_value / denom.count_value), 5) AS y_prevalence_1000_pp --prevalence, per 1000 persons
 FROM (
-	SELECT stratum_1, stratum_2, count_value
+	SELECT analysis_id, stratum_1, stratum_2, count_value
 	FROM @results_database_schema.achilles_results
 	WHERE analysis_id = 602
 	GROUP BY stratum_1, stratum_2, count_value
@@ -16,6 +16,6 @@ INNER JOIN (
 	WHERE analysis_id = 117
 	GROUP BY stratum_1, count_value
 ) denom ON num.stratum_2 = denom.stratum_1 --calendar year
-INNER JOIN @vocab_database_schema.concept c1 ON CAST(CASE WHEN isNumeric(num.stratum_1) = 1 THEN num.stratum_1 ELSE null END AS BIGINT) = c1.concept_id
+INNER JOIN @vocab_database_schema.concept c1 ON CAST(CASE WHEN num.analysis_id = 602 THEN num.stratum_1 ELSE null END AS BIGINT) = c1.concept_id
 WHERE c1.concept_id = @conceptId
-ORDER BY CAST(CASE WHEN isNumeric(num.stratum_2) = 1 THEN num.stratum_2 ELSE null END AS INT )
+ORDER BY CAST(CASE WHEN num.analysis_id = 602 THEN num.stratum_2 ELSE null END AS INT )

--- a/src/main/resources/resources/cdmresults/sql/report/procedure/drilldownsummary/ageAtFirstOccurrence.sql
+++ b/src/main/resources/resources/cdmresults/sql/report/procedure/drilldownsummary/ageAtFirstOccurrence.sql
@@ -11,8 +11,8 @@ SELECT
 FROM @results_database_schema.achilles_results_dist ard1
 INNER JOIN
 @vocab_database_schema.concept c1
-ON CAST(CASE WHEN isNumeric(ard1.stratum_1) = 1 THEN ard1.stratum_1 ELSE null END AS INT) = c1.concept_id
+ON CAST(CASE WHEN ard1.analysis_id = 606 THEN ard1.stratum_1 ELSE null END AS INT) = c1.concept_id
 INNER JOIN
 @vocab_database_schema.concept c2
-ON CAST(CASE WHEN isNumeric(ard1.stratum_2) = 1 THEN ard1.stratum_2 ELSE null END AS INT) = c2.concept_id
+ON CAST(CASE WHEN ard1.analysis_id = 606 THEN ard1.stratum_2 ELSE null END AS INT) = c2.concept_id
 WHERE ard1.analysis_id = 606

--- a/src/main/resources/resources/cdmresults/sql/report/procedure/drilldownsummary/frequencyDistribution.sql
+++ b/src/main/resources/resources/cdmresults/sql/report/procedure/drilldownsummary/frequencyDistribution.sql
@@ -5,8 +5,8 @@ SELECT
 	num.stratum_2								AS x_count
 FROM 
 	(SELECT count_value FROM @results_database_schema.achilles_results WHERE analysis_id = 1) denom,
-	(SELECT CAST(CASE WHEN isNumeric(stratum_1) = 1 THEN stratum_1 ELSE null END AS INT) stratum_1, 
-	        CAST(CASE WHEN isNumeric(stratum_2) = 1 THEN stratum_2 ELSE null END AS INT) stratum_2, count_value 
+	(SELECT CAST(CASE WHEN analysis_id = 691 THEN stratum_1 ELSE null END AS INT) stratum_1, 
+	        CAST(CASE WHEN analysis_id = 691 THEN stratum_2 ELSE null END AS INT) stratum_2, count_value 
 		FROM @results_database_schema.achilles_results
 		WHERE analysis_id = 691) num
 	INNER JOIN @vocab_database_schema.concept c1 ON num.stratum_1 = c1.concept_id

--- a/src/main/resources/resources/cdmresults/sql/report/procedure/drilldownsummary/prevalenceByGenderAgeYear.sql
+++ b/src/main/resources/resources/cdmresults/sql/report/procedure/drilldownsummary/prevalenceByGenderAgeYear.sql
@@ -1,18 +1,19 @@
 SELECT
   c1.concept_id                                                          AS concept_id,
   c1.concept_name                                                        AS concept_name,
-  CONCAT(cast(CAST(CASE WHEN isNumeric(num_stratum_4) = 1 THEN num_stratum_4 ELSE null END AS INT) * 10 AS VARCHAR(11)), 
-         '-', cast((CAST(CASE WHEN isNumeric(num_stratum_4) = 1 THEN num_stratum_4 ELSE null END AS INT) + 1) * 10 - 1 AS
+  CONCAT(cast(CAST(CASE WHEN num_analysis_id) = 604 THEN num_stratum_4 ELSE null END AS INT) * 10 AS VARCHAR(11)), 
+         '-', cast((CAST(CASE WHEN num_analysis_id) = 604 THEN num_stratum_4 ELSE null END AS INT) + 1) * 10 - 1 AS
                                                                 VARCHAR(11))) AS trellis_name,
   --age decile
   c2.concept_name                                                        AS series_name,
   --gender
-  CAST(CASE WHEN isNumeric(num_stratum_2) = 1 THEN num_stratum_2 ELSE null END AS INT)                                             AS x_calendar_year,
+  CAST(CASE WHEN num_analysis_id) = 604 THEN num_stratum_2 ELSE null END AS INT)                                             AS x_calendar_year,
   -- calendar year, note, there could be blanks
   ROUND(1000 * (1.0 * num_count_value / denom_count_value),
         5)                                                               AS y_prevalence_1000_pp --prevalence, per 1000 persons
 FROM (
        SELECT
+         num.analysis_id   AS num_analysis_id,
          num.stratum_1     AS num_stratum_1,
          num.stratum_2     AS num_stratum_2,
          num.stratum_3     AS num_stratum_3,
@@ -36,6 +37,6 @@ FROM (
               AND num.stratum_4 = denom.stratum_3
      ) tmp
   INNER JOIN @vocab_database_schema.concept c1
-ON CAST(CASE WHEN isNumeric(num_stratum_1) = 1 THEN num_stratum_1 ELSE null END AS INT) = c1.concept_id
+ON CAST(CASE WHEN num_analysis_id) = 604 THEN num_stratum_1 ELSE null END AS INT) = c1.concept_id
 INNER JOIN @vocab_database_schema.concept c2
-ON CAST(CASE WHEN isNumeric(num_stratum_3) = 1 THEN num_stratum_3 ELSE null END AS INT) = c2.concept_id
+ON CAST(CASE WHEN num_analysis_id) = 604 THEN num_stratum_3 ELSE null END AS INT) = c2.concept_id

--- a/src/main/resources/resources/cdmresults/sql/report/procedure/drilldownsummary/prevalenceByMonth.sql
+++ b/src/main/resources/resources/cdmresults/sql/report/procedure/drilldownsummary/prevalenceByMonth.sql
@@ -5,7 +5,7 @@ SELECT
   -- calendar year, note, there could be blanks
   round(1000 * (1.0 * num.count_value / denom.count_value), 5) AS y_prevalence_1000_pp --prevalence, per 1000 persons
 FROM (
-	SELECT stratum_1, stratum_2, count_value
+	SELECT analysis_id, stratum_1, stratum_2, count_value
 	FROM @results_database_schema.achilles_results
 	WHERE analysis_id = 602
 	GROUP BY stratum_1, stratum_2, count_value
@@ -16,5 +16,5 @@ INNER JOIN (
 	WHERE analysis_id = 117
 	GROUP BY stratum_1, count_value
 ) denom ON num.stratum_2 = denom.stratum_1 --calendar year
-INNER JOIN @vocab_database_schema.concept c1 ON CAST(CASE WHEN isNumeric(num.stratum_1) = 1 THEN num.stratum_1 ELSE null END AS BIGINT) = c1.concept_id
-ORDER BY CAST(CASE WHEN isNumeric(num.stratum_2) = 1 THEN num.stratum_2 ELSE null END AS INT )
+INNER JOIN @vocab_database_schema.concept c1 ON CAST(CASE WHEN num.analysis_id = 602 THEN num.stratum_1 ELSE null END AS BIGINT) = c1.concept_id
+ORDER BY CAST(CASE WHEN num.analysis_id = 602 THEN num.stratum_2 ELSE null END AS INT )

--- a/src/main/resources/resources/cdmresults/sql/report/procedure/treemap.sql
+++ b/src/main/resources/resources/cdmresults/sql/report/procedure/treemap.sql
@@ -17,7 +17,7 @@ FROM (SELECT *
     ON ar1.stratum_1 = ar2.stratum_1
   INNER JOIN
   @results_database_schema.concept_hierarchy concept_hierarchy
-    ON CAST(CASE WHEN isNumeric(ar1.stratum_1) = 1 THEN ar1.stratum_1 ELSE null END AS INT) = concept_hierarchy.concept_id
+    ON CAST(CASE WHEN ar1.analysis_id = 600 THEN ar1.stratum_1 ELSE null END AS INT) = concept_hierarchy.concept_id
    AND concept_hierarchy.treemap='Procedure'
  ,
   (SELECT count_value

--- a/src/main/resources/resources/cdmresults/sql/report/visit/drilldown/ageAtFirstOccurrence.sql
+++ b/src/main/resources/resources/cdmresults/sql/report/visit/drilldown/ageAtFirstOccurrence.sql
@@ -9,7 +9,7 @@ SELECT
   ard1.p90_value    AS p90_value,
   ard1.max_value    AS max_value
 FROM @results_database_schema.achilles_results_dist ard1
-INNER JOIN @vocab_database_schema.concept c1 ON CAST(CASE WHEN isNumeric(ard1.stratum_1) = 1 THEN ard1.stratum_1 ELSE null END AS INT) = c1.concept_id
-INNER JOIN @vocab_database_schema.concept c2 ON CAST(CASE WHEN isNumeric(ard1.stratum_2) = 1 THEN ard1.stratum_2 ELSE null END AS INT) = c2.concept_id
+INNER JOIN @vocab_database_schema.concept c1 ON CAST(CASE WHEN ard1.analysis_id = 206 THEN ard1.stratum_1 ELSE null END AS INT) = c1.concept_id
+INNER JOIN @vocab_database_schema.concept c2 ON CAST(CASE WHEN ard1.analysis_id = 206 THEN ard1.stratum_2 ELSE null END AS INT) = c2.concept_id
 WHERE ard1.analysis_id = 206
 AND c1.concept_id = @conceptId

--- a/src/main/resources/resources/cdmresults/sql/report/visit/drilldown/prevalenceByGenderAgeYear.sql
+++ b/src/main/resources/resources/cdmresults/sql/report/visit/drilldown/prevalenceByGenderAgeYear.sql
@@ -1,18 +1,19 @@
 SELECT
   c1.concept_id                                                          AS concept_id,
   c1.concept_name                                                        AS concept_name,
-  CONCAT(cast(CAST(CASE WHEN isNumeric(num_stratum_4) = 1 THEN num_stratum_4 ELSE null END AS INT) * 10 AS VARCHAR(11)), 
-         '-', cast((CAST(CASE WHEN isNumeric(num_stratum_4) = 1 THEN num_stratum_4 ELSE null END AS INT) + 1) * 10 - 1 AS
+  CONCAT(cast(CAST(CASE WHEN num_analysis_id = 204 THEN num_stratum_4 ELSE null END AS INT) * 10 AS VARCHAR(11)), 
+         '-', cast((CAST(CASE WHEN num_analysis_id = 204 THEN num_stratum_4 ELSE null END AS INT) + 1) * 10 - 1 AS
                                                                 VARCHAR(11))) AS trellis_name,
   --age decile
   c2.concept_name                                                        AS series_name,
   --gender
-  CAST(CASE WHEN isNumeric(num_stratum_2) = 1 THEN num_stratum_2 ELSE null END AS INT)                                             AS x_calendar_year,
+  CAST(CASE WHEN num_analysis_id = 204 THEN num_stratum_2 ELSE null END AS INT)                                             AS x_calendar_year,
   -- calendar year, note, there could be blanks
   ROUND(1000 * (1.0 * num_count_value / denom_count_value),
         5)                                                               AS y_prevalence_1000_pp --prevalence, per 1000 persons
 FROM (
        SELECT
+         num.analysis_id   AS num_analysis_id,
          num.stratum_1     AS num_stratum_1,
          num.stratum_2     AS num_stratum_2,
          num.stratum_3     AS num_stratum_3,
@@ -36,9 +37,9 @@ FROM (
               AND num.stratum_4 = denom.stratum_3
      ) tmp
   INNER JOIN @vocab_database_schema.concept c1
-ON CAST(CASE WHEN isNumeric(num_stratum_1) = 1 THEN num_stratum_1 ELSE null END AS INT) = c1.concept_id
+ON CAST(CASE WHEN num_analysis_id = 204 THEN num_stratum_1 ELSE null END AS INT) = c1.concept_id
 INNER JOIN @vocab_database_schema.concept c2
-ON CAST(CASE WHEN isNumeric(num_stratum_3) = 1 THEN num_stratum_3 ELSE null END AS INT) = c2.concept_id
+ON CAST(CASE WHEN num_analysis_id = 204 THEN num_stratum_3 ELSE null END AS INT) = c2.concept_id
 WHERE c1.concept_id = @conceptId
 
 

--- a/src/main/resources/resources/cdmresults/sql/report/visit/drilldown/prevalenceByMonth.sql
+++ b/src/main/resources/resources/cdmresults/sql/report/visit/drilldown/prevalenceByMonth.sql
@@ -12,6 +12,6 @@ FROM
   (SELECT *
    FROM @results_database_schema.achilles_results WHERE analysis_id = 117) denom ON num.stratum_2 = denom.stratum_1
   --calendar year
-  INNER JOIN @vocab_database_schema.concept c1 ON CAST(CASE WHEN isNumeric(num.stratum_1) = 1 THEN num.stratum_1 ELSE null END AS INT) = c1.concept_id
+  INNER JOIN @vocab_database_schema.concept c1 ON CAST(CASE WHEN num.analysis_id = 202 THEN num.stratum_1 ELSE null END AS INT) = c1.concept_id
 WHERE c1.concept_id = @conceptId
 

--- a/src/main/resources/resources/cdmresults/sql/report/visit/drilldown/visitDurationByType.sql
+++ b/src/main/resources/resources/cdmresults/sql/report/visit/drilldown/visitDurationByType.sql
@@ -10,6 +10,6 @@ SELECT
   ard1.max_value    AS max_value
 FROM @results_database_schema.achilles_results_dist ard1
 INNER JOIN
-@vocab_database_schema.concept c1 ON CAST(CASE WHEN isNumeric(ard1.stratum_1) = 1 THEN ard1.stratum_1 ELSE null END AS INT) = c1.concept_id
+@vocab_database_schema.concept c1 ON CAST(CASE WHEN ard1.analysis_id = 211 THEN ard1.stratum_1 ELSE null END AS INT) = c1.concept_id
 WHERE ard1.analysis_id = 211
-AND CAST(CASE WHEN isNumeric(ard1.stratum_1) = 1 THEN ard1.stratum_1 ELSE null END AS INT) = @conceptId
+AND CAST(CASE WHEN ard1.analysis_id = 211 THEN ard1.stratum_1 ELSE null END AS INT) = @conceptId

--- a/src/main/resources/resources/cdmresults/sql/report/visit/drilldownsummary/ageAtFirstOccurrence.sql
+++ b/src/main/resources/resources/cdmresults/sql/report/visit/drilldownsummary/ageAtFirstOccurrence.sql
@@ -9,6 +9,6 @@ SELECT
   ard1.p90_value    AS p90_value,
   ard1.max_value    AS max_value
 FROM @results_database_schema.achilles_results_dist ard1
-INNER JOIN @vocab_database_schema.concept c1 ON CAST(CASE WHEN isNumeric(ard1.stratum_1) = 1 THEN ard1.stratum_1 ELSE null END AS INT) = c1.concept_id
-INNER JOIN @vocab_database_schema.concept c2 ON CAST(CASE WHEN isNumeric(ard1.stratum_2) = 1 THEN ard1.stratum_2 ELSE null END AS INT) = c2.concept_id
+INNER JOIN @vocab_database_schema.concept c1 ON CAST(CASE WHEN ard1.analysis_id = 206 THEN ard1.stratum_1 ELSE null END AS INT) = c1.concept_id
+INNER JOIN @vocab_database_schema.concept c2 ON CAST(CASE WHEN ard1.analysis_id = 206 THEN ard1.stratum_2 ELSE null END AS INT) = c2.concept_id
 WHERE ard1.analysis_id = 206

--- a/src/main/resources/resources/cdmresults/sql/report/visit/drilldownsummary/prevalenceByGenderAgeYear.sql
+++ b/src/main/resources/resources/cdmresults/sql/report/visit/drilldownsummary/prevalenceByGenderAgeYear.sql
@@ -1,18 +1,19 @@
 SELECT
   c1.concept_id                                                          AS concept_id,
   c1.concept_name                                                        AS concept_name,
-  CONCAT(cast(CAST(CASE WHEN isNumeric(num_stratum_4) = 1 THEN num_stratum_4 ELSE null END AS INT) * 10 AS VARCHAR(11)), 
-         '-', cast((CAST(CASE WHEN isNumeric(num_stratum_4) = 1 THEN num_stratum_4 ELSE null END AS INT) + 1) * 10 - 1 AS
+  CONCAT(cast(CAST(CASE WHEN num_analysis_id = 204 THEN num_stratum_4 ELSE null END AS INT) * 10 AS VARCHAR(11)), 
+         '-', cast((CAST(CASE WHEN num_analysis_id = 204 THEN num_stratum_4 ELSE null END AS INT) + 1) * 10 - 1 AS
                                                                 VARCHAR(11))) AS trellis_name,
   --age decile
   c2.concept_name                                                        AS series_name,
   --gender
-  CAST(CASE WHEN isNumeric(num_stratum_2) = 1 THEN num_stratum_2 ELSE null END AS INT)                                             AS x_calendar_year,
+  CAST(CASE WHEN num_analysis_id = 204 THEN num_stratum_2 ELSE null END AS INT)                                             AS x_calendar_year,
   -- calendar year, note, there could be blanks
   ROUND(1000 * (1.0 * num_count_value / denom_count_value),
         5)                                                               AS y_prevalence_1000_pp --prevalence, per 1000 persons
 FROM (
        SELECT
+         num.analysis_id   AS num_analysis_id,
          num.stratum_1     AS num_stratum_1,
          num.stratum_2     AS num_stratum_2,
          num.stratum_3     AS num_stratum_3,
@@ -36,8 +37,8 @@ FROM (
               AND num.stratum_4 = denom.stratum_3
      ) tmp
   INNER JOIN @vocab_database_schema.concept c1
-ON CAST(CASE WHEN isNumeric(num_stratum_1) = 1 THEN num_stratum_1 ELSE null END AS INT) = c1.concept_id
+ON CAST(CASE WHEN num_analysis_id = 204 THEN num_stratum_1 ELSE null END AS INT) = c1.concept_id
 INNER JOIN @vocab_database_schema.concept c2
-ON CAST(CASE WHEN isNumeric(num_stratum_3) = 1 THEN num_stratum_3 ELSE null END AS INT) = c2.concept_id
+ON CAST(CASE WHEN num_analysis_id = 204 THEN num_stratum_3 ELSE null END AS INT) = c2.concept_id
 
 

--- a/src/main/resources/resources/cdmresults/sql/report/visit/drilldownsummary/prevalenceByMonth.sql
+++ b/src/main/resources/resources/cdmresults/sql/report/visit/drilldownsummary/prevalenceByMonth.sql
@@ -12,5 +12,5 @@ FROM
   (SELECT *
    FROM @results_database_schema.achilles_results WHERE analysis_id = 117) denom ON num.stratum_2 = denom.stratum_1
   --calendar year
-  INNER JOIN @vocab_database_schema.concept c1 ON CAST(CASE WHEN isNumeric(num.stratum_1) = 1 THEN num.stratum_1 ELSE null END AS INT) = c1.concept_id
+  INNER JOIN @vocab_database_schema.concept c1 ON CAST(CASE WHEN num.analysis_id = 202 THEN num.stratum_1 ELSE null END AS INT) = c1.concept_id
 

--- a/src/main/resources/resources/cdmresults/sql/report/visit/drilldownsummary/visitDurationByType.sql
+++ b/src/main/resources/resources/cdmresults/sql/report/visit/drilldownsummary/visitDurationByType.sql
@@ -10,5 +10,5 @@ SELECT
   ard1.max_value    AS max_value
 FROM @results_database_schema.achilles_results_dist ard1
 INNER JOIN
-@vocab_database_schema.concept c1 ON CAST(CASE WHEN isNumeric(ard1.stratum_1) = 1 THEN ard1.stratum_1 ELSE null END AS INT) = c1.concept_id
+@vocab_database_schema.concept c1 ON CAST(CASE WHEN ard1.analysis_id = 211 THEN ard1.stratum_1 ELSE null END AS INT) = c1.concept_id
 WHERE ard1.analysis_id = 211

--- a/src/main/resources/resources/cohortresults/sql/cohortSpecific/ageAtIndex.sql
+++ b/src/main/resources/resources/cohortresults/sql/cohortSpecific/ageAtIndex.sql
@@ -1,5 +1,5 @@
-select CAST(CASE WHEN isNumeric(stratum_1) = 1 THEN stratum_1 ELSE null END AS INT) as age_at_index,
+select CAST(CASE WHEN analysis_id = 1800 THEN stratum_1 ELSE null END AS INT) as age_at_index,
 	count_value as num_persons
 from @ohdsi_database_schema.heracles_results
-where analysis_id in (1800)
+where analysis_id = 1800
 and cohort_definition_id = @cohortDefinitionId

--- a/src/main/resources/resources/cohortresults/sql/cohortSpecific/byConcept/drugOccursRelativeToIndex.sql
+++ b/src/main/resources/resources/cohortresults/sql/cohortSpecific/byConcept/drugOccursRelativeToIndex.sql
@@ -9,33 +9,33 @@ SELECT hr1.cohort_definition_id,
          ELSE 0 
        END     AS pct_persons 
 FROM   (SELECT cohort_definition_id, 
-               CAST(CASE WHEN isNumeric(stratum_1) = 1 THEN stratum_1 ELSE null END AS INT)      AS concept_id,
-               CAST(CASE WHEN isNumeric(stratum_2) = 1 THEN stratum_2 ELSE null END AS INT) * 30 AS duration,
+               CAST(CASE WHEN analysis_id = 1870 THEN stratum_1 ELSE null END AS INT)      AS concept_id,
+               CAST(CASE WHEN analysis_id = 1870 THEN stratum_2 ELSE null END AS INT) * 30 AS duration,
                count_value 
         FROM   @ohdsi_database_schema.heracles_results 
-        WHERE  analysis_id IN ( 1870 ) 
+        WHERE  analysis_id = 1870 
                AND cohort_definition_id = @cohortDefinitionId) hr1 
        INNER JOIN (SELECT cohort_definition_id, 
-                          -1 * CAST(CASE WHEN isNumeric(stratum_1) = 1 THEN stratum_1 ELSE null END AS INT) * 30                AS
+                          -1 * CAST(CASE WHEN analysis_id = 1805 THEN stratum_1 ELSE null END AS INT) * 30                AS
               duration, 
                           Sum(count_value) 
                             OVER ( 
                               partition BY cohort_definition_id 
-                              ORDER BY -1* CAST(CASE WHEN isNumeric(stratum_1) = 1 THEN stratum_1 ELSE null END AS INT)*30 ASC) AS
+                              ORDER BY -1* CAST(CASE WHEN analysis_id = 1805 THEN stratum_1 ELSE null END AS INT)*30 ASC) AS
               count_value 
                    FROM   @ohdsi_database_schema.heracles_results 
-                   WHERE  analysis_id IN ( 1805 ) 
+                   WHERE  analysis_id = 1805 
                           AND cohort_definition_id = @cohortDefinitionId 
                           AND CAST(CASE WHEN isNumeric(stratum_1) = 1 THEN stratum_1 ELSE null END AS INT) > 0
                    UNION 
                    SELECT hr1.cohort_definition_id,
-                          CAST(CASE WHEN isNumeric(hr1.stratum_1) = 1 THEN hr1.stratum_1 ELSE null END AS INT) * 30
+                          CAST(CASE WHEN hr1.analysis_id = 1806 THEN hr1.stratum_1 ELSE null END AS INT) * 30
                           AS 
                           duration, 
                           t1.count_value - Sum(hr1.count_value) 
                           OVER ( 
                             partition BY hr1.cohort_definition_id 
-                            ORDER BY CAST(CASE WHEN isNumeric(hr1.stratum_1) = 1 THEN hr1.stratum_1 ELSE null END AS INT)*
+                            ORDER BY CAST(CASE WHEN hr1.analysis_id = 1806 THEN hr1.stratum_1 ELSE null END AS INT)*
                           30 ASC) AS 
                           count_value 
                    FROM   @ohdsi_database_schema.heracles_results hr1 
@@ -47,7 +47,7 @@ FROM   (SELECT cohort_definition_id,
                                       GROUP  BY cohort_definition_id) t1 
                                   ON hr1.cohort_definition_id = 
                                      t1.cohort_definition_id 
-                   WHERE  hr1.analysis_id IN ( 1806 ) 
+                   WHERE  hr1.analysis_id = 1806 
                           AND hr1.cohort_definition_id IN 
                               ( @cohortDefinitionId )) t1 
                ON hr1.cohort_definition_id = t1.cohort_definition_id 

--- a/src/main/resources/resources/cohortresults/sql/cohortSpecific/conditionOccurrencePrevalenceOfCondition.sql
+++ b/src/main/resources/resources/cohortresults/sql/cohortSpecific/conditionOccurrencePrevalenceOfCondition.sql
@@ -23,10 +23,10 @@ select   concept_hierarchy.concept_id,
 from
 (select stratum_1 as concept_id,
 	sum(count_value) as num_persons,
-	sum(case when CAST(CASE WHEN isNumeric(stratum_2) = 1 THEN stratum_2 ELSE null END AS INT) < 0 then count_value else 0 end) as num_persons_before,
-	sum(case when CAST(CASE WHEN isNumeric(stratum_2) = 1 THEN stratum_2 ELSE null END AS INT) > 0 then count_value else 0 end) as num_persons_after
+	sum(case when CAST(CASE WHEN analysis_id = 1820 THEN stratum_2 ELSE null END AS INT) < 0 then count_value else 0 end) as num_persons_before,
+	sum(case when CAST(CASE WHEN analysis_id = 1820 THEN stratum_2 ELSE null END AS INT) > 0 then count_value else 0 end) as num_persons_after
 from @ohdsi_database_schema.heracles_results
-where analysis_id in (1820) --first occurrence of condition
+where analysis_id = 1820 --first occurrence of condition
 and cohort_definition_id = @cohortDefinitionId
 group by stratum_1
 ) hr1

--- a/src/main/resources/resources/cohortresults/sql/cohortSpecific/drugEraPrevalenceOfDrug.sql
+++ b/src/main/resources/resources/cohortresults/sql/cohortSpecific/drugEraPrevalenceOfDrug.sql
@@ -31,10 +31,10 @@ select   concept_hierarchy.concept_id,
 from
 (select stratum_1 as concept_id,
 	sum(count_value) as num_persons,
-	sum(case when CAST(CASE WHEN isNumeric(stratum_2) = 1 THEN stratum_2 ELSE null END AS INT) < 0 then count_value else 0 end) as num_persons_before,
-	sum(case when CAST(CASE WHEN isNumeric(stratum_2) = 1 THEN stratum_2 ELSE null END AS INT) > 0 then count_value else 0 end) as num_persons_after
+	sum(case when CAST(CASE WHEN analysis_id = 1870 THEN stratum_2 ELSE null END AS INT) < 0 then count_value else 0 end) as num_persons_before,
+	sum(case when CAST(CASE WHEN analysis_id = 1870 THEN stratum_2 ELSE null END AS INT) > 0 then count_value else 0 end) as num_persons_after
 from @ohdsi_database_schema.heracles_results
-where analysis_id in (1870) --first occurrence of drug
+where analysis_id = 1870 --first occurrence of drug
 and cohort_definition_id = @cohortDefinitionId
 group by stratum_1
 ) hr1

--- a/src/main/resources/resources/cohortresults/sql/cohortSpecific/getTimeToEventDrilldown.sql
+++ b/src/main/resources/resources/cohortresults/sql/cohortSpecific/getTimeToEventDrilldown.sql
@@ -20,16 +20,16 @@ WITH denominator AS (
 
 			SELECT exposure_cohort_definition_id, 
 				outcome_cohort_definition_id,
-				CAST(CASE WHEN isNumeric(stratum_2) = 1 THEN stratum_2 ELSE null END AS INT) as stratum_1, sum(count_value) as count_value
+				CAST(CASE WHEN analysis_id = 1805 THEN stratum_2 ELSE null END AS INT) as stratum_1, sum(count_value) as count_value
 			FROM @ohdsi_database_schema.penelope_results
 			WHERE exposure_cohort_definition_id = @exposure_cohort_definition_id
 			AND outcome_cohort_definition_id = @outcome_cohort_definition_id
 			AND analysis_id = 1805
 			GROUP BY exposure_cohort_definition_id, 
 				outcome_cohort_definition_id,
-				CAST(CASE WHEN isNumeric(stratum_2) = 1 THEN stratum_2 ELSE null END AS INT)
+				CAST(CASE WHEN analysis_id = 1805 THEN stratum_2 ELSE null END AS INT)
 		) t0
-		WHERE CAST(CASE WHEN isNumeric(stratum_1) = 1 THEN stratum_1 ELSE null END AS INT)<= 10 OR count_value > 0
+		WHERE stratum_1 <= 10 OR count_value > 0
 		GROUP BY exposure_cohort_definition_id, outcome_cohort_definition_id, stratum_1 
 	) t1
 
@@ -57,16 +57,16 @@ WITH denominator AS (
 
 			SELECT exposure_cohort_definition_id, 
 				outcome_cohort_definition_id,
-				CAST(CASE WHEN isNumeric(stratum_2) = 1 THEN stratum_2 ELSE null END AS INT) as stratum_1, sum(count_value) as count_value
+				CAST(CASE WHEN analysis_id = 1806 THEN stratum_2 ELSE null END AS INT) as stratum_1, sum(count_value) as count_value
 			FROM @ohdsi_database_schema.penelope_results
 			WHERE exposure_cohort_definition_id = @exposure_cohort_definition_id
 			AND outcome_cohort_definition_id = @outcome_cohort_definition_id
 			AND analysis_id = 1806
 			GROUP BY exposure_cohort_definition_id, 
 				outcome_cohort_definition_id,
-				CAST(CASE WHEN isNumeric(stratum_2) = 1 THEN stratum_2 ELSE null END AS INT)
+				CAST(CASE WHEN analysis_id = 1806 THEN stratum_2 ELSE null END AS INT)
 		) t0
-		WHERE CAST(CASE WHEN isNumeric(stratum_1) = 1 THEN stratum_1 ELSE null END AS INT)<= 10 OR count_value > 0
+		WHERE stratum_1 <= 10 OR count_value > 0
 		GROUP BY exposure_cohort_definition_id, outcome_cohort_definition_id, stratum_1 
 	) t1
 	INNER JOIN
@@ -88,7 +88,7 @@ numerator_first as
 (
 	SELECT exposure_cohort_definition_id, 
 		outcome_cohort_definition_id,
-		CAST(CASE WHEN isNumeric(stratum_1) = 1 THEN stratum_1 ELSE null END AS INT)*30 AS duration,
+		CAST(CASE WHEN analysis_id = 12 THEN stratum_1 ELSE null END AS INT)*30 AS duration,
 		count_value
 	FROM @ohdsi_database_schema.penelope_results
 	WHERE exposure_cohort_definition_id = @exposure_cohort_definition_id
@@ -99,7 +99,7 @@ numerator_all as
 (
 	SELECT exposure_cohort_definition_id, 
 		outcome_cohort_definition_id,
-		CAST(CASE WHEN isNumeric(stratum_1) = 1 THEN stratum_1 ELSE null END AS INT)*30 AS duration,
+		CAST(CASE WHEN analysis_id = 13 THEN stratum_1 ELSE null END AS INT)*30 AS duration,
 		count_value
 	FROM @ohdsi_database_schema.penelope_results
 	WHERE exposure_cohort_definition_id = @exposure_cohort_definition_id

--- a/src/main/resources/resources/cohortresults/sql/cohortSpecific/observationPeriodTimeRelativeToIndex.sql
+++ b/src/main/resources/resources/cohortresults/sql/cohortSpecific/observationPeriodTimeRelativeToIndex.sql
@@ -6,31 +6,30 @@ select hr1.cohort_definition_id,
 from
 (
 select cohort_definition_id,
-		-1* CAST(CASE WHEN isNumeric(stratum_1) = 1 THEN stratum_1 ELSE null END AS INT)*30 as duration,
+		-1* CAST(CASE WHEN analysis_id = 1805 THEN stratum_1 ELSE null END AS INT)*30 as duration,
 		sum(count_value) over (partition by cohort_definition_id
-		order by -1* CAST(CASE WHEN isNumeric(stratum_1) = 1 THEN stratum_1 ELSE null END AS INT)*30 asc) as count_value
+		order by -1* CAST(CASE WHEN analysis_id = 1805 THEN stratum_1 ELSE null END AS INT)*30 asc) as count_value
 	from
 	@ohdsi_database_schema.heracles_results
-	where analysis_id in (1805)
+	where analysis_id = 1805
 	and cohort_definition_id = @cohortDefinitionId
-	and CAST(CASE WHEN isNumeric(stratum_1) = 1 THEN stratum_1 ELSE null END AS INT) > 0
+	and CAST(CASE WHEN analysis_id = 1805 THEN stratum_1 ELSE null END AS INT) > 0
 
 	union
 
 	select hr1.cohort_definition_id,
-	  CAST(CASE WHEN isNumeric(hr1.stratum_1) = 1 THEN hr1.stratum_1 ELSE null END AS INT)*30 as duration,
+	  CAST(CASE WHEN hr1.analysis_id = 1806 THEN hr1.stratum_1 ELSE null END AS INT)*30 as duration,
 		t1.count_value - sum(hr1.count_value) over (partition by hr1.cohort_definition_id
-		order by CAST(CASE WHEN isNumeric(hr1.stratum_1) = 1 THEN hr1.stratum_1 ELSE null END AS INT)*30 asc) as count_value
-	from
-	@ohdsi_database_schema.heracles_results hr1
-	inner join
-	(select cohort_definition_id, sum(count_value) as count_value 
-	from @ohdsi_database_schema.heracles_results 
-	where analysis_id = 1806
-	and cohort_definition_id = @cohortDefinitionId
-	group by cohort_definition_id) t1
-	on hr1.cohort_definition_id = t1.cohort_definition_id
-	where hr1.analysis_id in (1806)
+		order by CAST(CASE WHEN hr1.analysis_id = 1806 THEN hr1.stratum_1 ELSE null END AS INT)*30 asc) as count_value
+	from @ohdsi_database_schema.heracles_results hr1
+	inner join (
+    select cohort_definition_id, sum(count_value) as count_value 
+    from @ohdsi_database_schema.heracles_results 
+    where analysis_id = 1806
+      and cohort_definition_id = @cohortDefinitionId
+    group by cohort_definition_id
+  ) t1 on hr1.cohort_definition_id = t1.cohort_definition_id
+	where hr1.analysis_id = 1806
 	and hr1.cohort_definition_id = @cohortDefinitionId
 ) hr1,
 (select count_value from @ohdsi_database_schema.heracles_results where analysis_id = 1 and cohort_definition_id = @cohortDefinitionId) t1

--- a/src/main/resources/resources/cohortresults/sql/cohortSpecific/personsInCohortFromCohortStartToEnd.sql
+++ b/src/main/resources/resources/cohortresults/sql/cohortSpecific/personsInCohortFromCohortStartToEnd.sql
@@ -1,7 +1,7 @@
 --persons in cohort from cohort start time to cohort end time, in 30d increments
-select CAST(CASE WHEN isNumeric(hr1.stratum_1) = 1 THEN hr1.stratum_1 ELSE null END AS INT) as month_year,
+select CAST(CASE WHEN hr1.analysis_id = 1804 THEN hr1.stratum_1 ELSE null END AS INT) as month_year,
   hr1.count_value as count_value, 
 round(1.0*hr1.count_value / denom.count_value,5) as percent_value
 from (select * from @ohdsi_database_schema.heracles_results where analysis_id = 1804 and cohort_definition_id = @cohortDefinitionId) hr1,
 (select count_value from @ohdsi_database_schema.heracles_results where analysis_id = 1 and cohort_definition_id = @cohortDefinitionId) denom
-order by CAST(CASE WHEN isNumeric(hr1.stratum_1) = 1 THEN hr1.stratum_1 ELSE null END AS INT) asc
+order by CAST(CASE WHEN hr1.analysis_id = 1804 THEN hr1.stratum_1 ELSE null END AS INT) asc

--- a/src/main/resources/resources/cohortresults/sql/cohortSpecific/prevalenceByYearGenderSex.sql
+++ b/src/main/resources/resources/cohortresults/sql/cohortSpecific/prevalenceByYearGenderSex.sql
@@ -8,20 +8,20 @@ select
 	round(1000*(1.0*hr1.count_value / t1.count_value),5) as Y_PREVALENCE_1000PP
 from (select cohort_definition_id,
 	stratum_1 as index_year,
-	CAST(CASE WHEN isNumeric(stratum_2) = 1 THEN stratum_2 ELSE null END AS INT) as gender_concept_id,
-	CAST(CASE WHEN isNumeric(stratum_3) = 1 THEN stratum_3 ELSE null END AS INT) as age_decile,
+	CAST(CASE WHEN analysis_id = 1814 THEN stratum_2 ELSE null END AS INT) as gender_concept_id,
+	CAST(CASE WHEN analysis_id = 1814 THEN stratum_3 ELSE null END AS INT) as age_decile,
 	count_value 
 	from @ohdsi_database_schema.heracles_results
-	where analysis_id in (1814)
+	where analysis_id = 1814
 	and cohort_definition_id = @cohortDefinitionId
-	and CAST(CASE WHEN isNumeric(stratum_2) = 1 THEN stratum_2 ELSE null END AS INT) in (8507,8532)
-	and CAST(CASE WHEN isNumeric(stratum_3) = 1 THEN stratum_3 ELSE null END AS INT) >= 0
+	and CAST(CASE WHEN analysis_id = 1814 THEN stratum_2 ELSE null END AS INT) in (8507,8532)
+	and CAST(CASE WHEN analysis_id = 1814 THEN stratum_3 ELSE null END AS INT) >= 0
 ) hr1
 	inner join 
 (
 	select stratum_1 as index_year,
-	CAST(CASE WHEN isNumeric(stratum_2) = 1 THEN stratum_2 ELSE null END AS INT) as gender_concept_id,
-	CAST(CASE WHEN isNumeric(stratum_3) = 1 THEN stratum_3 ELSE null END AS INT) as age_decile,
+	CAST(CASE WHEN analysis_id = 116 THEN stratum_2 ELSE null END AS INT) as gender_concept_id,
+	CAST(CASE WHEN analysis_id = 116 THEN stratum_3 ELSE null END AS INT) as age_decile,
 	count_value 
 	from @ohdsi_database_schema.heracles_results 
 	where analysis_id = 116


### PR DESCRIPTION
Fixes #2187.

These changes span a large number of files.   I did not change any files related to heracles reports (these should probably be deprecated).

The general strategy is moving away from isNumeric() and instead depending on the record's `analysis_id` to determine how the casting should perform.   The problem with isNumeric() is that numeric values like '123.45' were passign the isNumeric() test, but can not be casted to an integer.   By using analysis_id you can be certain that the cast you are doing is appropriate to the analysis that generated the record.
