### PR TITLE
OpenID Connect custom parameters

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -101,6 +101,7 @@
     <security.oid.url></security.oid.url>
     <security.oid.logoutUrl></security.oid.logoutUrl>
     <security.oid.extraScopes></security.oid.extraScopes>
+    <security.oid.customParams>{:}</security.oid.customParams>
     <security.oid.redirectUrl>http://localhost/index.html#/welcome/</security.oid.redirectUrl>
     <security.kerberos.spn></security.kerberos.spn>
     <security.kerberos.keytabPath></security.kerberos.keytabPath>

--- a/src/main/java/org/ohdsi/webapi/OidcConfCreator.java
+++ b/src/main/java/org/ohdsi/webapi/OidcConfCreator.java
@@ -23,6 +23,9 @@ import org.pac4j.oidc.config.OidcConfiguration;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
+import java.util.HashMap;
+import java.util.Map;
+
 
 @Component
 public class OidcConfCreator {
@@ -41,6 +44,9 @@ public class OidcConfCreator {
 
     @Value("${security.oid.extraScopes}")
     private String extraScopes;
+
+    @Value("#{${security.oid.customParams:{T(java.util.Collections).emptyMap()}}}")
+    private Map<String, String> customParams = new HashMap<>();
     
     @Value("${security.oauth.callback.api}")
     private String oauthApiCallback;

--- a/src/main/java/org/ohdsi/webapi/OidcConfCreator.java
+++ b/src/main/java/org/ohdsi/webapi/OidcConfCreator.java
@@ -59,6 +59,10 @@ public class OidcConfCreator {
         conf.setLogoutUrl(logoutUrl);
         conf.setWithState(true);
         conf.setUseNonce(true);
+        
+        if (customParams != null) {
+            customParams.forEach(conf::addCustomParam);
+        }
 
         String scopes = "openid";
         if (extraScopes != null && !extraScopes.isEmpty()){

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -127,6 +127,7 @@ security.oid.url=${security.oid.url}
 security.oid.redirectUrl=${security.oid.redirectUrl}
 security.oid.logoutUrl=${security.oid.logoutUrl}
 security.oid.extraScopes=${security.oid.extraScopes}
+security.oid.customParams=${security.oid.customParams}
 security.db.datasource.driverClassName=${security.db.datasource.driverClassName}
 security.db.datasource.url=${security.db.datasource.url}
 security.db.datasource.username=${security.db.datasource.username}


### PR DESCRIPTION
Hi!

I would like to be able to pass the 'domain_hint' parameter with oidc authorization for 'a slightly more streamlined user experience' (https://learn.microsoft.com/en-us/azure/active-directory/develop/v2-oauth2-auth-code-flow) with Azure Active Directory.

When using it it would look something like this "security.oid.customParams={\"domain_hint\":\"your.org\"}"

Would be happy to hear what you think :-)