### PR TITLE
Permission Checks now use Wildcard semantics.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -761,18 +761,6 @@
       <artifactId>xml-security-impl</artifactId>
       <version>1.0</version>
     </dependency>
-    <dependency>
-      <groupId>org.springframework.boot</groupId>
-      <artifactId>spring-boot-starter-test</artifactId>
-      <version>${spring.boot.version}</version>
-      <scope>test</scope>
-        <exclusions>
-            <exclusion>
-                <groupId>com.vaadin.external.google</groupId>
-                <artifactId>android-json</artifactId>
-            </exclusion>
-        </exclusions>
-    </dependency>
     <!-- It is overriding a transitive dependency from the dependency above -->
     <!-- After migrating to Spring Boot 2.x we should get rid of it -->
     <!-- It is currently inefficient as com.nimbusds:nimbus-jose-jwt has hard bounds [1.3.1,2.3] -->
@@ -1030,24 +1018,6 @@
       <version>1.9.2</version>
     </dependency>
     <dependency>
-      <groupId>org.dbunit</groupId>
-      <artifactId>dbunit</artifactId>
-      <version>2.7.0</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>com.github.springtestdbunit</groupId>
-      <artifactId>spring-test-dbunit</artifactId>
-      <version>1.3.0</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>pl.pragmatists</groupId>
-      <artifactId>JUnitParams</artifactId>
-      <version>1.1.0</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>org.bouncycastle</groupId>
       <artifactId>bcprov-jdk15on</artifactId>
       <version>${bouncycastle.version}</version>
@@ -1209,18 +1179,6 @@
       <version>0.15.2</version>
     </dependency>
     <dependency>
-      <groupId>com.opentable.components</groupId>
-      <artifactId>otj-pg-embedded</artifactId>
-      <version>0.13.1</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-        <groupId>com.github.mjeanroy</groupId>
-        <artifactId>dbunit-plus</artifactId>
-        <version>2.0.1</version>
-        <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>org.dom4j</groupId>
       <artifactId>dom4j</artifactId>
       <version>${dom4j.version}</version>
@@ -1230,9 +1188,50 @@
       <artifactId>syslog-java-client</artifactId>
       <version>1.1.7</version>
     </dependency>
+    <dependency>
+      <groupId>com.opentable.components</groupId>
+      <artifactId>otj-pg-embedded</artifactId>
+      <version>0.13.1</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-test</artifactId>
+      <version>${spring.boot.version}</version>
+      <scope>test</scope>
+        <exclusions>
+            <exclusion>
+                <groupId>com.vaadin.external.google</groupId>
+                <artifactId>android-json</artifactId>
+            </exclusion>
+        </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>org.dbunit</groupId>
+      <artifactId>dbunit</artifactId>
+      <version>2.7.0</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.github.springtestdbunit</groupId>
+      <artifactId>spring-test-dbunit</artifactId>
+      <version>1.3.0</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>pl.pragmatists</groupId>
+      <artifactId>JUnitParams</artifactId>
+      <version>1.1.0</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+        <groupId>com.github.mjeanroy</groupId>
+        <artifactId>dbunit-plus</artifactId>
+        <version>2.0.1</version>
+        <scope>test</scope>
+    </dependency>
   </dependencies>
   <profiles>
-
     <profile>
       <id>webapi-oracle</id>
       <properties>

--- a/src/main/java/org/ohdsi/webapi/security/model/UserSimpleAuthorizationInfo.java
+++ b/src/main/java/org/ohdsi/webapi/security/model/UserSimpleAuthorizationInfo.java
@@ -1,25 +1,39 @@
 package org.ohdsi.webapi.security.model;
 
+import java.util.List;
+import java.util.Map;
+import org.apache.shiro.authz.Permission;
 import org.apache.shiro.authz.SimpleAuthorizationInfo;
 
 public class UserSimpleAuthorizationInfo extends SimpleAuthorizationInfo {
-    private Long userId;
 
-    private String login;
+  private Long userId;
+  private String login;
+  private Map<String,List<Permission>> permissionIdx;
 
-    public Long getUserId() {
-        return userId;
-    }
+  
+  public Long getUserId() {
+    return userId;
+  }
 
-    public void setUserId(Long userId) {
-        this.userId = userId;
-    }
+  public void setUserId(Long userId) {
+    this.userId = userId;
+  }
 
-    public String getLogin() {
-        return login;
-    }
+  public String getLogin() {
+    return login;
+  }
 
-    public void setLogin(String login) {
-        this.login = login;
-    }
+  public void setLogin(String login) {
+    this.login = login;
+  }
+  
+  public Map<String, List<Permission>> getPermissionIdx() {
+    return permissionIdx;
+  }
+
+  public void setPermissionIdx(Map<String, List<Permission>> permissionIdx) {
+    this.permissionIdx = permissionIdx;
+  }
+
 }

