### PR TITLE
Filter cohorts and concepts by permission (#2245)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+Makefile
 WebAPIConfig/
 *application.properties
 .idea/
@@ -12,6 +13,7 @@ sandbox/
 /nbactions*.xml
 *~
 .DS_Store
+.factorypath
 
 ### Developer's personal properties ###
 **/resources/config/application*-dev-*.properties

--- a/Makefile
+++ b/Makefile
@@ -1,56 +1,21 @@
 compile:
-	mvn clean
-	mvn compile -Pwebapi-postgresql-laertes
+	mvn clean compile -DskipUnitTests -DskipITtests -s WebAPIConfig/settings.xml -P webapi-postgresql
 
 package: compile
-	mvn package -Pwebapi-postgresql-laertes
+	mvn package -DskipUnitTests -DskipITtests -s WebAPIConfig/settings.xml -P webapi-postgresql
 
-deploy: package 
-	sudo service tomcat7 stop
-	sleep 4
-	sudo rm -rf /var/lib/tomcat7/webapps/WebAPI*
-	sudo cp -r target/WebAPI.war  /var/lib/tomcat7/webapps/
-	sudo chown tomcat7 /var/lib/tomcat7/webapps/WebAPI.war
-	sudo chgrp tomcat7 /var/lib/tomcat7/webapps/WebAPI.war
-	sudo service tomcat7 start
+deploy: package
+	/home/ubuntu/Downloads/apache-tomcat-8.5.84-DEV/bin/shutdown.sh 
+	mv /home/ubuntu/Downloads/apache-tomcat-8.5.84-DEV/webapps/WebAPI /mnt/disk1/webapi-dev-tmp/WebAPI-FOLDER-`date +%m%d%H%S`
+	mv /home/ubuntu/Downloads/apache-tomcat-8.5.84-DEV/webapps/WebAPI.war /mnt/disk1/webapi-dev-tmp/WebAPI.war-`date +%m%d%H%S`
+	mv target/WebAPI.war /home/ubuntu/Downloads/apache-tomcat-8.5.84-DEV/webapps/
+	echo "Now run /home/ubuntu/Downloads/apache-tomcat-8.5.84-DEV/bin/startup.sh"
 
 git-push:
-	git push myfork master
+	git push
 
 test:
-	wget -O tests/test-general-evidence.json "http://localhost:8080/WebAPI/LAERTES_CDM/evidence/752061"
-	wget -O tests/test-drug-hoi.json "http://localhost:8080/WebAPI/LAERTES_CDM/evidence/drughoi/752061-374013"
-	wget -O tests/test-drug.json "http://localhost:8080/WebAPI/LAERTES_CDM/evidence/drug/752061"
-	wget -O tests/test-hoi.json "http://localhost:8080/WebAPI/LAERTES_CDM/evidence/hoi/320073"
-	wget -O tests/test-info.json "http://localhost:8080/WebAPI/LAERTES_CDM/evidence/info"
-	wget -O tests/test-drug-hoi-eu-spc.json "http://localhost:8080/WebAPI/LAERTES_CDM/evidence/drughoi/904351-4190045" 
-	wget -O tests/test-drug-hoi-splicer.json "http://localhost:8080/WebAPI/LAERTES_CDM/evidence/drughoi/19133853-195588"
-	wget -O tests/test-drug-hoi-faers-counts-and-signals.json "http://localhost:8080/WebAPI/LAERTES_CDM/evidence/drughoi/1154343-433031"
-	wget -O tests/test-drug-hoi-pubmed-mesh-cr.json "http://localhost:8080/WebAPI/LAERTES_CDM/evidence/drughoi/1154343-433031" 
-	wget -O tests/test-drug-hoi-pubmed-mesh-clin-trial.json "http://localhost:8080/WebAPI/LAERTES_CDM/evidence/drughoi/789578-378144"
-	wget -O tests/test-drug-hoi-pubmed-mesh-other.json "http://localhost:8080/WebAPI/LAERTES_CDM/evidence/drughoi/19010482-316866"
-	wget -O tests/test-drug-hoi-semmed-cr.json "http://localhost:8080/WebAPI/LAERTES_CDM/evidence/drughoi/1112807-441202"
-	wget -O tests/test-drug-hoi-semmed-clin-trial.json "http://localhost:8080/WebAPI/LAERTES_CDM/evidence/drughoi/19059744-381591"
-	wget -O tests/test-drug-rollup-ingredient.json "http://localhost:8080/WebAPI/LAERTES_CDM/evidence/drugrollup/ingredient/1000632"
-	wget -O tests/test-drug-rollup-clin-drug.json "http://localhost:8080/WebAPI/LAERTES_CDM/evidence/drugrollup/clinicaldrug/19074181"
-	wget -O tests/test-drug-rollup-branded-drug.json "http://localhost:8080/WebAPI/LAERTES_CDM/evidence/drugrollup/brandeddrug/1000640"
-	wget -O tests/test-rdf-evidencesummary.json "http://localhost:8080/WebAPI/LAERTES_CDM/evidence/evidencesummary?conditionID=139900&drugID=1115008&evidenceGroup=Literature"
-	wget -O tests/test-rdf-evidencedetails.json "http://localhost:8080/WebAPI/LAERTES_CDM/evidence/evidencedetails?conditionID=24134&drugID=1115008&evidenceType=SPL_SPLICER_ADR"
+	wget -O /tmp/tests/test-drug-rollup-branded-drug.json "http://api.ohdsi.org/WebAPI/CS1/evidence/drugrollup/brandeddrug/1000640"
 
 test-public:
-	wget -O tests/test-general-evidence.json "http://api.ohdsi.org/WebAPI/CS1/evidence/1000640"
-	wget -O /tmp/tests/test-drug-hoi.json "http://api.ohdsi.org/WebAPI/CS1/evidence/drughoi/1000640-137682"
-	wget -O /tmp/tests/test-drug.json "http://api.ohdsi.org/WebAPI/CS1/evidence/drug/1000640"
-	wget -O /tmp/tests/test-hoi.json "http://api.ohdsi.org/WebAPI/CS1/evidence/hoi/320073"
-	wget -O /tmp/tests/test-info.json "http://api.ohdsi.org/WebAPI/CS1/evidence/info"
-	wget -O /tmp/tests/test-drug-hoi-eu-spc.json "http://api.ohdsi.org/WebAPI/CS1/evidence/drughoi/40239056-75053" 
-	wget -O /tmp/tests/test-drug-hoi-splicer.json "http://api.ohdsi.org/WebAPI/CS1/evidence/drughoi/19133853-195588"
-	wget -O /tmp/tests/test-drug-hoi-faers-counts-and-signals.json "http://api.ohdsi.org/WebAPI/CS1/evidence/drughoi/1154343-433031"
-	wget -O /tmp/tests/test-drug-hoi-pubmed-mesh-cr.json "http://api.ohdsi.org/WebAPI/CS1/evidence/drughoi/1154343-433031" 
-	wget -O /tmp/tests/test-drug-hoi-pubmed-mesh-clin-trial.json "http://api.ohdsi.org/WebAPI/CS1/evidence/drughoi/789578-378144"
-	wget -O /tmp/tests/test-drug-hoi-pubmed-mesh-other.json "http://api.ohdsi.org/WebAPI/CS1/evidence/drughoi/19010482-316866"
-	wget -O /tmp/tests/test-drug-hoi-semmed-cr.json "http://api.ohdsi.org/WebAPI/CS1/evidence/drughoi/1782521-45612000"
-	wget -O /tmp/tests/test-drug-hoi-semmed-clin-trial.json "http://api.ohdsi.org/WebAPI/CS1/evidence/drughoi/1303425-45616736"
-	wget -O /tmp/tests/test-drug-rollup-ingredient.json "http://api.ohdsi.org/WebAPI/CS1/evidence/drugrollup/ingredient/1000632"
-	wget -O /tmp/tests/test-drug-rollup-clin-drug.json "http://api.ohdsi.org/WebAPI/CS1/evidence/drugrollup/clinicaldrug/19074181"
 	wget -O /tmp/tests/test-drug-rollup-branded-drug.json "http://api.ohdsi.org/WebAPI/CS1/evidence/drugrollup/brandeddrug/1000640"

--- a/pom.xml
+++ b/pom.xml
@@ -192,6 +192,11 @@
     <spring.datasource.hikari.register-mbeans>true</spring.datasource.hikari.register-mbeans>
     <spring.datasource.hikari.mbean-name>authDataSource</spring.datasource.hikari.mbean-name>
 
+    <!-- If defaultGlobalReadPermissions is set to true (default), then all users can see every artifact.  -->
+    <!-- If it is set to false, WebAPI will filter out the artifacts that a user does not explicitly have -->
+    <!-- read permissions to -->
+    <security.defaultGlobalReadPermissions>true</security.defaultGlobalReadPermissions>	
+    
     <!-- EMBEDDED SERVER CONFIGURATION (ServerProperties) -->
     <server.port>8080</server.port>
     <server.ssl.key-store></server.ssl.key-store>

--- a/src/main/java/org/ohdsi/webapi/cohortcharacterization/CcController.java
+++ b/src/main/java/org/ohdsi/webapi/cohortcharacterization/CcController.java
@@ -89,9 +89,6 @@ public class CcController {
     private CharacterizationChecker checker;
     private PermissionService permissionService;
 
-    @Value("#{'${security.defaultGlobalReadPermissions}'.equals(false)}")
-    private boolean defaultGlobalReadPermissions;
-  
     public CcController(
             final CcService service,
             final FeAnalysisService feAnalysisService,
@@ -157,28 +154,12 @@ public class CcController {
     @Produces(MediaType.APPLICATION_JSON)
     @Consumes(MediaType.APPLICATION_JSON)
     public Page<CcShortDTO> list(@Pagination Pageable pageable) {
-			if (defaultGlobalReadPermissions == true) { // don't filter based on read permissions 
-				return service.getPage(pageable).map(entity -> {
-					CcShortDTO dto = convertCcToShortDto(entity);
-					permissionService.fillWriteAccess(entity, dto);
-					permissionService.fillReadAccess(entity, dto);
-					return dto;
-				});
-			} else { // filter out what the user does not have read access to
-			  List<CcShortDTO> dtolist = new ArrayList<CcShortDTO>();
-
-			  Page<CohortCharacterizationEntity> newpage = service.getPage(pageable);
-			  
-			  for (CohortCharacterizationEntity entity : newpage) {			    
-			    if(permissionService.hasReadAccess(entity)){
-			      CcShortDTO dto = convertCcToShortDto(entity);
-			      permissionService.fillWriteAccess(entity, dto);
-			      permissionService.fillReadAccess(entity, dto);
-			      dtolist.add(dto);
-			    } 
-			  }
-			  return new PageImpl<CcShortDTO>(dtolist, pageable, dtolist.size());
-			}
+      return service.getPage(pageable).map(entity -> {
+          CcShortDTO dto = convertCcToShortDto(entity);
+          permissionService.fillWriteAccess(entity, dto);
+          permissionService.fillReadAccess(entity, dto);
+          return dto;
+      });
     }
 
     /**
@@ -191,7 +172,12 @@ public class CcController {
     @Produces(MediaType.APPLICATION_JSON)
     @Consumes(MediaType.APPLICATION_JSON)
     public Page<CohortCharacterizationDTO> listDesign(@Pagination Pageable pageable) {
-        return service.getPageWithLinkedEntities(pageable).map(this::convertCcToDto);
+        return service.getPageWithLinkedEntities(pageable).map(entity -> {
+          CohortCharacterizationDTO dto = convertCcToDto(entity);
+          permissionService.fillWriteAccess(entity, dto);
+          permissionService.fillReadAccess(entity, dto);
+          return dto;
+      });
     }
 
     /**

--- a/src/main/java/org/ohdsi/webapi/cohortcharacterization/CcServiceImpl.java
+++ b/src/main/java/org/ohdsi/webapi/cohortcharacterization/CcServiceImpl.java
@@ -133,6 +133,9 @@ import static org.ohdsi.webapi.Constants.Params.COHORT_CHARACTERIZATION_ID;
 import static org.ohdsi.webapi.Constants.Params.JOB_AUTHOR;
 import static org.ohdsi.webapi.Constants.Params.JOB_NAME;
 import static org.ohdsi.webapi.Constants.Params.SOURCE_ID;
+import org.ohdsi.webapi.security.PermissionService;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.data.domain.PageImpl;
 
 @Service
 @Transactional
@@ -207,7 +210,12 @@ public class CcServiceImpl extends AbstractDaoService implements CcService, Gene
     private final GenericConversionService genericConversionService;
     private final VocabularyService vocabularyService;
     private VersionService<CharacterizationVersion> versionService;
+    
+    private PermissionService permissionService;
 
+    @Value("#{'${security.defaultGlobalReadPermissions}'.equals(false)}")
+    private boolean defaultGlobalReadPermissions;
+    
     private final Environment env;
 
     public CcServiceImpl(
@@ -231,6 +239,7 @@ public class CcServiceImpl extends AbstractDaoService implements CcService, Gene
             final JobInvalidator jobInvalidator,
             final VocabularyService vocabularyService,
             final VersionService<CharacterizationVersion> versionService,
+            final PermissionService permissionService,
             @Qualifier("conversionService") final GenericConversionService genericConversionService,
             Environment env) {
         this.repository = ccRepository;
@@ -251,6 +260,7 @@ public class CcServiceImpl extends AbstractDaoService implements CcService, Gene
         this.eventPublisher = eventPublisher;
         this.jobInvalidator = jobInvalidator;
         this.vocabularyService = vocabularyService;
+        this.permissionService = permissionService;
         this.genericConversionService = genericConversionService;
         this.versionService = versionService;
         this.env = env;
@@ -531,12 +541,24 @@ public class CcServiceImpl extends AbstractDaoService implements CcService, Gene
 
     @Override
     public Page<CohortCharacterizationEntity> getPageWithLinkedEntities(final Pageable pageable) {
-        return repository.findAll(pageable, defaultEntityGraph);
+      return repository.findAll(pageable, defaultEntityGraph);
+      
     }
 
     @Override
     public Page<CohortCharacterizationEntity> getPage(final Pageable pageable) {
-        return repository.findAll(pageable);
+      List<CohortCharacterizationEntity> ccList = repository.findAll()
+              .stream().filter(!defaultGlobalReadPermissions ? entity -> permissionService.hasReadAccess(entity) : entity -> true)
+              .collect(Collectors.toList());
+      return getPageFromResults(pageable, ccList);
+    }
+    
+    private Page<CohortCharacterizationEntity> getPageFromResults(Pageable pageable, List<CohortCharacterizationEntity> results) {
+      // Calculate the start and end indices for the current page
+      int startIndex = pageable.getPageNumber() * pageable.getPageSize();
+      int endIndex = Math.min(startIndex + pageable.getPageSize(), results.size());      
+      
+      return new PageImpl<>(results.subList(startIndex, endIndex), pageable, results.size());
     }
 
     @Override

--- a/src/main/java/org/ohdsi/webapi/estimation/EstimationController.java
+++ b/src/main/java/org/ohdsi/webapi/estimation/EstimationController.java
@@ -101,26 +101,15 @@ public class EstimationController {
   @Path("/")
   @Produces(MediaType.APPLICATION_JSON)
   public List<EstimationShortDTO> getAnalysisList() {
-    if (defaultGlobalReadPermissions == true) { // don't filter based on read permissions 
-      return StreamSupport.stream(service.getAnalysisList().spliterator(), false)
-	.map(analysis -> {
-	    EstimationShortDTO dto = conversionService.convert(analysis, EstimationShortDTO.class);
-	    permissionService.fillWriteAccess(analysis, dto);
-	    permissionService.fillReadAccess(analysis, dto);
-	    return dto;
-	  })
-	.collect(Collectors.toList());
-    } else {
-      return StreamSupport.stream(service.getAnalysisList().spliterator(), false)
-	.filter(candidateEstimation -> permissionService.hasReadAccess(candidateEstimation))
-	.map(analysis -> {
-	    EstimationShortDTO dto = conversionService.convert(analysis, EstimationShortDTO.class);
-	    permissionService.fillWriteAccess(analysis, dto);
-	    permissionService.fillReadAccess(analysis, dto);
-	    return dto;
-	  })
-	.collect(Collectors.toList());
-    }
+    return StreamSupport.stream(service.getAnalysisList().spliterator(), false)
+            .filter(!defaultGlobalReadPermissions ? entity -> permissionService.hasReadAccess(entity) : entity -> true)
+            .map(analysis -> {
+              EstimationShortDTO dto = conversionService.convert(analysis, EstimationShortDTO.class);
+              permissionService.fillWriteAccess(analysis, dto);
+              permissionService.fillReadAccess(analysis, dto);
+              return dto;
+            })
+            .collect(Collectors.toList());
   }
 
   /**

--- a/src/main/java/org/ohdsi/webapi/estimation/EstimationController.java
+++ b/src/main/java/org/ohdsi/webapi/estimation/EstimationController.java
@@ -22,6 +22,7 @@ import org.ohdsi.webapi.util.ExceptionUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.core.convert.support.GenericConversionService;
 import org.springframework.stereotype.Controller;
 
@@ -70,7 +71,10 @@ public class EstimationController {
   private final ScriptExecutionService executionService;
   private EstimationChecker checker;
   private PermissionService permissionService;
-
+  
+  @Value("#{'${security.defaultGlobalReadPermissions}'.equals(false)}")
+  private boolean defaultGlobalReadPermissions;
+  
   public EstimationController(EstimationService service,
                               GenericConversionService conversionService,
                               CommonGenerationSensitiveInfoService sensitiveInfoService,
@@ -97,14 +101,26 @@ public class EstimationController {
   @Path("/")
   @Produces(MediaType.APPLICATION_JSON)
   public List<EstimationShortDTO> getAnalysisList() {
-
-    return StreamSupport.stream(service.getAnalysisList().spliterator(), false)
-            .map(analysis -> {
-              EstimationShortDTO dto = conversionService.convert(analysis, EstimationShortDTO.class);
-              permissionService.fillWriteAccess(analysis, dto);
-              return dto;
-            })
-            .collect(Collectors.toList());
+    if (defaultGlobalReadPermissions == true) { // don't filter based on read permissions 
+      return StreamSupport.stream(service.getAnalysisList().spliterator(), false)
+	.map(analysis -> {
+	    EstimationShortDTO dto = conversionService.convert(analysis, EstimationShortDTO.class);
+	    permissionService.fillWriteAccess(analysis, dto);
+	    permissionService.fillReadAccess(analysis, dto);
+	    return dto;
+	  })
+	.collect(Collectors.toList());
+    } else {
+      return StreamSupport.stream(service.getAnalysisList().spliterator(), false)
+	.filter(candidateEstimation -> permissionService.hasReadAccess(candidateEstimation))
+	.map(analysis -> {
+	    EstimationShortDTO dto = conversionService.convert(analysis, EstimationShortDTO.class);
+	    permissionService.fillWriteAccess(analysis, dto);
+	    permissionService.fillReadAccess(analysis, dto);
+	    return dto;
+	  })
+	.collect(Collectors.toList());
+    }
   }
 
   /**

--- a/src/main/java/org/ohdsi/webapi/pathway/PathwayController.java
+++ b/src/main/java/org/ohdsi/webapi/pathway/PathwayController.java
@@ -56,9 +56,6 @@ public class PathwayController {
 	private PathwayChecker checker;
 	private PermissionService permissionService;
 
-        @Value("#{'${security.defaultGlobalReadPermissions}'.equals(false)}")
-        private boolean defaultGlobalReadPermissions;
-
 	@Autowired
 	public PathwayController(ConversionService conversionService, ConverterUtils converterUtils, PathwayService pathwayService, SourceService sourceService, CommonGenerationSensitiveInfoService sensitiveInfoService, PathwayChecker checker, PermissionService permissionService, I18nService i18nService) {
 
@@ -162,27 +159,12 @@ public class PathwayController {
 	@Consumes(MediaType.APPLICATION_JSON)
 	@Transactional
 	public Page<PathwayAnalysisDTO> list(@Pagination Pageable pageable) {
-		if (defaultGlobalReadPermissions == true) { // don't filter based on read permissions 
-			return pathwayService.getPage(pageable).map(pa -> {
-				PathwayAnalysisDTO dto = conversionService.convert(pa, PathwayAnalysisDTO.class);
-				permissionService.fillWriteAccess(pa, dto);
-				permissionService.fillReadAccess(pa, dto);
-				return dto;
-			});
-		} else { // filter out entities that the user does not have read permissions to view
-			List<PathwayAnalysisDTO> dtolist = new ArrayList<PathwayAnalysisDTO>();
-
-			Page<PathwayAnalysisEntity> newpage = pathwayService.getPage(pageable);
-			for (PathwayAnalysisEntity pa : newpage) {
-				if (permissionService.hasReadAccess(pa)) {
-					PathwayAnalysisDTO dto = conversionService.convert(pa, PathwayAnalysisDTO.class);
-					permissionService.fillWriteAccess(pa, dto);
-					permissionService.fillReadAccess(pa, dto);
-					dtolist.add(dto);
-				}
-			}
-			return new PageImpl<PathwayAnalysisDTO>(dtolist, pageable, dtolist.size());
-		}
+		return pathwayService.getPage(pageable).map(pa -> {
+			PathwayAnalysisDTO dto = conversionService.convert(pa, PathwayAnalysisDTO.class);
+			permissionService.fillWriteAccess(pa, dto);
+			permissionService.fillReadAccess(pa, dto);
+			return dto;
+		});
 	}
   
 

--- a/src/main/java/org/ohdsi/webapi/pathway/PathwayServiceImpl.java
+++ b/src/main/java/org/ohdsi/webapi/pathway/PathwayServiceImpl.java
@@ -96,6 +96,10 @@ import static org.ohdsi.webapi.Constants.Params.JOB_AUTHOR;
 import static org.ohdsi.webapi.Constants.Params.JOB_NAME;
 import static org.ohdsi.webapi.Constants.Params.PATHWAY_ANALYSIS_ID;
 import static org.ohdsi.webapi.Constants.Params.SOURCE_ID;
+import org.ohdsi.webapi.cohortcharacterization.domain.CohortCharacterizationEntity;
+import org.ohdsi.webapi.security.PermissionService;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.data.domain.PageImpl;
 
 @Service
 @Transactional
@@ -115,6 +119,11 @@ public class PathwayServiceImpl extends AbstractDaoService implements PathwaySer
 	private final StepBuilderFactory stepBuilderFactory;
 	private final CohortDefinitionService cohortDefinitionService;
 	private final VersionService<PathwayVersion> versionService;
+
+	private PermissionService permissionService;
+
+	@Value("#{'${security.defaultGlobalReadPermissions}'.equals(false)}")
+	private boolean defaultGlobalReadPermissions;
 
 	private final List<String> STEP_COLUMNS = Arrays.asList(new String[]{"step_1", "step_2", "step_3", "step_4", "step_5", "step_6", "step_7", "step_8", "step_9", "step_10"});
 
@@ -142,7 +151,8 @@ public class PathwayServiceImpl extends AbstractDaoService implements PathwaySer
 					@Qualifier("conversionService") GenericConversionService genericConversionService,
 					StepBuilderFactory stepBuilderFactory,
 					CohortDefinitionService cohortDefinitionService,
-					VersionService<PathwayVersion> versionService) {
+					VersionService<PathwayVersion> versionService,
+					PermissionService permissionService) {
 
 		this.pathwayAnalysisRepository = pathwayAnalysisRepository;
 		this.pathwayAnalysisGenerationRepository = pathwayAnalysisGenerationRepository;
@@ -159,6 +169,7 @@ public class PathwayServiceImpl extends AbstractDaoService implements PathwaySer
 		this.stepBuilderFactory = stepBuilderFactory;
 		this.cohortDefinitionService = cohortDefinitionService;
 		this.versionService = versionService;
+		this.permissionService = permissionService;
 
 		SerializedPathwayAnalysisToPathwayAnalysisConverter.setConversionService(conversionService);
 	}
@@ -218,8 +229,18 @@ public class PathwayServiceImpl extends AbstractDaoService implements PathwaySer
 
 	@Override
 	public Page<PathwayAnalysisEntity> getPage(final Pageable pageable) {
+		List<PathwayAnalysisEntity> pathwayList = pathwayAnalysisRepository.findAll(defaultEntityGraph)
+						.stream().filter(!defaultGlobalReadPermissions ? entity -> permissionService.hasReadAccess(entity) : entity -> true)
+						.collect(Collectors.toList());
+		return getPageFromResults(pageable, pathwayList);
+	}
 
-		return pathwayAnalysisRepository.findAll(pageable, defaultEntityGraph);
+	private Page<PathwayAnalysisEntity> getPageFromResults(Pageable pageable, List<PathwayAnalysisEntity> results) {
+		// Calculate the start and end indices for the current page
+		int startIndex = pageable.getPageNumber() * pageable.getPageSize();
+		int endIndex = Math.min(startIndex + pageable.getPageSize(), results.size());
+
+		return new PageImpl<>(results.subList(startIndex, endIndex), pageable, results.size());
 	}
 
 	@Override

--- a/src/main/java/org/ohdsi/webapi/prediction/PredictionController.java
+++ b/src/main/java/org/ohdsi/webapi/prediction/PredictionController.java
@@ -97,40 +97,28 @@ public class PredictionController {
   @GET
   @Path("/")
   @Produces(MediaType.APPLICATION_JSON)
-	public List<CommonAnalysisDTO> getAnalysisList() {
-		if (defaultGlobalReadPermissions == true) { // don't filter based on read permissions 
-			return StreamSupport
-					.stream(service.getAnalysisList().spliterator(), false)
-					.map(analysis -> {
-						CommonAnalysisDTO dto = conversionService.convert(analysis, CommonAnalysisDTO.class);
-						permissionService.fillWriteAccess(analysis, dto);
-						permissionService.fillReadAccess(analysis, dto);
-						return dto;
-					})
-					.collect(Collectors.toList());
-		} else {
-			return StreamSupport
-					.stream(service.getAnalysisList().spliterator(), false)
-					.filter(candidateAnalysis -> permissionService.hasReadAccess(candidateAnalysis))
-					.map(analysis -> {
-						CommonAnalysisDTO dto = conversionService.convert(analysis, CommonAnalysisDTO.class);
-						permissionService.fillWriteAccess(analysis, dto);
-						permissionService.fillReadAccess(analysis, dto);
-						return dto;
-					})
-					.collect(Collectors.toList());
-		}
-	}
-	
+  public List<CommonAnalysisDTO> getAnalysisList() {
+    return StreamSupport
+            .stream(service.getAnalysisList().spliterator(), false)
+            .filter(!defaultGlobalReadPermissions ? entity -> permissionService.hasReadAccess(entity) : entity -> true)
+            .map(analysis -> {
+              CommonAnalysisDTO dto = conversionService.convert(analysis, CommonAnalysisDTO.class);
+              permissionService.fillWriteAccess(analysis, dto);
+              permissionService.fillReadAccess(analysis, dto);
+              return dto;
+            })
+            .collect(Collectors.toList());
+  }
 
-	/**
-	 * Check to see if a prediction design exists by name
-	 * 
-	 * @summary Prediction design exists by name
-	 * @param id The prediction design id
-	 * @param name The prediction design name
-	 * @return 1 if a prediction design with the given name and id exist in WebAPI and 0 otherwise
-	 */
+  /**
+   * Check to see if a prediction design exists by name
+   *
+   * @summary Prediction design exists by name
+   * @param id The prediction design id
+   * @param name The prediction design name
+   * @return 1 if a prediction design with the given name and id exist in WebAPI
+   * and 0 otherwise
+   */
   @GET
   @Path("/{id}/exists")
   @Produces(MediaType.APPLICATION_JSON)

--- a/src/main/java/org/ohdsi/webapi/prediction/PredictionController.java
+++ b/src/main/java/org/ohdsi/webapi/prediction/PredictionController.java
@@ -21,6 +21,7 @@ import org.ohdsi.webapi.util.ExceptionUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.core.convert.support.GenericConversionService;
 import org.springframework.stereotype.Controller;
 
@@ -67,6 +68,9 @@ public class PredictionController {
 
   private PermissionService permissionService;
 
+  @Value("#{'${security.defaultGlobalReadPermissions}'.equals(false)}")
+  private boolean defaultGlobalReadPermissions;
+  
   @Autowired
   public PredictionController(PredictionService service,
                               GenericConversionService conversionService,
@@ -93,26 +97,40 @@ public class PredictionController {
   @GET
   @Path("/")
   @Produces(MediaType.APPLICATION_JSON)
-  public List<CommonAnalysisDTO> getAnalysisList() {
+	public List<CommonAnalysisDTO> getAnalysisList() {
+		if (defaultGlobalReadPermissions == true) { // don't filter based on read permissions 
+			return StreamSupport
+					.stream(service.getAnalysisList().spliterator(), false)
+					.map(analysis -> {
+						CommonAnalysisDTO dto = conversionService.convert(analysis, CommonAnalysisDTO.class);
+						permissionService.fillWriteAccess(analysis, dto);
+						permissionService.fillReadAccess(analysis, dto);
+						return dto;
+					})
+					.collect(Collectors.toList());
+		} else {
+			return StreamSupport
+					.stream(service.getAnalysisList().spliterator(), false)
+					.filter(candidateAnalysis -> permissionService.hasReadAccess(candidateAnalysis))
+					.map(analysis -> {
+						CommonAnalysisDTO dto = conversionService.convert(analysis, CommonAnalysisDTO.class);
+						permissionService.fillWriteAccess(analysis, dto);
+						permissionService.fillReadAccess(analysis, dto);
+						return dto;
+					})
+					.collect(Collectors.toList());
+		}
+	}
+	
 
-    return StreamSupport
-            .stream(service.getAnalysisList().spliterator(), false)
-            .map(analysis -> {
-              CommonAnalysisDTO dto = conversionService.convert(analysis, CommonAnalysisDTO.class);
-              permissionService.fillWriteAccess(analysis, dto);
-              return dto;
-            })
-            .collect(Collectors.toList());
-  }
-
-  /**
-   * Check to see if a prediction design exists by name
-   * 
-   * @summary Prediction design exists by name
-   * @param id The prediction design id
-   * @param name The prediction design name
-   * @return 1 if a prediction design with the given name and id exist in WebAPI and 0 otherwise
-   */
+	/**
+	 * Check to see if a prediction design exists by name
+	 * 
+	 * @summary Prediction design exists by name
+	 * @param id The prediction design id
+	 * @param name The prediction design name
+	 * @return 1 if a prediction design with the given name and id exist in WebAPI and 0 otherwise
+	 */
   @GET
   @Path("/{id}/exists")
   @Produces(MediaType.APPLICATION_JSON)

--- a/src/main/java/org/ohdsi/webapi/security/PermissionController.java
+++ b/src/main/java/org/ohdsi/webapi/security/PermissionController.java
@@ -84,12 +84,13 @@ public class PermissionController {
 
     /**
      * Get roles that have a permission type (READ/WRITE) to entity
-     * 
-     * @summary Get roles that have a specific permission (READ/WRITE) for the entity
+     *
+     * @summary Get roles that have a specific permission (READ/WRITE) for the
+     * entity
      * @param entityType The entity type
      * @param entityId The entity ID
      * @return The list of permissions for the permission type
-     * @throws Exception 
+     * @throws Exception
      */
     @GET
     @Path("/access/{entityType}/{entityId}/{permType}")
@@ -98,16 +99,12 @@ public class PermissionController {
     public List<RoleDTO> listAccessesForEntityByPermType(
             @PathParam("entityType") EntityType entityType,
             @PathParam("entityId") Integer entityId,
-	    @PathParam("permType") String permType
+            @PathParam("permType") AccessType permType
     ) throws Exception {
 
         permissionService.checkCommonEntityOwnership(entityType, entityId);
-	Set<String> permissionTemplates = null;
-	if (permType == "WRITE") {
-	  permissionTemplates = permissionService.getTemplatesForType(entityType, AccessType.WRITE).keySet();
-	} else {
-	  permissionTemplates = permissionService.getTemplatesForType(entityType, AccessType.READ).keySet();
-	}
+        Set<String> permissionTemplates = null;
+        permissionTemplates = permissionService.getTemplatesForType(entityType, permType).keySet();
 
         List<String> permissions = permissionTemplates
                 .stream()
@@ -119,6 +116,26 @@ public class PermissionController {
         return roles.stream().map(re -> conversionService.convert(re, RoleDTO.class)).collect(Collectors.toList());
     }
 
+    /**
+     * Get roles that have a permission type (READ/WRITE) to entity
+     *
+     * @summary Get roles that have a specific permission (READ/WRITE) for the
+     * entity
+     * @param entityType The entity type
+     * @param entityId The entity ID
+     * @return The list of permissions for the permission type
+     * @throws Exception
+     */
+    @GET
+    @Path("/access/{entityType}/{entityId}")
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Produces(MediaType.APPLICATION_JSON)
+    public List<RoleDTO> listAccessesForEntity(
+            @PathParam("entityType") EntityType entityType,
+            @PathParam("entityId") Integer entityId
+    ) throws Exception {
+        return listAccessesForEntityByPermType(entityType, entityId, AccessType.WRITE);
+    }
 
     /**
      * Grant group of permissions (READ / WRITE / ...) for the specified entity to the given role.

--- a/src/main/java/org/ohdsi/webapi/security/PermissionController.java
+++ b/src/main/java/org/ohdsi/webapi/security/PermissionController.java
@@ -83,26 +83,31 @@ public class PermissionController {
     }
 
     /**
-     * Get entity role access information
+     * Get roles that have a permission type (READ/WRITE) to entity
      * 
-     * @summary Get entity role information
+     * @summary Get roles that have a specific permission (READ/WRITE) for the entity
      * @param entityType The entity type
      * @param entityId The entity ID
-     * @return The list of roles
+     * @return The list of permissions for the permission type
      * @throws Exception 
      */
     @GET
-    @Path("/access/{entityType}/{entityId}")
+    @Path("/access/{entityType}/{entityId}/{permType}")
     @Consumes(MediaType.APPLICATION_JSON)
     @Produces(MediaType.APPLICATION_JSON)
-    public List<RoleDTO> listAccessesForEntity(
+    public List<RoleDTO> listAccessesForEntityByPermType(
             @PathParam("entityType") EntityType entityType,
-            @PathParam("entityId") Integer entityId
+            @PathParam("entityId") Integer entityId,
+	    @PathParam("permType") String permType
     ) throws Exception {
 
         permissionService.checkCommonEntityOwnership(entityType, entityId);
-
-        Set<String> permissionTemplates = permissionService.getTemplatesForType(entityType, AccessType.WRITE).keySet();
+	Set<String> permissionTemplates = null;
+	if (permType == "WRITE") {
+	  permissionTemplates = permissionService.getTemplatesForType(entityType, AccessType.WRITE).keySet();
+	} else {
+	  permissionTemplates = permissionService.getTemplatesForType(entityType, AccessType.READ).keySet();
+	}
 
         List<String> permissions = permissionTemplates
                 .stream()

--- a/src/main/java/org/ohdsi/webapi/security/PermissionService.java
+++ b/src/main/java/org/ohdsi/webapi/security/PermissionService.java
@@ -136,6 +136,8 @@ public class PermissionService {
         switch (accessType) {
             case WRITE:
                 return permissionSchema.getWritePermissions();
+ 	    case READ:
+	        return permissionSchema.getReadPermissions();
             default:
                 throw new UnsupportedOperationException();
         }
@@ -227,6 +229,25 @@ public class PermissionService {
         return roles;
     }
 
+    public List<RoleDTO> getRolesHavingReadPermissions(EntityType entityType, Number id) {
+        Set<String> permissionTemplates = getTemplatesForType(entityType, AccessType.READ).keySet();
+        preparePermissionCache(entityType, permissionTemplates);
+
+        List<String> permissions = permissionTemplates.stream()
+                .map(pt -> getPermission(pt, id))
+                .collect(Collectors.toList());
+        int fitCount = permissions.size();
+        Map<RoleDTO, Long> roleMap = permissions.stream()
+                .filter(p -> permissionCache.get().get(entityType).get(p) != null)
+                .flatMap(p -> permissionCache.get().get(entityType).get(p).stream())
+                .collect(Collectors.groupingBy(Function.identity(), Collectors.counting()));
+        List<RoleDTO> roles = roleMap.entrySet().stream()
+                .filter(es -> es.getValue() == fitCount)
+                .map(es -> es.getKey())
+                .collect(Collectors.toList());
+        return roles;
+    }
+
     public void clearPermissionCache() {
         this.permissionCache.set(new ConcurrentHashMap<>());
     }
@@ -237,7 +258,9 @@ public class PermissionService {
             try {
                 String login = this.permissionManager.getSubjectName();
                 UserSimpleAuthorizationInfo authorizationInfo = this.permissionManager.getAuthorizationInfo(login);
-                if (!Objects.equals(authorizationInfo.getUserId(), entity.getCreatedBy().getId())) {
+                if (Objects.equals(authorizationInfo.getUserId(), entity.getCreatedBy().getId())) {
+		    hasAccess = true; // the role is the one that created the artifact
+		} else {
                     EntityType entityType = entityPermissionSchemaResolver.getEntityType(entity.getClass());
 
                     List<RoleDTO> roles = getRolesHavingPermissions(entityType, entity.getId());
@@ -255,9 +278,42 @@ public class PermissionService {
         return hasAccess;
     }
 
+
+    public boolean hasReadAccess(CommonEntity entity) {
+        boolean hasAccess = false;
+        if (securityEnabled && entity.getCreatedBy() != null) {
+            try {
+                String login = this.permissionManager.getSubjectName();
+                UserSimpleAuthorizationInfo authorizationInfo = this.permissionManager.getAuthorizationInfo(login);
+                if (Objects.equals(authorizationInfo.getUserId(), entity.getCreatedBy().getId())){
+		    hasAccess = true; // the role is the one that created the artifact
+		} else {
+                    EntityType entityType = entityPermissionSchemaResolver.getEntityType(entity.getClass());
+
+                    List<RoleDTO> roles = getRolesHavingReadPermissions(entityType, entity.getId());
+
+                    Collection<String> userRoles = authorizationInfo.getRoles();
+                    hasAccess = roles.stream()
+                            .anyMatch(r -> userRoles.stream()
+                                    .anyMatch(re -> re.equals(r.getName())));
+                }
+            } catch (Exception e) {
+                logger.error("Error getting user roles and permissions", e);
+                throw new RuntimeException(e);
+            }
+        }
+        return hasAccess;
+    }
+
     public void fillWriteAccess(CommonEntity entity, CommonEntityDTO entityDTO) {
         if (securityEnabled && entity.getCreatedBy() != null) {
             entityDTO.setHasWriteAccess(hasWriteAccess(entity));
+        }
+    }
+
+    public void fillReadAccess(CommonEntity entity, CommonEntityDTO entityDTO) {
+        if (securityEnabled && entity.getCreatedBy() != null) {
+            entityDTO.setHasReadAccess(hasReadAccess(entity));
         }
     }
     

--- a/src/main/java/org/ohdsi/webapi/security/PermissionService.java
+++ b/src/main/java/org/ohdsi/webapi/security/PermissionService.java
@@ -259,8 +259,8 @@ public class PermissionService {
                 String login = this.permissionManager.getSubjectName();
                 UserSimpleAuthorizationInfo authorizationInfo = this.permissionManager.getAuthorizationInfo(login);
                 if (Objects.equals(authorizationInfo.getUserId(), entity.getCreatedBy().getId())) {
-		    hasAccess = true; // the role is the one that created the artifact
-		} else {
+                    hasAccess = true; // the role is the one that created the artifact
+                } else {
                     EntityType entityType = entityPermissionSchemaResolver.getEntityType(entity.getClass());
 
                     List<RoleDTO> roles = getRolesHavingPermissions(entityType, entity.getId());
@@ -268,7 +268,7 @@ public class PermissionService {
                     Collection<String> userRoles = authorizationInfo.getRoles();
                     hasAccess = roles.stream()
                             .anyMatch(r -> userRoles.stream()
-                                    .anyMatch(re -> re.equals(r.getName())));
+                            .anyMatch(re -> re.equals(r.getName())));
                 }
             } catch (Exception e) {
                 logger.error("Error getting user roles and permissions", e);

--- a/src/main/java/org/ohdsi/webapi/security/model/CohortCharacterizationPermissionSchema.java
+++ b/src/main/java/org/ohdsi/webapi/security/model/CohortCharacterizationPermissionSchema.java
@@ -13,8 +13,19 @@ public class CohortCharacterizationPermissionSchema extends EntityPermissionSche
         put("cohort-characterization:%s:delete", "Delete Cohort Characterization with ID = %s");
     }};
 
+   private static Map<String, String> readPermissions = new HashMap<String, String>() {{                                     
+       put("cohort-characterization:%s:get", "Get cohort characterization");                         
+       put("cohort-characterization:%s:generation:get", "Get cohort characterization generations");
+       put("cohort-characterization:generation:*:get", "Get cohort characterization generation");
+       put("cohort-characterization:design:get", "cohort-characterization:design:get");
+       put("cohort-characterization:%s:design:get", "Get cohort characterization design");                         
+       put("cohort-characterization:design:%s:get", "view cohort characterization with id %s");
+       put("cohort-characterization:%s:version:get", "Get list of characterization versions");                         
+       put("cohort-characterization:%s:version:*:get", "Get list of characterization version");
+    }};
+  
     public CohortCharacterizationPermissionSchema() {
 
-        super(EntityType.COHORT_CHARACTERIZATION, new HashMap<>(), writePermissions);
+        super(EntityType.COHORT_CHARACTERIZATION, readPermissions, writePermissions);
     }
 }

--- a/src/main/java/org/ohdsi/webapi/security/model/CohortDefinitionPermissionSchema.java
+++ b/src/main/java/org/ohdsi/webapi/security/model/CohortDefinitionPermissionSchema.java
@@ -14,8 +14,17 @@ public class CohortDefinitionPermissionSchema extends EntityPermissionSchema {
         put("cohortdefinition:%s:check:post", "Fix Cohort Definition with ID = %s");
     }};
 
+  private static Map<String, String> readPermissions = new HashMap<String, String>() {{                                     
+	put("cohortdefinition:%s:get", "Get Cohort Definition by ID");
+	put("cohortdefinition:%s:info:get","");
+
+	put("cohortdefinition:%s:version:get", "Get list of cohort versions");
+	put("cohortdefinition:%s:version:*:get", "Get cohort version");		       
+      }
+    };
+  
     public CohortDefinitionPermissionSchema() {
 
-        super(EntityType.COHORT_DEFINITION, new HashMap<>(), writePermissions);
+        super(EntityType.COHORT_DEFINITION, readPermissions, writePermissions);
     }
 }

--- a/src/main/java/org/ohdsi/webapi/security/model/ConceptSetPermissionSchema.java
+++ b/src/main/java/org/ohdsi/webapi/security/model/ConceptSetPermissionSchema.java
@@ -14,8 +14,14 @@ public class ConceptSetPermissionSchema extends EntityPermissionSchema {
         put("conceptset:%s:delete", "Delete Concept Set with ID = %s");
     }};
 
+    private static Map<String, String> readPermissions = new HashMap<String, String>() {{
+        put("conceptset:%s:get", "view conceptset  definition with id %s");
+        put("conceptset:%s:expression:get", "Resolve concept set %s expression");
+        put("conceptset:%s:version:*:expression:get", "Get expression for concept set %s items for default source");
+    }};
+
     public ConceptSetPermissionSchema() {
 
-        super(EntityType.CONCEPT_SET, new HashMap<>(), writePermissions);
+        super(EntityType.CONCEPT_SET, readPermissions, writePermissions);
     }
 }

--- a/src/main/java/org/ohdsi/webapi/security/model/EstimationPermissionSchema.java
+++ b/src/main/java/org/ohdsi/webapi/security/model/EstimationPermissionSchema.java
@@ -13,8 +13,19 @@ public class EstimationPermissionSchema extends EntityPermissionSchema {
         put("estimation:%s:delete", "Delete Estimation with ID=%s");
     }};
 
-    public EstimationPermissionSchema() {
+    private static Map<String, String> readPermissions = new HashMap<String, String>() {{ 
+	put("estimation:%s:get", "Get Estimation instance");
+	put("estimation:%s:generation:get", "View Estimation Generations");
+	put("estimation:%s:copy:get", "Copy Estimation instance");
+	put("estimation:%s:download:get", "Download Estimation package");
+	put("estimation:%s:export:get", "Export Estimation");
+	put("estimation:%s:generation:get", "View Estimation Generations");
+	put("comparativecohortanalysis:%s:get","Get estimation");
+      }
+      };
 
-        super(EntityType.ESTIMATION, new HashMap<>(), writePermissions);
+  
+    public EstimationPermissionSchema() {
+        super(EntityType.ESTIMATION, readPermissions, writePermissions);
     }
 }

--- a/src/main/java/org/ohdsi/webapi/security/model/FeatureAnalysisPermissionSchema.java
+++ b/src/main/java/org/ohdsi/webapi/security/model/FeatureAnalysisPermissionSchema.java
@@ -13,8 +13,14 @@ public class FeatureAnalysisPermissionSchema extends EntityPermissionSchema {
         put("feature-analysis:%s:delete", "Delete Feature Analysis with ID = %s");
     }};
 
+    private static Map<String, String> readPermissions = new HashMap<String, String>() {{                                     
+	put("feature-analysis:%s:get", "get feature analysis");
+        put("feature-analysis:aggregates:get", "feature-analysis:aggregates:get");                                                   
+      }
+      };
+  
     public FeatureAnalysisPermissionSchema() {
 
-        super(EntityType.FE_ANALYSIS, new HashMap<>(), writePermissions);
+        super(EntityType.FE_ANALYSIS, readPermissions, writePermissions);
     }
 }

--- a/src/main/java/org/ohdsi/webapi/security/model/IncidenceRatePermissionSchema.java
+++ b/src/main/java/org/ohdsi/webapi/security/model/IncidenceRatePermissionSchema.java
@@ -15,8 +15,18 @@ public class IncidenceRatePermissionSchema extends EntityPermissionSchema {
         put("ir:%s:delete", "Delete Incidence Rate with ID=%s");
     }};
 
+  private static Map<String, String> readPermissions = new HashMap<String, String>() {{                                     
+        put("ir:%s:get", "view list of incident rates");
+        put("ir:%s:version:get", "Get list of IR analsis versions");
+	put("ir:%s:version:*:get", "Get IR analysis version");
+	put("ir:%s:copy:get","Copy incidence rate");
+	put("ir:%s:info:get","Get IR info");
+	put("ir:%s:design:get","Export Incidence Rates design");
+    }
+    };
+  
     public IncidenceRatePermissionSchema() {
 
-        super(EntityType.INCIDENCE_RATE, new HashMap<>(), writePermissions);
+        super(EntityType.INCIDENCE_RATE, readPermissions, writePermissions);
     }
 }

--- a/src/main/java/org/ohdsi/webapi/security/model/PathwayAnalysisPermissionSchema.java
+++ b/src/main/java/org/ohdsi/webapi/security/model/PathwayAnalysisPermissionSchema.java
@@ -14,8 +14,19 @@ public class PathwayAnalysisPermissionSchema extends EntityPermissionSchema {
         put("pathway-analysis:%s:delete", "Delete Pathway Analysis with ID = %s");
     }};
 
+  private static Map<String, String> readPermissions = new HashMap<String, String>() {{                                     
+	put("pathway-analysis:%s:get", "Get Pathways Analysis instance");
+	put("pathway-analysis:%s:generation:get", "Get Pathways Analysis generations list");
+	put("pathway-analysis:generation:*:get", "Get Pathways Analysis generation instance");
+	put("pathway-analysis:generation:*:result:get", "Get Pathways Analysis generation results");
+	put("pathway-analysis:generation:*:design:get", "Get Pathways Analysis generation design");
+	put("pathway-analysis:%s:version:get", "Get list of pathway analysis versions");
+	put("pathway-analysis:%s:version:*:get", "Get pathway analysis version");
+      }
+    };  
+  
     public PathwayAnalysisPermissionSchema() {
 
-        super(EntityType.PATHWAY_ANALYSIS, new HashMap<>(), writePermissions);
+      super(EntityType.PATHWAY_ANALYSIS, readPermissions, writePermissions);
     }
 }

--- a/src/main/java/org/ohdsi/webapi/security/model/PredictionPermissionSchema.java
+++ b/src/main/java/org/ohdsi/webapi/security/model/PredictionPermissionSchema.java
@@ -13,8 +13,19 @@ public class PredictionPermissionSchema extends EntityPermissionSchema {
         put("prediction:%s:delete", "Delete Estimation with ID=%s");
     }};
 
+  private static Map<String, String> readPermissions = new HashMap<String, String>() {{                                     
+        put("prediction:%s:get", "Get Prediction instance");
+	put("prediction:%s:copy:get", "Copy Prediction instance");
+	put("prediction:%s:download:get", "Download Prediction package");
+	put("prediction:%s:export:get", "Export Prediction");
+	put("prediction:%s:generation:get", "View Prediction Generations");
+	put("prediction:%s:exists:get", "Check name uniqueness of prediction");
+	put("plp:%s:get", "Get population level prediction");
+    }
+    };
+    
     public PredictionPermissionSchema() {
 
-        super(EntityType.PREDICTION, new HashMap<>(), writePermissions);
+        super(EntityType.PREDICTION, readPermissions, writePermissions);
     }
 }

--- a/src/main/java/org/ohdsi/webapi/security/model/ReusablePermissionSchema.java
+++ b/src/main/java/org/ohdsi/webapi/security/model/ReusablePermissionSchema.java
@@ -13,6 +13,13 @@ public class ReusablePermissionSchema extends EntityPermissionSchema {
         put("reusable:%s:put", "Update reusable");
     }};
 
+  private static Map<String, String> readPermissions = new HashMap<String, String>() {{                                     
+        put("reusable:%s:get", "view reusable with id %s");                                                      
+        put("reusable:%s:expression:get", "Resolve reusable %s expression");                                            
+        put("reusable:%s:version:*:get", "Get expression for reusable %s items for default source");
+		}
+	};
+  
     public ReusablePermissionSchema() {
 
         super(EntityType.REUSABLE, new HashMap<>(), writePermissions);

--- a/src/main/java/org/ohdsi/webapi/security/model/TagPermissionSchema.java
+++ b/src/main/java/org/ohdsi/webapi/security/model/TagPermissionSchema.java
@@ -13,6 +13,12 @@ public class TagPermissionSchema extends EntityPermissionSchema {
         put("tag:%s:put", "Update tag");
     }};
 
+  private static Map<String, String> readPermissions = new HashMap<String, String>() {{                                     
+        put("tag:get", "view tag with id %s");                                                      
+        put("tag:search:get", "Resolve tag %s expression");                                            
+    }
+    };
+  
     public TagPermissionSchema() {
 
         super(EntityType.TAG, new HashMap<>(), writePermissions);

--- a/src/main/java/org/ohdsi/webapi/service/CohortDefinitionService.java
+++ b/src/main/java/org/ohdsi/webapi/service/CohortDefinitionService.java
@@ -86,6 +86,7 @@ import org.springframework.batch.core.configuration.annotation.JobBuilderFactory
 import org.springframework.batch.core.configuration.annotation.StepBuilderFactory;
 import org.springframework.batch.core.job.builder.SimpleJobBuilder;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.core.convert.ConversionService;
 import org.springframework.jdbc.core.RowMapper;
@@ -203,6 +204,9 @@ public class CohortDefinitionService extends AbstractDaoService implements HasTa
 
 	@Autowired
 	private VersionService<CohortVersion> versionService;
+
+        @Value("#{'${security.defaultGlobalReadPermissions}'.equals(false)}")
+	private boolean defaultGlobalReadPermissions;
 
 	private final MarkdownRender markdownPF = new MarkdownRender();
 
@@ -406,14 +410,26 @@ public class CohortDefinitionService extends AbstractDaoService implements HasTa
 	@Transactional
 	public List<CohortMetadataDTO> getCohortDefinitionList() {
 		List<CohortDefinition> definitions = cohortDefinitionRepository.list();
-
-		return definitions.stream()
-						.map(def -> {
-							CohortMetadataDTO dto = conversionService.convert(def, CohortMetadataImplDTO.class);
-							permissionService.fillWriteAccess(def, dto);
-							return dto;
-						})
-						.collect(Collectors.toList());
+		if (defaultGlobalReadPermissions == true) { // don't filter based on read permissions 
+			return definitions.stream()
+					.map(def -> {
+						CohortMetadataDTO dto = conversionService.convert(def, CohortMetadataImplDTO.class);
+						permissionService.fillWriteAccess(def, dto);
+						permissionService.fillReadAccess(def, dto);
+						return dto;
+					})
+					.collect(Collectors.toList());
+		} else { // filter out cohortdefinitions that the user does not have read access to
+			return definitions.stream()
+					.filter(candidateCohortDef -> permissionService.hasReadAccess(candidateCohortDef))
+					.map(def -> {
+						CohortMetadataDTO dto = conversionService.convert(def, CohortMetadataImplDTO.class);
+						permissionService.fillWriteAccess(def, dto);
+						permissionService.fillReadAccess(def, dto);
+						return dto;
+					})
+					.collect(Collectors.toList());
+		}
 	}
 
 	/**

--- a/src/main/java/org/ohdsi/webapi/service/CohortDefinitionService.java
+++ b/src/main/java/org/ohdsi/webapi/service/CohortDefinitionService.java
@@ -410,26 +410,15 @@ public class CohortDefinitionService extends AbstractDaoService implements HasTa
 	@Transactional
 	public List<CohortMetadataDTO> getCohortDefinitionList() {
 		List<CohortDefinition> definitions = cohortDefinitionRepository.list();
-		if (defaultGlobalReadPermissions == true) { // don't filter based on read permissions 
-			return definitions.stream()
-					.map(def -> {
-						CohortMetadataDTO dto = conversionService.convert(def, CohortMetadataImplDTO.class);
-						permissionService.fillWriteAccess(def, dto);
-						permissionService.fillReadAccess(def, dto);
-						return dto;
-					})
-					.collect(Collectors.toList());
-		} else { // filter out cohortdefinitions that the user does not have read access to
-			return definitions.stream()
-					.filter(candidateCohortDef -> permissionService.hasReadAccess(candidateCohortDef))
-					.map(def -> {
-						CohortMetadataDTO dto = conversionService.convert(def, CohortMetadataImplDTO.class);
-						permissionService.fillWriteAccess(def, dto);
-						permissionService.fillReadAccess(def, dto);
-						return dto;
-					})
-					.collect(Collectors.toList());
-		}
+		return definitions.stream()
+						.filter(!defaultGlobalReadPermissions ? entity -> permissionService.hasReadAccess(entity) : entity -> true)
+						.map(def -> {
+							CohortMetadataDTO dto = conversionService.convert(def, CohortMetadataImplDTO.class);
+							permissionService.fillWriteAccess(def, dto);
+							permissionService.fillReadAccess(def, dto);
+							return dto;
+						})
+						.collect(Collectors.toList());
 	}
 
 	/**

--- a/src/main/java/org/ohdsi/webapi/service/ConceptSetService.java
+++ b/src/main/java/org/ohdsi/webapi/service/ConceptSetService.java
@@ -58,6 +58,7 @@ import org.ohdsi.webapi.versioning.dto.VersionUpdateDTO;
 import org.ohdsi.webapi.versioning.service.VersionService;
 import org.ohdsi.webapi.vocabulary.Concept;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.core.convert.support.GenericConversionService;
 import org.springframework.dao.EmptyResultDataAccessException;
 import org.springframework.stereotype.Component;
@@ -103,6 +104,9 @@ public class ConceptSetService extends AbstractDaoService implements HasTags<Int
     @Autowired
     private VersionService<ConceptSetVersion> versionService;
 
+    @Value("#{'${security.defaultGlobalReadPermissions}'.equals(false)}")
+    private boolean defaultGlobalReadPermissions;
+    
     public static final String COPY_NAME = "copyName";
 
     /**
@@ -131,15 +135,28 @@ public class ConceptSetService extends AbstractDaoService implements HasTags<Int
     @Path("/")
     @Produces(MediaType.APPLICATION_JSON)
     public Collection<ConceptSetDTO> getConceptSets() {
-        return getTransactionTemplate().execute(transactionStatus ->
-                StreamSupport.stream(getConceptSetRepository().findAll().spliterator(), false)
-                        .map(conceptSet -> {
-                            ConceptSetDTO dto = conversionService.convert(conceptSet, ConceptSetDTO.class);
-                            permissionService.fillWriteAccess(conceptSet, dto);
-                            return dto;
-                        })
-                        .collect(Collectors.toList())
-        );
+   	       if (defaultGlobalReadPermissions == true) { // don't filter based on read permissions 
+			return getTransactionTemplate().execute(
+					transactionStatus -> StreamSupport.stream(getConceptSetRepository().findAll().spliterator(), false)
+							.map(conceptSet -> {
+								ConceptSetDTO dto = conversionService.convert(conceptSet, ConceptSetDTO.class);
+								permissionService.fillWriteAccess(conceptSet, dto);
+								permissionService.fillReadAccess(conceptSet, dto);
+								return dto;
+							})
+							.collect(Collectors.toList()));
+		} else { // filter out conceptsets that the user does not have read access to 
+		    return getTransactionTemplate().execute(
+					transactionStatus -> StreamSupport.stream(getConceptSetRepository().findAll().spliterator(), false)
+					                .filter(candidateConceptSet -> permissionService.hasReadAccess(candidateConceptSet))
+							.map(conceptSet -> {
+								ConceptSetDTO dto = conversionService.convert(conceptSet, ConceptSetDTO.class);
+								permissionService.fillWriteAccess(conceptSet, dto);
+								permissionService.fillReadAccess(conceptSet, dto);
+								return dto;
+							})
+					                .collect(Collectors.toList()));
+		}
     }
 
     /**

--- a/src/main/java/org/ohdsi/webapi/service/ConceptSetService.java
+++ b/src/main/java/org/ohdsi/webapi/service/ConceptSetService.java
@@ -135,28 +135,17 @@ public class ConceptSetService extends AbstractDaoService implements HasTags<Int
     @Path("/")
     @Produces(MediaType.APPLICATION_JSON)
     public Collection<ConceptSetDTO> getConceptSets() {
-   	       if (defaultGlobalReadPermissions == true) { // don't filter based on read permissions 
-			return getTransactionTemplate().execute(
-					transactionStatus -> StreamSupport.stream(getConceptSetRepository().findAll().spliterator(), false)
-							.map(conceptSet -> {
-								ConceptSetDTO dto = conversionService.convert(conceptSet, ConceptSetDTO.class);
-								permissionService.fillWriteAccess(conceptSet, dto);
-								permissionService.fillReadAccess(conceptSet, dto);
-								return dto;
-							})
-							.collect(Collectors.toList()));
-		} else { // filter out conceptsets that the user does not have read access to 
-		    return getTransactionTemplate().execute(
-					transactionStatus -> StreamSupport.stream(getConceptSetRepository().findAll().spliterator(), false)
-					                .filter(candidateConceptSet -> permissionService.hasReadAccess(candidateConceptSet))
-							.map(conceptSet -> {
-								ConceptSetDTO dto = conversionService.convert(conceptSet, ConceptSetDTO.class);
-								permissionService.fillWriteAccess(conceptSet, dto);
-								permissionService.fillReadAccess(conceptSet, dto);
-								return dto;
-							})
-					                .collect(Collectors.toList()));
-		}
+        return getTransactionTemplate().execute(
+                transactionStatus -> StreamSupport.stream(getConceptSetRepository().findAll().spliterator(), false)
+                        .filter(!defaultGlobalReadPermissions ? entity -> permissionService.hasReadAccess(entity) : entity -> true)
+                        .map(conceptSet -> {
+                            ConceptSetDTO dto = conversionService.convert(conceptSet, ConceptSetDTO.class);
+                            permissionService.fillWriteAccess(conceptSet, dto);
+                            permissionService.fillReadAccess(conceptSet, dto);
+                            return dto;
+                        })
+                        .collect(Collectors.toList()));
+
     }
 
     /**

--- a/src/main/java/org/ohdsi/webapi/service/dto/CommonEntityDTO.java
+++ b/src/main/java/org/ohdsi/webapi/service/dto/CommonEntityDTO.java
@@ -17,7 +17,9 @@ public abstract class CommonEntityDTO implements CommonDTO {
   private Date createdDate;
   @JsonProperty(access = JsonProperty.Access.READ_ONLY)
   private Date modifiedDate;
+
   private boolean hasWriteAccess;
+  private boolean hasReadAccess;
 
   public UserDTO getCreatedBy() {
     return createdBy;
@@ -57,5 +59,13 @@ public abstract class CommonEntityDTO implements CommonDTO {
 
   public void setHasWriteAccess(boolean hasWriteAccess) {
     this.hasWriteAccess = hasWriteAccess;
+  }
+
+  public boolean isHasReadAccess() {
+    return hasReadAccess;
+  }
+
+  public void setHasReadAccess(boolean hasReadAccess) {
+    this.hasReadAccess = hasReadAccess;
   }
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -107,6 +107,7 @@ csrf.disable=true
 
 sparql.endpoint=http://virtuoso.ohdsi.org:8890/sparql?default-graph-uri=&query=
 
+security.defaultGlobalReadPermissions=${security.defaultGlobalReadPermissions}
 security.provider=${security.provider}
 security.cors.enabled=${security.cors.enabled}
 security.token.expiration=${security.token.expiration}


### PR DESCRIPTION
Enable WebAPI to do filtering based on READ permissions. The new property is called security.defaultGlobalReadPermissions.
