### PR TITLE
Hypersistence Optimizer Issues: Critical: EagerFetchingEvent

### DIFF
--- a/src/main/java/org/ohdsi/webapi/cohortcharacterization/domain/CohortCharacterizationEntity.java
+++ b/src/main/java/org/ohdsi/webapi/cohortcharacterization/domain/CohortCharacterizationEntity.java
@@ -70,7 +70,7 @@ public class CohortCharacterizationEntity extends CommonEntityExt<Long> implemen
     @Column(name = "strata_only")
     private Boolean strataOnly;
 
-    @OneToOne(mappedBy = "cohortCharacterization", cascade = CascadeType.ALL)
+    @OneToOne(mappedBy = "cohortCharacterization", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
     private CcStrataConceptSetEntity conceptSetEntity;
     
     @Column(name = "hash_code")

--- a/src/main/java/org/ohdsi/webapi/cohortdefinition/CohortGenerationInfo.java
+++ b/src/main/java/org/ohdsi/webapi/cohortdefinition/CohortGenerationInfo.java
@@ -52,7 +52,7 @@ public class CohortGenerationInfo implements Serializable, IExecutionInfo {
   @EmbeddedId
   private CohortGenerationInfoId id;
   
-  @ManyToOne
+  @ManyToOne(fetch = FetchType.LAZY)
   @MapsId("cohortDefinitionId")
   @JoinColumn(name="id", referencedColumnName="id")
   private CohortDefinition cohortDefinition;

--- a/src/main/java/org/ohdsi/webapi/executionengine/entity/AnalysisFile.java
+++ b/src/main/java/org/ohdsi/webapi/executionengine/entity/AnalysisFile.java
@@ -27,7 +27,7 @@ public class AnalysisFile {
     @Column
     private Long id;
 
-    @ManyToOne(optional = false)
+    @ManyToOne(optional = false, fetch = FetchType.LAZY)
     @JoinColumn(name = "execution_id", nullable = false, updatable = false)
     private ExecutionEngineAnalysisStatus analysisExecution;
 

--- a/src/main/java/org/ohdsi/webapi/executionengine/entity/AnalysisResultFileContent.java
+++ b/src/main/java/org/ohdsi/webapi/executionengine/entity/AnalysisResultFileContent.java
@@ -16,7 +16,7 @@ public class AnalysisResultFileContent {
     @Column(name = "output_file_id")
     private Long id;
 
-    @OneToOne
+    @OneToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "output_file_id")
     @MapsId
     private AnalysisResultFile analysisResultFile;

--- a/src/main/java/org/ohdsi/webapi/feanalysis/domain/FeAnalysisCriteriaEntity.java
+++ b/src/main/java/org/ohdsi/webapi/feanalysis/domain/FeAnalysisCriteriaEntity.java
@@ -45,7 +45,7 @@ public abstract class FeAnalysisCriteriaEntity implements WithId<Long> {
     @Type(type = "org.hibernate.type.TextType")
     private String expressionString;
 
-    @ManyToOne(fetch = FetchType.EAGER)
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "fe_aggregate_id")
     private FeAnalysisAggregateEntity aggregate;
 

--- a/src/main/java/org/ohdsi/webapi/feanalysis/domain/FeAnalysisWithCriteriaEntity.java
+++ b/src/main/java/org/ohdsi/webapi/feanalysis/domain/FeAnalysisWithCriteriaEntity.java
@@ -11,11 +11,11 @@ import java.util.Objects;
 @Entity
 public abstract class FeAnalysisWithCriteriaEntity<T extends FeAnalysisCriteriaEntity> extends FeAnalysisEntity<List<T>> implements FeatureAnalysisWithCriteria<T, Integer> {
     
-    @OneToMany(targetEntity = FeAnalysisCriteriaEntity.class, fetch = FetchType.EAGER, mappedBy = "featureAnalysis",
+    @OneToMany(targetEntity = FeAnalysisCriteriaEntity.class, fetch = FetchType.LAZY, mappedBy = "featureAnalysis",
             cascade = {CascadeType.MERGE, CascadeType.REMOVE, CascadeType.REFRESH, CascadeType.DETACH})
     private List<T> design;
 
-    @OneToOne(fetch = FetchType.EAGER, mappedBy = "featureAnalysis", cascade = CascadeType.ALL)
+    @OneToOne(fetch = FetchType.LAZY, mappedBy = "featureAnalysis", cascade = CascadeType.ALL)
     private FeAnalysisConcepsetEntity conceptSetEntity;
 
     public FeAnalysisWithCriteriaEntity() {

--- a/src/main/java/org/ohdsi/webapi/feasibility/StudyGenerationInfo.java
+++ b/src/main/java/org/ohdsi/webapi/feasibility/StudyGenerationInfo.java
@@ -22,6 +22,7 @@ import java.util.Date;
 import javax.persistence.Column;
 import javax.persistence.EmbeddedId;
 import javax.persistence.Entity;
+import javax.persistence.FetchType;
 import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
 import javax.persistence.MapsId;
@@ -42,13 +43,13 @@ public class StudyGenerationInfo implements Serializable {
   private StudyGenerationInfoId id;
   
   @JsonIgnore
-  @ManyToOne
+  @ManyToOne(fetch = FetchType.LAZY)
   @MapsId("studyId")
   @JoinColumn(name="study_id", referencedColumnName="id")
   private FeasibilityStudy study;
 
   @JsonIgnore
-  @ManyToOne
+  @ManyToOne(fetch = FetchType.LAZY)
   @MapsId("sourceId")
   @JoinColumn(name="source_id", referencedColumnName="source_id")
   private Source source;

--- a/src/main/java/org/ohdsi/webapi/ircalc/ExecutionInfo.java
+++ b/src/main/java/org/ohdsi/webapi/ircalc/ExecutionInfo.java
@@ -40,13 +40,13 @@ public class ExecutionInfo implements Serializable, IExecutionInfo {
   private ExecutionInfoId id;
   
   @JsonIgnore
-  @ManyToOne
+  @ManyToOne(fetch = FetchType.LAZY)
   @MapsId("analysisId")
   @JoinColumn(name="analysis_id", referencedColumnName="id")
   private IncidenceRateAnalysis analysis;
 
   @JsonIgnore
-  @ManyToOne
+  @ManyToOne(fetch = FetchType.LAZY)
   @MapsId("sourceId")
   @JoinColumn(name="source_id", referencedColumnName="source_id")
   @NotFound(action = NotFoundAction.IGNORE)

--- a/src/main/java/org/ohdsi/webapi/ircalc/IncidenceRateAnalysisDetails.java
+++ b/src/main/java/org/ohdsi/webapi/ircalc/IncidenceRateAnalysisDetails.java
@@ -40,7 +40,7 @@ public class IncidenceRateAnalysisDetails implements Serializable {
   private Integer id;
   
   @MapsId
-  @OneToOne
+  @OneToOne(fetch = FetchType.LAZY)
   @JoinColumn(name="id")
   private IncidenceRateAnalysis analysis;
  

--- a/src/main/java/org/ohdsi/webapi/shiro/Entities/RolePermissionEntity.java
+++ b/src/main/java/org/ohdsi/webapi/shiro/Entities/RolePermissionEntity.java
@@ -3,6 +3,7 @@ package org.ohdsi.webapi.shiro.Entities;
 import java.io.Serializable;
 import javax.persistence.Column;
 import javax.persistence.Entity;
+import javax.persistence.FetchType;
 import javax.persistence.GeneratedValue;
 import javax.persistence.Id;
 import javax.persistence.JoinColumn;
@@ -37,11 +38,11 @@ public class RolePermissionEntity implements Serializable {
   @Column(name = "STATUS")
   private String status;
 
-  @ManyToOne
+  @ManyToOne(fetch = FetchType.LAZY)
   @JoinColumn(name="ROLE_ID", nullable=false)
   private RoleEntity role;
 
-  @ManyToOne
+  @ManyToOne(fetch = FetchType.LAZY)
   @JoinColumn(name="PERMISSION_ID", nullable=false)
   private PermissionEntity permission;
 

--- a/src/main/java/org/ohdsi/webapi/shiro/Entities/UserRoleEntity.java
+++ b/src/main/java/org/ohdsi/webapi/shiro/Entities/UserRoleEntity.java
@@ -5,6 +5,7 @@ import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.EnumType;
 import javax.persistence.Enumerated;
+import javax.persistence.FetchType;
 import javax.persistence.GeneratedValue;
 import javax.persistence.Id;
 import javax.persistence.JoinColumn;
@@ -58,7 +59,7 @@ public class UserRoleEntity implements Serializable {
     this.status = status;
   }
 
-  @ManyToOne
+  @ManyToOne(fetch = FetchType.LAZY)
   @JoinColumn(name="USER_ID", nullable=false)
   public UserEntity getUser() {
     return user;
@@ -68,7 +69,7 @@ public class UserRoleEntity implements Serializable {
     this.user = user;
   }
 
-  @ManyToOne
+  @ManyToOne(fetch = FetchType.LAZY)
   @JoinColumn(name="ROLE_ID", nullable=false)
   public RoleEntity getRole() {
     return role;

--- a/src/main/java/org/ohdsi/webapi/source/SourceDaimon.java
+++ b/src/main/java/org/ohdsi/webapi/source/SourceDaimon.java
@@ -21,15 +21,17 @@ import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.EnumType;
 import javax.persistence.Enumerated;
+import javax.persistence.FetchType;
 import javax.persistence.GeneratedValue;
 import javax.persistence.Id;
 import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
 import javax.persistence.Table;
+
 import org.hibernate.annotations.GenericGenerator;
 import org.hibernate.annotations.Parameter;
 import org.hibernate.annotations.SQLDelete;
-import org.hibernate.annotations.Where;
+
 import java.io.Serializable;
 import java.util.Objects;
 
@@ -65,7 +67,7 @@ public class SourceDaimon implements Serializable {
   @Column(name="SOURCE_DAIMON_ID")  
   private int sourceDaimonId;
   
-  @ManyToOne
+  @ManyToOne(fetch = FetchType.LAZY)
   @JsonIgnore
   @JoinColumn(name="SOURCE_ID", referencedColumnName="SOURCE_ID")
   private Source source;

--- a/src/main/java/org/ohdsi/webapi/user/importer/model/RoleGroupEntity.java
+++ b/src/main/java/org/ohdsi/webapi/user/importer/model/RoleGroupEntity.java
@@ -5,6 +5,7 @@ import javax.persistence.Entity;
 import javax.persistence.EnumType;
 import javax.persistence.Enumerated;
 import javax.persistence.GeneratedValue;
+import javax.persistence.FetchType;
 import javax.persistence.Id;
 import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
@@ -40,11 +41,11 @@ public class RoleGroupEntity {
   @Column(name = "group_name")
   private String groupName;
 
-  @ManyToOne
+  @ManyToOne(fetch = FetchType.LAZY)
   @JoinColumn(name = "role_id")
   private RoleEntity role;
 
-  @ManyToOne()
+  @ManyToOne(fetch = FetchType.LAZY)
   @JoinColumn(name = "job_id")
   private UserImportJob userImportJob;
 

--- a/src/main/java/org/ohdsi/webapi/user/importer/model/UserImportJob.java
+++ b/src/main/java/org/ohdsi/webapi/user/importer/model/UserImportJob.java
@@ -33,7 +33,7 @@ import java.util.List;
   attributeNodes = @NamedAttributeNode("roleGroupMapping"))
 public class UserImportJob extends ArachneJob {
 
-  @ElementCollection(fetch = FetchType.EAGER)
+  @ElementCollection(fetch = FetchType.LAZY)
   @CollectionTable(name = "user_import_job_weekdays", joinColumns = @JoinColumn(name = "user_import_job_id"))
   @Column(name = "day_of_week")
   @Enumerated(EnumType.STRING)


### PR DESCRIPTION
Consider using lazy fetching which, not only that is more efficient, but is way more flexible when it comes to fetching data. For more info about this event, check out this User Guide link - https://vladmihalcea.com/hypersistence-optimizer/docs/user-guide/#EagerFetchingEvent

I left one reported below as is because it seem eager is necessary here to avoid no session error i encountered.
The [daimons] attribute in the [org.ohdsi.webapi.source.Source] 
This article points out alternatives and i concluded keeping eager is right thing to do in this case.
https://www.baeldung.com/hibernate-initialize-proxy-exception

Reran report
BEFORE
165 issues were found: 1 BLOCKER, 80 CRITICAL, 40 MAJOR, 44 MINOR
AFTER
137 issues were found: 1 BLOCKER, 52 CRITICAL, 40 MAJOR, 44 MINOR