--- a/src/main/java/org/ohdsi/webapi/service/UserService.java
+++ b/src/main/java/org/ohdsi/webapi/service/UserService.java
@@ -51,7 +51,7 @@ public class UserService {
     public String login;
     public String name;
     public List<Permission> permissions;
-    public JsonNode permissionIdx;
+    public Map<String, List<String>> permissionIdx;
 
     public User() {}
 

--- a/src/main/java/org/ohdsi/webapi/shiro/filters/CacheFilter.java
+++ b/src/main/java/org/ohdsi/webapi/shiro/filters/CacheFilter.java
@@ -19,9 +19,6 @@ public class CacheFilter implements Filter {
     @Autowired
     private PermissionManager permissionManager;
 
-    @Autowired
-    private PermissionService permissionService;
-
     @Override
     public void init(FilterConfig filterConfig) throws ServletException {
 
@@ -31,7 +28,6 @@ public class CacheFilter implements Filter {
     public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain) throws IOException, ServletException {
 
         permissionManager.clearAuthorizationInfoCache();
-        permissionService.clearPermissionCache();
         chain.doFilter(request, response);
     }
 

--- a/src/main/java/org/ohdsi/webapi/shiro/realms/JwtAuthRealm.java
+++ b/src/main/java/org/ohdsi/webapi/shiro/realms/JwtAuthRealm.java
@@ -1,12 +1,17 @@
 package org.ohdsi.webapi.shiro.realms;
 
+import java.util.ArrayList;
+import java.util.List;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.shiro.authc.AuthenticationException;
 import org.apache.shiro.authc.AuthenticationInfo;
 import org.apache.shiro.authc.AuthenticationToken;
 import org.apache.shiro.authc.SimpleAuthenticationInfo;
 import org.apache.shiro.authz.AuthorizationInfo;
+import org.apache.shiro.authz.Permission;
 import org.apache.shiro.realm.AuthorizingRealm;
 import org.apache.shiro.subject.PrincipalCollection;
+import org.ohdsi.webapi.security.model.UserSimpleAuthorizationInfo;
 import org.ohdsi.webapi.shiro.PermissionManager;
 import org.ohdsi.webapi.shiro.tokens.JwtAuthToken;
 
@@ -37,5 +42,20 @@ public class JwtAuthRealm extends AuthorizingRealm {
   @Override
   protected AuthenticationInfo doGetAuthenticationInfo(AuthenticationToken at) throws AuthenticationException {
     return new SimpleAuthenticationInfo(at.getPrincipal(), "", getName());
-  }  
+  }
+
+  @Override
+  protected boolean isPermitted(Permission permission, AuthorizationInfo info) {
+    // for speed, we check the permission against the set of permissions found by the key '*' and the first element of the permission.
+    String permPrefix =  StringUtils.split(permission.toString(), ":")[0];
+    // we only need to check * perms and perms that begin with the same prefix (up to first :) as the requested permission
+    // starting with perms that start with *
+    List<Permission> permsToCheck = new ArrayList(((UserSimpleAuthorizationInfo)info).getPermissionIdx().getOrDefault("*", new ArrayList<>()));
+    // adding those permissiosn that start with the permPrefix
+    permsToCheck.addAll(((UserSimpleAuthorizationInfo)info).getPermissionIdx().getOrDefault(permPrefix, new ArrayList<>()));
+    
+    // do check
+    return permsToCheck.stream().anyMatch(permToCheck -> permToCheck.implies(permission));
+    
+  }
 }

--- a/src/test/java/org/ohdsi/webapi/AbstractDatabaseTest.java
+++ b/src/test/java/org/ohdsi/webapi/AbstractDatabaseTest.java
@@ -1,5 +1,6 @@
 package org.ohdsi.webapi;
 
+import com.github.mjeanroy.dbunit.core.dataset.DataSetFactory;
 import org.junit.ClassRule;
 import org.junit.Ignore;
 import org.junit.rules.ExternalResource;
@@ -16,63 +17,101 @@ import javax.sql.DataSource;
 import java.sql.Driver;
 import java.sql.DriverManager;
 import java.sql.SQLException;
+import org.dbunit.DatabaseUnitException;
+import org.dbunit.database.DatabaseConfig;
+import org.dbunit.database.DatabaseDataSourceConnection;
+import org.dbunit.database.IDatabaseConnection;
+import org.dbunit.dataset.IDataSet;
+import org.dbunit.ext.postgresql.PostgresqlDataTypeFactory;
+import org.dbunit.operation.DatabaseOperation;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.fail;
 
 @SpringBootTest
 @RunWith(SpringRunner.class)
 @TestPropertySource(locations = "/application-test.properties")
 public abstract class AbstractDatabaseTest {
-    static class JdbcTemplateTestWrapper extends ExternalResource {
-        @Override
-        protected void before() throws Throwable {
-            jdbcTemplate = new JdbcTemplate(getDataSource());
-            try {
-                // note for future reference: should probably either define a TestContext DataSource with these params
-                // or make it so this proparty is only set once (during database initialization) since the below will run for each test class (but only be effective once)
-                System.setProperty("datasource.url", getDataSource().getConnection().getMetaData().getURL());
-                System.setProperty("flyway.datasource.url", System.getProperty("datasource.url"));
-            } catch (Exception ex) {
-                throw new RuntimeException(ex);
-            }
+
+  static class JdbcTemplateTestWrapper extends ExternalResource {
+
+    @Override
+    protected void before() throws Throwable {
+      jdbcTemplate = new JdbcTemplate(getDataSource());
+      try {
+        // note for future reference: should probably either define a TestContext DataSource with these params
+        // or make it so this proparty is only set once (during database initialization) since the below will run for each test class (but only be effective once)
+        System.setProperty("datasource.url", getDataSource().getConnection().getMetaData().getURL());
+        System.setProperty("flyway.datasource.url", System.getProperty("datasource.url"));
+      } catch (Exception ex) {
+        throw new RuntimeException(ex);
+      }
+    }
+  }
+
+  static class DriverExcludeTestWrapper extends ExternalResource {
+
+    @Override
+    protected void before() throws Throwable {
+      // Put the redshift driver at the end so that it doesn't
+      // conflict with postgres queries
+      java.util.Enumeration<Driver> drivers = DriverManager.getDrivers();
+      while (drivers.hasMoreElements()) {
+        Driver driver = drivers.nextElement();
+        if (driver.getClass().getName().contains("com.amazon.redshift.jdbc")) {
+          try {
+            DriverManager.deregisterDriver(driver);
+            DriverManager.registerDriver(driver);
+          } catch (SQLException e) {
+            throw new RuntimeException("Could not deregister redshift driver", e);
+          }
         }
+      }
     }
+  }
 
-    static class DriverExcludeTestWrapper extends ExternalResource {
-        @Override
-        protected void before() throws Throwable {
-            // Put the redshift driver at the end so that it doesn't
-            // conflict with postgres queries
-            java.util.Enumeration<Driver> drivers =  DriverManager.getDrivers();
-            while (drivers.hasMoreElements()) {
-                Driver driver = drivers.nextElement();
-                if (driver.getClass().getName().contains("com.amazon.redshift.jdbc")) {
-                    try {
-                        DriverManager.deregisterDriver(driver);
-                        DriverManager.registerDriver(driver);
-                    } catch (SQLException e) {
-                        throw new RuntimeException("Could not deregister redshift driver", e);
-                    }
-                }
-            }
-        }
+  @ClassRule
+  public static TestRule chain = RuleChain.outerRule(new DriverExcludeTestWrapper())
+          .around(pg = new PostgresSingletonRule())
+          .around(new JdbcTemplateTestWrapper());
+
+  protected static PostgresSingletonRule pg;
+
+  protected static JdbcTemplate jdbcTemplate;
+
+  protected static DataSource getDataSource() {
+    return pg.getEmbeddedPostgres().getPostgresDatabase();
+  }
+
+  protected void truncateTable(String tableName) {
+    jdbcTemplate.execute(String.format("TRUNCATE %s CASCADE", tableName));
+  }
+
+  protected void resetSequence(String sequenceName) {
+    jdbcTemplate.execute(String.format("ALTER SEQUENCE %s RESTART WITH 1", sequenceName));
+  }
+
+  protected static IDatabaseConnection getConnection() throws SQLException {
+    final IDatabaseConnection con = new DatabaseDataSourceConnection(getDataSource());
+    con.getConfig().setProperty(DatabaseConfig.FEATURE_QUALIFIED_TABLE_NAMES, true);
+    con.getConfig().setProperty(DatabaseConfig.PROPERTY_DATATYPE_FACTORY, new PostgresqlDataTypeFactory());
+    return con;
+  }
+  
+  protected void loadPrepData(String[] datasetPaths) throws Exception {
+    loadPrepData(datasetPaths, DatabaseOperation.CLEAN_INSERT);
+  }
+  protected void loadPrepData(String[] datasetPaths, DatabaseOperation dbOp) throws Exception {
+    final IDatabaseConnection dbUnitCon = getConnection();
+    final IDataSet ds = DataSetFactory.createDataSet(datasetPaths);
+
+    assertNotNull("No dataset found", ds);
+
+    try {
+      dbOp.execute(dbUnitCon, ds); // clean load of the DB. Careful, clean means "delete the old stuff"
+    } catch (final DatabaseUnitException e) {
+      fail(e.getMessage());
+    } finally {
+      dbUnitCon.close();
     }
-
-    @ClassRule
-    public static TestRule chain = RuleChain.outerRule(new DriverExcludeTestWrapper())
-            .around(pg = new PostgresSingletonRule())
-            .around(new JdbcTemplateTestWrapper());
-
-    protected static PostgresSingletonRule pg;
-
-    protected static JdbcTemplate jdbcTemplate;
-
-    protected static DataSource getDataSource() {
-        return pg.getEmbeddedPostgres().getPostgresDatabase();
-    }
-   
-    protected void truncateTable (String tableName) {
-      jdbcTemplate.execute(String.format("TRUNCATE %s CASCADE",tableName));
-    }
-    protected void resetSequence(String sequenceName) {
-      jdbcTemplate.execute(String.format("ALTER SEQUENCE %s RESTART WITH 1", sequenceName));
-    }
+  }  
 }

--- a/src/test/java/org/ohdsi/webapi/pathway/PathwayAnalysisTest.java
+++ b/src/test/java/org/ohdsi/webapi/pathway/PathwayAnalysisTest.java
@@ -24,16 +24,12 @@ import java.util.Arrays;
 import java.util.Collection;
 import org.dbunit.Assertion;
 import org.dbunit.DatabaseUnitException;
-import org.dbunit.database.DatabaseConfig;
-import org.dbunit.database.DatabaseDataSourceConnection;
 import org.dbunit.database.IDatabaseConnection;
 import org.dbunit.dataset.CompositeDataSet;
 import org.dbunit.dataset.IDataSet;
 import org.dbunit.dataset.ITable;
-import org.dbunit.ext.postgresql.PostgresqlDataTypeFactory;
 import org.dbunit.operation.DatabaseOperation;
 import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.junit.Assert.assertEquals;
 
@@ -96,12 +92,6 @@ public class PathwayAnalysisTest extends AbstractDatabaseTest {
 
   private static SerializedPathwayAnalysisToPathwayAnalysisConverter converter =  new SerializedPathwayAnalysisToPathwayAnalysisConverter();
 
-  private static IDatabaseConnection getConnection() throws SQLException {
-    final IDatabaseConnection con = new DatabaseDataSourceConnection(getDataSource());
-    con.getConfig().setProperty(DatabaseConfig.FEATURE_QUALIFIED_TABLE_NAMES, true);
-    con.getConfig().setProperty(DatabaseConfig.PROPERTY_DATATYPE_FACTORY, new PostgresqlDataTypeFactory());
-    return con;
-  }
   
   @Before
   public void setUp() throws Exception {
@@ -181,21 +171,6 @@ public class PathwayAnalysisTest extends AbstractDatabaseTest {
     source.setDaimons(Arrays.asList(cdmDaimon, vocabDaimon, resultsDaimon));
 
     return source;
-  }
-  
-  private void loadPrepData(String[] datasetPaths) throws Exception {
-    final IDatabaseConnection dbUnitCon = getConnection();
-    final IDataSet ds = DataSetFactory.createDataSet(datasetPaths);
-
-    assertNotNull("No dataset found", ds);
-
-    try {
-      DatabaseOperation.CLEAN_INSERT.execute(dbUnitCon, ds); // clean load of the DB. Careful, clean means "delete the old stuff"
-    } catch (final DatabaseUnitException e) {
-      fail(e.getMessage());
-    } finally {
-      dbUnitCon.close();
-    }
   }
   
   private void generateAnalysis(PathwayAnalysisEntity entity) throws Exception {

--- a/src/test/java/org/ohdsi/webapi/security/PermissionTest.java
+++ b/src/test/java/org/ohdsi/webapi/security/PermissionTest.java
@@ -66,13 +66,12 @@ public class PermissionTest extends AbstractDatabaseTest {
 
   @Test
   public void permsTest() throws Exception {
-    // Set up the mock Subject as the currently authenticated user
     Subject s = SecurityUtils.getSubject();
     String subjetName = permissionManager.getSubjectName();
 
     final String[] testDataSetsPaths = new String[] {"/permission/permsTest_PREP.json" };
      
-    loadPrepData(testDataSetsPaths);
+    loadPrepData(testDataSetsPaths, DatabaseOperation.REFRESH);
 
     // subject can manage printer1 and printer2, can do print and query on any printer.
     assertTrue(s.isPermitted("printer:manage:printer1"));
@@ -85,4 +84,21 @@ public class PermissionTest extends AbstractDatabaseTest {
     
   }
   
+  @Test
+  public void wildcardTest() throws Exception {
+    Subject s = SecurityUtils.getSubject();
+    String subjetName = permissionManager.getSubjectName();
+
+    final String[] testDataSetsPaths = new String[] {"/permission/wildcardTest_PREP.json" };
+     
+    loadPrepData(testDataSetsPaths, DatabaseOperation.REFRESH);
+
+    // subject has * permisison, so any permisison test is true
+    assertTrue(s.isPermitted("printer:manage:printer1"));
+    assertTrue(s.isPermitted("printer"));
+    
+    loadPrepData(testDataSetsPaths, DatabaseOperation.DELETE);
+    
+  }
+
 }

--- a/src/test/java/org/ohdsi/webapi/security/PermissionTest.java
+++ b/src/test/java/org/ohdsi/webapi/security/PermissionTest.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2024 cknoll1.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.ohdsi.webapi.security;
+
+import java.util.Arrays;
+import org.apache.shiro.SecurityUtils;
+import org.apache.shiro.subject.SimplePrincipalCollection;
+import org.apache.shiro.subject.Subject;
+import org.apache.shiro.util.ThreadContext;
+import org.apache.shiro.web.mgt.DefaultWebSecurityManager;
+import org.dbunit.operation.DatabaseOperation;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import org.junit.Before;
+import org.junit.Test;
+import org.ohdsi.webapi.AbstractDatabaseTest;
+import org.ohdsi.webapi.shiro.PermissionManager;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.test.context.TestPropertySource;
+
+/**
+ *
+ * @author cknoll1
+ */
+@TestPropertySource(properties = {
+  "security.provider=AtlasRegularSecurity"
+})
+public class PermissionTest extends AbstractDatabaseTest {
+  
+  @Autowired
+  private PermissionManager permissionManager;
+
+  @Value("${security.provider}")
+  String securityProvider;
+
+  @Autowired
+  private DefaultWebSecurityManager securityManager;
+
+  private Subject subject;
+  
+  @Before
+  public void setup() {
+    // Set the SecurityManager for the current thread
+    SimplePrincipalCollection principalCollection = new SimplePrincipalCollection();
+      principalCollection.addAll(Arrays.asList("permsTest"),"testRealm");
+    subject = new Subject.Builder(securityManager)
+            .authenticated(true)
+            .principals(principalCollection)
+            .buildSubject();
+    ThreadContext.bind(subject);    
+  }
+
+  @Test
+  public void permsTest() throws Exception {
+    // Set up the mock Subject as the currently authenticated user
+    Subject s = SecurityUtils.getSubject();
+    String subjetName = permissionManager.getSubjectName();
+
+    final String[] testDataSetsPaths = new String[] {"/permission/permsTest_PREP.json" };
+     
+    loadPrepData(testDataSetsPaths);
+
+    // subject can manage printer1 and printer2, can do print and query on any printer.
+    assertTrue(s.isPermitted("printer:manage:printer1"));
+    assertTrue(s.isPermitted("printer:manage:printer2"));
+    assertFalse(s.isPermitted("printer:manage:printer3"));
+    assertTrue(s.isPermitted("printer:query:printer4"));
+    assertTrue(s.isPermitted("printer:print:printer5"));
+    
+    loadPrepData(testDataSetsPaths, DatabaseOperation.DELETE);
+    
+  }
+  
+}

--- a/src/test/java/org/ohdsi/webapi/security/PermissionTest.java
+++ b/src/test/java/org/ohdsi/webapi/security/PermissionTest.java
@@ -66,6 +66,8 @@ public class PermissionTest extends AbstractDatabaseTest {
 
   @Test
   public void permsTest() throws Exception {
+    // need to clear authorization cache before each test
+    permissionManager.clearAuthorizationInfoCache();
     Subject s = SecurityUtils.getSubject();
     String subjetName = permissionManager.getSubjectName();
 
@@ -86,11 +88,10 @@ public class PermissionTest extends AbstractDatabaseTest {
   
   @Test
   public void wildcardTest() throws Exception {
+    // need to clear authorization cache before each test
+    permissionManager.clearAuthorizationInfoCache();
     Subject s = SecurityUtils.getSubject();
-    String subjetName = permissionManager.getSubjectName();
-
     final String[] testDataSetsPaths = new String[] {"/permission/wildcardTest_PREP.json" };
-     
     loadPrepData(testDataSetsPaths, DatabaseOperation.REFRESH);
 
     // subject has * permisison, so any permisison test is true

--- a/src/test/resources/permission/permsTest_PREP.json
+++ b/src/test/resources/permission/permsTest_PREP.json
@@ -1,0 +1,65 @@
+{
+  "public.sec_user": [
+    {
+      "id":1001,
+      "login":"permsTest",
+      "name":"Perms Test User",
+      "origin":"SYSTEM"
+    }
+  ],
+  "public.sec_role": [
+    {
+      "id": 1001,
+      "name":"permsTest",
+      "system_role":false
+    }
+  ],
+  "public.sec_permission" : [
+    {
+      "id": 1001,
+      "value":"printer:manage:printer1"
+    },
+    {
+      "id": 1002,
+      "value":"printer:manage:printer2"
+    },
+    {
+      "id": 1003,
+      "value":"printer:query:*"
+    },
+    {
+      "id": 1004,
+      "value":"printer:print"
+    }
+  ],
+  "public.sec_role_permission" : [
+    {
+      "id":1001,
+      "role_id":1001,
+      "permission_id":1001
+    },
+    {
+      "id":1002,
+      "role_id":1001,
+      "permission_id":1002
+    },
+    {
+      "id":1003,
+      "role_id":1001,
+      "permission_id":1003
+    },
+    {
+      "id":1004,
+      "role_id":1001,
+      "permission_id":1004
+    }
+  ],
+  "public.sec_user_role": [
+    {
+      "id": 1001,
+      "user_id":1001,
+      "role_id":1001,
+      "origin":"SYSTEM"
+    }
+  ]
+}

--- a/src/test/resources/permission/wildcardTest_PREP.json
+++ b/src/test/resources/permission/wildcardTest_PREP.json
@@ -1,0 +1,38 @@
+{
+  "public.sec_user": [
+    {
+      "id":1001,
+      "login":"permsTest",
+      "name":"Perms Test User",
+      "origin":"SYSTEM"
+    }
+  ],
+  "public.sec_role": [
+    {
+      "id": 1001,
+      "name":"permsTest",
+      "system_role":false
+    }
+  ],
+  "public.sec_permission" : [
+    {
+      "id": 1001,
+      "value":"*"
+    }
+  ],
+  "public.sec_role_permission" : [
+    {
+      "id":1001,
+      "role_id":1001,
+      "permission_id":1001
+    }
+  ],
+  "public.sec_user_role": [
+    {
+      "id": 1001,
+      "user_id":1001,
+      "role_id":1001,
+      "origin":"SYSTEM"
+    }
+  ]
+}


### PR DESCRIPTION
Removed role cache from Permission Service.
Changed read/write permission checks to use permissions instead of roles. 
Permission checks are using Subject.isPermitted() which honors wildcard semantics. 
Altered JwtAuthRealm to filter user permissions to either * or first element of permission to check for speed. 
Changed permission index from JsonNode to Map<>.  Serializes same way, but map semantics are simpler to navigate. 
Altered AuthrizationInfo to contain index of Permissions and store Wildcard perms.

General cleanup of unused imports and removed unused dependencies (ie: Autowired fields were removed if no longer needed).

Fixes #2353.