### PR TITLE
Add Databricks profile

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1456,6 +1456,41 @@
       </properties>
       <dependencies>
         <dependency>
+          <groupId>com.simba</groupId>
+          <artifactId>spark</artifactId>
+          <version>2.6.22.1040</version>
+        </dependency>
+      </dependencies>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-install-plugin</artifactId>
+            <version>3.1.0</version>
+            <executions>
+              <execution>
+                <id>spark-jdbc</id>
+                <phase>initialize</phase>
+                <goals>
+                  <goal>install-file</goal>
+                </goals>
+                <configuration>
+                  <groupId>com.simba</groupId>
+                  <artifactId>spark</artifactId>
+                  <version>2.6.22.1040</version>
+                  <packaging>jar</packaging>
+                  <file>${spark.classpath}/spark-2.6.22.1040.jar</file>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+    <profile>
+      <id>webapi-databricks</id>
+      <dependencies>
+        <dependency>
           <groupId>com.databricks</groupId>
           <artifactId>databricks-jdbc</artifactId>
           <version>2.6.34</version>

--- a/pom.xml
+++ b/pom.xml
@@ -1455,38 +1455,13 @@
         <spark.classpath>${basedir}/src/main/extras/spark</spark.classpath>
       </properties>
       <dependencies>
-		<dependency>
-			<groupId>com.databricks</groupId>
-			<artifactId>databricks-jdbc</artifactId>
-			<version>2.6.36</version>
-			<scope>runtime</scope>
-		</dependency>
+        <dependency>
+          <groupId>com.databricks</groupId>
+          <artifactId>databricks-jdbc</artifactId>
+          <version>2.6.36</version>
+          <scope>runtime</scope>
+        </dependency>
       </dependencies>
-<!--      <build>
-        <plugins>
-          <plugin>
-            <groupId>org.apache.maven.plugins</groupId>
-            <artifactId>maven-install-plugin</artifactId>
-            <version>3.1.0</version>
-            <executions>
-              <execution>
-                <id>spark-jdbc</id>
-                <phase>initialize</phase>
-                <goals>
-                  <goal>install-file</goal>
-                </goals>
-                <configuration>
-                  <groupId>com.databricks</groupId>
-                  <artifactId>databricks-jdbc</artifactId>
-                  <version>2.6.36</version>
-                  <packaging>jar</packaging>
-                  <file>${spark.classpath}/DatabricksJDBC42.jar</file>
-                </configuration>
-              </execution>
-            </executions>
-          </plugin>
-        </plugins>
-      </build> -->
     </profile>
     <profile>
       <id>webapi-bigquery</id>

--- a/pom.xml
+++ b/pom.xml
@@ -1458,7 +1458,7 @@
         <dependency>
           <groupId>com.databricks</groupId>
           <artifactId>databricks-jdbc</artifactId>
-          <version>2.6.36</version>
+          <version>2.6.34</version>
           <scope>runtime</scope>
         </dependency>
       </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -1480,7 +1480,7 @@
                   <artifactId>databricks-jdbc</artifactId>
                   <version>2.6.36</version>
                   <packaging>jar</packaging>
-                  <file>${spark.classpath}/spark-2.6.36.jar</file>
+                  <file>${spark.classpath}/DatabricksJDBC42.jar</file>
                 </configuration>
               </execution>
             </executions>

--- a/pom.xml
+++ b/pom.xml
@@ -1462,7 +1462,7 @@
 			<scope>runtime</scope>
 		</dependency>
       </dependencies>
-      <build>
+<!--      <build>
         <plugins>
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
@@ -1486,7 +1486,7 @@
             </executions>
           </plugin>
         </plugins>
-      </build>
+      </build> -->
     </profile>
     <profile>
       <id>webapi-bigquery</id>

--- a/pom.xml
+++ b/pom.xml
@@ -1455,11 +1455,12 @@
         <spark.classpath>${basedir}/src/main/extras/spark</spark.classpath>
       </properties>
       <dependencies>
-        <dependency>
-          <groupId>com.simba</groupId>
-          <artifactId>spark</artifactId>
-          <version>2.6.22.1040</version>
-        </dependency>
+		<dependency>
+			<groupId>com.databricks</groupId>
+			<artifactId>databricks-jdbc</artifactId>
+			<version>2.6.36</version>
+			<scope>runtime</scope>
+		</dependency>
       </dependencies>
       <build>
         <plugins>
@@ -1475,11 +1476,11 @@
                   <goal>install-file</goal>
                 </goals>
                 <configuration>
-                  <groupId>com.simba</groupId>
-                  <artifactId>spark</artifactId>
-                  <version>2.6.22.1040</version>
+                  <groupId>com.databricks</groupId>
+                  <artifactId>databricks-jdbc</artifactId>
+                  <version>2.6.36</version>
                   <packaging>jar</packaging>
-                  <file>${spark.classpath}/spark-2.6.22.1040.jar</file>
+                  <file>${spark.classpath}/spark-2.6.36.jar</file>
                 </configuration>
               </execution>
             </executions>

