### PR TITLE
Changed non-TLS nexus to use TLS for docker

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1342,7 +1342,7 @@
         <repository>
           <id>ohdsi</id>
           <name>repo.ohdsi.org</name>
-          <url>http://repo.ohdsi.org:8085/nexus/content/groups/public</url>
+          <url>https://repo.ohdsi.org/nexus/content/groups/public</url>
         </repository>
       </repositories>
     </profile>


### PR DESCRIPTION
In docker-webapi profile, edited the nexus url to use TLS, same as in other profiles.

Issue #2230 