### PR TITLE
Add handling for Snowflake IN clause limit

### DIFF
--- a/src/main/java/org/ohdsi/webapi/util/PreparedSqlRender.java
+++ b/src/main/java/org/ohdsi/webapi/util/PreparedSqlRender.java
@@ -84,7 +84,7 @@ public class PreparedSqlRender {
 			returnVal = 990;
 		} else if (sourceDialect.equals(DBMSType.MS_SQL_SERVER.getOhdsiDB()) || sourceDialect.equals(DBMSType.PDW.getOhdsiDB())) {
 			returnVal = 2000;
-		} else if (sourceDialect.equals(DBMSType.BIGQUERY.getOhdsiDB())) {
+		} else if (sourceDialect.equals(DBMSType.BIGQUERY.getOhdsiDB()) || sourceDialect.equals(DBMSType.SNOWFLAKE.getOhdsiDB())) {
 			returnVal = 10000;
 		}
 		return returnVal;


### PR DESCRIPTION
Aims to fix #2284 to handle the `IN` clause expression limit in Snowflake SQL.