### PR TITLE
Webapi docker pom tls

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1335,15 +1335,17 @@
           lower(email) = lower(?)</security.db.datasource.authenticationQuery>
       </properties>
       <repositories>
-        <repository>
-          <id>central</id>
-          <url>https://repo.maven.apache.org/maven2</url>
-        </repository>
-        <repository>
-          <id>ohdsi</id>
-          <name>repo.ohdsi.org</name>
-          <url>https://repo.ohdsi.org/nexus/content/groups/public</url>
-        </repository>
+	<repository>
+          <id>ohdsi.snapshots</id>
+          <name>repo.ohdsi.org-snapshots</name>
+          <url>https://repo.ohdsi.org/nexus/content/repositories/snapshots</url>
+          <releases>
+            <enabled>false</enabled>
+          </releases>
+      	  <snapshots>
+            <enabled>true</enabled>
+      	  </snapshots>
+    	</repository>
       </repositories>
     </profile>
     <profile>

--- a/pom.xml
+++ b/pom.xml
@@ -1342,7 +1342,7 @@
         <repository>
           <id>ohdsi</id>
           <name>repo.ohdsi.org</name>
-          <url>http://repo.ohdsi.org:8085/nexus/content/groups/public</url>
+          <url>https://repo.ohdsi.org/nexus/content/groups/public</url>
         </repository>
       </repositories>
     </profile>


### PR DESCRIPTION
Issue #2230 

In this PR version, I've removed the extra maven and ohdsi repo entries for the webapi-docker profile. 

However, I have added a repo entry for ohdsi snapshots. This ensures that all snapshots from the ohdsi repo are handled with TLS enabled, and doesn't revert to using snapshots on the non-TLS sites. 