--- a/src/main/java/org/ohdsi/webapi/DataAccessConfig.java
+++ b/src/main/java/org/ohdsi/webapi/DataAccessConfig.java
@@ -82,7 +82,7 @@ public class DataAccessConfig {
         //note autocommit defaults vary across vendors. use provided @Autowired TransactionTemplate
 
         String[] supportedDrivers;
-        supportedDrivers = new String[]{"org.postgresql.Driver", "com.microsoft.sqlserver.jdbc.SQLServerDriver", "oracle.jdbc.driver.OracleDriver", "com.amazon.redshift.jdbc.Driver", "com.cloudera.impala.jdbc.Driver", "net.starschema.clouddb.jdbc.BQDriver", "org.netezza.Driver", "com.simba.googlebigquery.jdbc42.Driver", "org.apache.hive.jdbc.HiveDriver", "com.simba.spark.jdbc.Driver", "net.snowflake.client.jdbc.SnowflakeDriver", "com.databricks.client.jdbc42.Driver"};
+        supportedDrivers = new String[]{"org.postgresql.Driver", "com.microsoft.sqlserver.jdbc.SQLServerDriver", "oracle.jdbc.driver.OracleDriver", "com.amazon.redshift.jdbc.Driver", "com.cloudera.impala.jdbc.Driver", "net.starschema.clouddb.jdbc.BQDriver", "org.netezza.Driver", "com.simba.googlebigquery.jdbc42.Driver", "org.apache.hive.jdbc.HiveDriver", "com.simba.spark.jdbc.Driver", "net.snowflake.client.jdbc.SnowflakeDriver", "com.databricks.client.jdbc.Driver"};
         for (String driverName : supportedDrivers) {
             try {
                 Class.forName(driverName);

--- a/src/main/java/org/ohdsi/webapi/DataAccessConfig.java
+++ b/src/main/java/org/ohdsi/webapi/DataAccessConfig.java
@@ -82,7 +82,7 @@ public class DataAccessConfig {
         //note autocommit defaults vary across vendors. use provided @Autowired TransactionTemplate
 
         String[] supportedDrivers;
-        supportedDrivers = new String[]{"org.postgresql.Driver", "com.microsoft.sqlserver.jdbc.SQLServerDriver", "oracle.jdbc.driver.OracleDriver", "com.amazon.redshift.jdbc.Driver", "com.cloudera.impala.jdbc.Driver", "net.starschema.clouddb.jdbc.BQDriver", "org.netezza.Driver", "com.simba.googlebigquery.jdbc42.Driver", "org.apache.hive.jdbc.HiveDriver", "com.simba.spark.jdbc.Driver", "net.snowflake.client.jdbc.SnowflakeDriver"};
+        supportedDrivers = new String[]{"org.postgresql.Driver", "com.microsoft.sqlserver.jdbc.SQLServerDriver", "oracle.jdbc.driver.OracleDriver", "com.amazon.redshift.jdbc.Driver", "com.cloudera.impala.jdbc.Driver", "net.starschema.clouddb.jdbc.BQDriver", "org.netezza.Driver", "com.simba.googlebigquery.jdbc42.Driver", "org.apache.hive.jdbc.HiveDriver", "com.simba.spark.jdbc.Driver", "net.snowflake.client.jdbc.SnowflakeDriver", "com.databricks.client.jdbc42.Driver"};
         for (String driverName : supportedDrivers) {
             try {
                 Class.forName(driverName);

--- a/src/main/java/org/ohdsi/webapi/util/CancelableJdbcTemplate.java
+++ b/src/main/java/org/ohdsi/webapi/util/CancelableJdbcTemplate.java
@@ -78,7 +78,8 @@ public class CancelableJdbcTemplate extends JdbcTemplate {
         }
         else {
           for (int i = 0; i < sql.length; i++) {
-            if (stmt.getConnection().getMetaData().getURL().startsWith("jdbc:spark")) {
+            String connectionString = stmt.getConnection().getMetaData().getURL();
+            if (connectionString.startsWith("jdbc:spark") || connectionString.startsWith("jdbc:databricks")) {
               this.currSql = BigQuerySparkTranslate.sparkHandleInsert(sql[i], stmt.getConnection());
               if (this.currSql == "" || this.currSql.isEmpty() || this.currSql == null) {
                 rowsAffected[i] = -1;


### PR DESCRIPTION
Per feedback from @konstjar, I've added a new profile "webapi-databricks" to use the [Databricks JDBC Driver](https://mvnrepository.com/artifact/com.databricks/databricks-jdbc) reference. Some notes on this PR:

- Using the latest Databricks driver (v2.6.36) was problematic in Apache Tomcat 8.5.x. When using this driver, the servlet container would crash and WebAPI failed to start. v2.6.34 did not exhibit this behavior hence that is why it is referenced in the pom.xml
- Added `com.databricks.client.jdbc.Driver` to the list of supported drivers to support this newer JDBC driver.