### PR TITLE
Update Dependencies and address defaultGlobalReadOnly param

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
 
     <commons-fileupload.version>1.3.3</commons-fileupload.version>
 
-    <circe.version>1.11.0</circe.version>
+    <circe.version>1.11.1</circe.version>
     <jersey.version>2.14</jersey.version>
     <SqlRender.version>1.13.1</SqlRender.version>
     <hive-jdbc.version>3.1.2</hive-jdbc.version>

--- a/pom.xml
+++ b/pom.xml
@@ -1142,7 +1142,7 @@
     <dependency>
       <groupId>org.ohdsi</groupId>
       <artifactId>standardized-analysis-utils</artifactId>
-      <version>1.3.2</version>
+      <version>1.4.0</version>
       <exclusions>
         <exclusion>
           <groupId>com.fasterxml.jackson.core</groupId>

--- a/src/main/java/org/ohdsi/webapi/cohortcharacterization/CcServiceImpl.java
+++ b/src/main/java/org/ohdsi/webapi/cohortcharacterization/CcServiceImpl.java
@@ -213,7 +213,7 @@ public class CcServiceImpl extends AbstractDaoService implements CcService, Gene
     
     private PermissionService permissionService;
 
-    @Value("#{'${security.defaultGlobalReadPermissions}'.equals(false)}")
+    @Value("${security.defaultGlobalReadPermissions}")
     private boolean defaultGlobalReadPermissions;
     
     private final Environment env;

--- a/src/main/java/org/ohdsi/webapi/estimation/EstimationController.java
+++ b/src/main/java/org/ohdsi/webapi/estimation/EstimationController.java
@@ -72,7 +72,7 @@ public class EstimationController {
   private EstimationChecker checker;
   private PermissionService permissionService;
   
-  @Value("#{'${security.defaultGlobalReadPermissions}'.equals(false)}")
+  @Value("${security.defaultGlobalReadPermissions}")
   private boolean defaultGlobalReadPermissions;
   
   public EstimationController(EstimationService service,

--- a/src/main/java/org/ohdsi/webapi/pathway/PathwayServiceImpl.java
+++ b/src/main/java/org/ohdsi/webapi/pathway/PathwayServiceImpl.java
@@ -122,7 +122,7 @@ public class PathwayServiceImpl extends AbstractDaoService implements PathwaySer
 
 	private PermissionService permissionService;
 
-	@Value("#{'${security.defaultGlobalReadPermissions}'.equals(false)}")
+	@Value("${security.defaultGlobalReadPermissions}")
 	private boolean defaultGlobalReadPermissions;
 
 	private final List<String> STEP_COLUMNS = Arrays.asList(new String[]{"step_1", "step_2", "step_3", "step_4", "step_5", "step_6", "step_7", "step_8", "step_9", "step_10"});

--- a/src/main/java/org/ohdsi/webapi/prediction/PredictionController.java
+++ b/src/main/java/org/ohdsi/webapi/prediction/PredictionController.java
@@ -68,7 +68,7 @@ public class PredictionController {
 
   private PermissionService permissionService;
 
-  @Value("#{'${security.defaultGlobalReadPermissions}'.equals(false)}")
+  @Value("${security.defaultGlobalReadPermissions}")
   private boolean defaultGlobalReadPermissions;
   
   @Autowired

--- a/src/main/java/org/ohdsi/webapi/service/CohortDefinitionService.java
+++ b/src/main/java/org/ohdsi/webapi/service/CohortDefinitionService.java
@@ -205,7 +205,7 @@ public class CohortDefinitionService extends AbstractDaoService implements HasTa
 	@Autowired
 	private VersionService<CohortVersion> versionService;
 
-        @Value("#{'${security.defaultGlobalReadPermissions}'.equals(false)}")
+        @Value("${security.defaultGlobalReadPermissions}")
 	private boolean defaultGlobalReadPermissions;
 
 	private final MarkdownRender markdownPF = new MarkdownRender();

--- a/src/main/java/org/ohdsi/webapi/service/ConceptSetService.java
+++ b/src/main/java/org/ohdsi/webapi/service/ConceptSetService.java
@@ -104,7 +104,7 @@ public class ConceptSetService extends AbstractDaoService implements HasTags<Int
     @Autowired
     private VersionService<ConceptSetVersion> versionService;
 
-    @Value("#{'${security.defaultGlobalReadPermissions}'.equals(false)}")
+    @Value("${security.defaultGlobalReadPermissions}")
     private boolean defaultGlobalReadPermissions;
     
     public static final String COPY_NAME = "copyName";

--- a/src/main/java/org/ohdsi/webapi/service/IRAnalysisService.java
+++ b/src/main/java/org/ohdsi/webapi/service/IRAnalysisService.java
@@ -142,7 +142,7 @@ public class IRAnalysisService extends AbstractDaoService implements
 
   private final IRAnalysisQueryBuilder queryBuilder;
 
-  @Value("#{'${security.defaultGlobalReadPermissions}'.equals(false)}")
+  @Value("${security.defaultGlobalReadPermissions}")
   private boolean defaultGlobalReadPermissions;
   
   @Autowired


### PR DESCRIPTION
Updated circe to version 1.11.1
Updated StandardAnalysisUtils to 1.4.0.
Fixed the assignment of defaultGlobalReadOnly field.
