### PR TITLE
Fix cdmresults drill-down reports

### DIFF
--- a/src/main/resources/resources/cdmresults/sql/report/conditionera/drilldown/prevalenceByMonth.sql
+++ b/src/main/resources/resources/cdmresults/sql/report/conditionera/drilldown/prevalenceByMonth.sql
@@ -11,5 +11,5 @@ FROM
     ON num.stratum_2 = denom.stratum_1
   --calendar year
   INNER JOIN
-  @vocab_database_schema.concept c1 ON CAST(CASE WHEN analysis_id = 1002 THEN num.stratum_1 ELSE null END AS INT) = c1.concept_id
+  @vocab_database_schema.concept c1 ON CAST(CASE WHEN num.analysis_id = 1002 THEN num.stratum_1 ELSE null END AS INT) = c1.concept_id
 WHERE c1.concept_id = @conceptId

--- a/src/main/resources/resources/cdmresults/sql/report/measurement/drilldown/prevalenceByGenderAgeYear.sql
+++ b/src/main/resources/resources/cdmresults/sql/report/measurement/drilldown/prevalenceByGenderAgeYear.sql
@@ -13,7 +13,7 @@ SELECT
         5)                                                               AS y_prevalence_1000_pp --prevalence, per 1000 persons
 FROM (
        SELECT
-         num.analysis_id   AS num_analysis_id
+         num.analysis_id   AS num_analysis_id,
          num.stratum_1     AS num_stratum_1,
          num.stratum_2     AS num_stratum_2,
          num.stratum_3     AS num_stratum_3,

--- a/src/main/resources/resources/cdmresults/sql/report/procedure/drilldown/prevalenceByMonth.sql
+++ b/src/main/resources/resources/cdmresults/sql/report/procedure/drilldown/prevalenceByMonth.sql
@@ -8,7 +8,7 @@ FROM (
 	SELECT analysis_id, stratum_1, stratum_2, count_value
 	FROM @results_database_schema.achilles_results
 	WHERE analysis_id = 602
-	GROUP BY stratum_1, stratum_2, count_value
+	GROUP BY analysis_id, stratum_1, stratum_2, count_value
 ) num
 INNER JOIN (
 	SELECT stratum_1, count_value

--- a/src/main/resources/resources/cohortanalysis/heraclesanalyses/sql/200_201.sql
+++ b/src/main/resources/resources/cohortanalysis/heraclesanalyses/sql/200_201.sql
@@ -19,9 +19,8 @@ WHERE vo1.visit_start_date>=c1.cohort_start_date and vo1.visit_end_date<=c1.coho
 --}
 group by c1.cohort_definition_id,
 --{@CDM_version == '4'}?{
-vo1.place_of_service_CONCEPT_ID
+vo1.place_of_service_CONCEPT_ID;
 --}
 --{@CDM_version == '5'}?{
-vo1.visit_CONCEPT_ID
+vo1.visit_CONCEPT_ID;
 --}
-;


### PR DESCRIPTION
Three files had minor typos breaking drill-down report components.
Also fixes issue #2248 in Heracles Full Reports where analysis # 200 is concatenated to the next one (# 500).