### PR TITLE
Enable OIDC authentication with a direct client

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -953,6 +953,17 @@
     </dependency>
     <dependency>
       <groupId>org.pac4j</groupId>
+      <artifactId>pac4j-http</artifactId>
+      <version>${pac4j.version}</version>
+      <exclusions>
+        <exclusion>
+          <groupId>com.fasterxml.jackson.core</groupId>
+          <artifactId>jackson-databind</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>org.pac4j</groupId>
       <artifactId>pac4j-saml-opensamlv3</artifactId>
       <version>${pac4j.version}</version>
     </dependency>

--- a/src/main/java/org/ohdsi/webapi/shiro/management/FilterTemplates.java
+++ b/src/main/java/org/ohdsi/webapi/shiro/management/FilterTemplates.java
@@ -31,6 +31,7 @@ public enum FilterTemplates {
     LDAP_FILTER("ldapFilter"),
     AD_FILTER("adFilter"),
     OIDC_AUTH("oidcAuth"),
+    OIDC_DIRECT_AUTH("oidcDirectAuth"),
     OAUTH_CALLBACK("oauthCallback"),
     HANDLE_UNSUCCESSFUL_OAUTH("handleUnsuccessfullOAuth"),
     HANDLE_CAS("handleCas"),


### PR DESCRIPTION
The OpenID Connect story continues.

As per this issue #2288 we are trying to access WebAPI programmatically and the current OIDC implementation only allows the code flow through the UI, this adds the option to authenticate with a token supplied by the identity provider.

I think, as far as the needs of EMC go, with this we are now at a fully functional OIDC implementation for WebAPI :-)