### PR TITLE
Utilizing circe-be extensions to pertain cohort covariates during its generation

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
 
     <commons-fileupload.version>1.5</commons-fileupload.version>
 
-    <circe.version>1.11.2</circe.version>
+    <circe.version>1.11.4-SNAPSHOT</circe.version>
     <jersey.version>2.14</jersey.version>
     <SqlRender.version>1.16.1</SqlRender.version>
     <hive-jdbc.version>3.1.2</hive-jdbc.version>

--- a/src/main/java/org/ohdsi/webapi/Constants.java
+++ b/src/main/java/org/ohdsi/webapi/Constants.java
@@ -82,6 +82,7 @@ public interface Constants {
     String EXECUTABLE_FILE_NAME = "executableFilename";
     String GENERATION_ID = "generation_id";
     String DESIGN_HASH = "design_hash";
+    String RETAIN_COHORT_COVARIATES = "retains_cohort_covariates";
   }
 
   interface Variables {

--- a/src/main/java/org/ohdsi/webapi/cohortdefinition/CohortGenerationInfo.java
+++ b/src/main/java/org/ohdsi/webapi/cohortdefinition/CohortGenerationInfo.java
@@ -84,6 +84,8 @@ public class CohortGenerationInfo implements Serializable, IExecutionInfo {
   @ManyToOne(fetch = FetchType.LAZY)
   @JoinColumn(name = "created_by_id")
   private UserEntity createdBy;
+  @Column(name = "is_choose_covariates")
+  private boolean isChooseCovariates;
 
   public CohortGenerationInfoId getId() {
     return id;
@@ -186,5 +188,13 @@ public class CohortGenerationInfo implements Serializable, IExecutionInfo {
 
   public UserEntity getCreatedBy() {
     return createdBy;
+  }
+
+  public boolean isChooseCovariates() {
+    return isChooseCovariates;
+  }
+
+  public void setChooseCovariates(boolean chooseCovariates) {
+    isChooseCovariates = chooseCovariates;
   }
 }

--- a/src/main/java/org/ohdsi/webapi/cohortdefinition/CohortGenerationRequest.java
+++ b/src/main/java/org/ohdsi/webapi/cohortdefinition/CohortGenerationRequest.java
@@ -11,7 +11,7 @@ public class CohortGenerationRequest {
     private String targetSchema;
     private Integer targetId;
     private Boolean retainCohortCovariates;
-    
+    private Integer cohortId;
 
     public CohortGenerationRequest(CohortExpression expression, Source source, String sessionId, Integer targetId, String targetSchema) {
 
@@ -22,7 +22,8 @@ public class CohortGenerationRequest {
         this.targetSchema = targetSchema;
     }
     
-    public CohortGenerationRequest(CohortExpression expression, Source source, String sessionId, Integer targetId, String targetSchema, Boolean retainCohortCovariates) {
+    public CohortGenerationRequest(CohortExpression expression, Source source, String sessionId, Integer targetId, 
+            String targetSchema, Boolean retainCohortCovariates, Integer cohortId) {
 
         this.expression = expression;
         this.source = source;
@@ -30,6 +31,7 @@ public class CohortGenerationRequest {
         this.targetId = targetId;
         this.targetSchema = targetSchema;
         this.retainCohortCovariates = retainCohortCovariates;
+        this.cohortId = cohortId;
     }
 
     public CohortExpression getExpression() {
@@ -60,5 +62,10 @@ public class CohortGenerationRequest {
     public Boolean getRetainCohortCovariates() {
 
         return retainCohortCovariates;
+    }
+    
+    public Integer getCohortId() {
+
+        return cohortId;
     }
 }

--- a/src/main/java/org/ohdsi/webapi/cohortdefinition/CohortGenerationRequest.java
+++ b/src/main/java/org/ohdsi/webapi/cohortdefinition/CohortGenerationRequest.java
@@ -10,6 +10,8 @@ public class CohortGenerationRequest {
     private String sessionId;
     private String targetSchema;
     private Integer targetId;
+    private Boolean retainCohortCovariates;
+    
 
     public CohortGenerationRequest(CohortExpression expression, Source source, String sessionId, Integer targetId, String targetSchema) {
 
@@ -18,6 +20,16 @@ public class CohortGenerationRequest {
         this.sessionId = sessionId;
         this.targetId = targetId;
         this.targetSchema = targetSchema;
+    }
+    
+    public CohortGenerationRequest(CohortExpression expression, Source source, String sessionId, Integer targetId, String targetSchema, Boolean retainCohortCovariates) {
+
+        this.expression = expression;
+        this.source = source;
+        this.sessionId = sessionId;
+        this.targetId = targetId;
+        this.targetSchema = targetSchema;
+        this.retainCohortCovariates = retainCohortCovariates;
     }
 
     public CohortExpression getExpression() {
@@ -43,5 +55,10 @@ public class CohortGenerationRequest {
     public Integer getTargetId() {
 
         return targetId;
+    }
+    
+    public Boolean getRetainCohortCovariates() {
+
+        return retainCohortCovariates;
     }
 }

--- a/src/main/java/org/ohdsi/webapi/cohortdefinition/CohortGenerationRequestBuilder.java
+++ b/src/main/java/org/ohdsi/webapi/cohortdefinition/CohortGenerationRequestBuilder.java
@@ -10,6 +10,7 @@ public class CohortGenerationRequestBuilder {
     private String sessionId;
     private String targetSchema;
     private Integer targetId;
+    private Integer cohortId;
     private Boolean retainCohortCovariates;
     
     public CohortGenerationRequestBuilder(String sessionId, String targetSchema) {
@@ -47,6 +48,11 @@ public class CohortGenerationRequestBuilder {
         this.targetId = targetId;
         return this;
     }
+    
+    public CohortGenerationRequestBuilder withCohortId(Integer cohortId) {
+        this.cohortId = cohortId;
+        return this;
+    }
 
     public CohortGenerationRequest build() {
 
@@ -63,6 +69,7 @@ public class CohortGenerationRequestBuilder {
             throw new RuntimeException("CohortGenerationRequest should contain non-null expression, source and targetId");
         }
 
-        return new CohortGenerationRequest(expression, source, sessionId, targetId, targetSchema, retainCohortCovariates);
+        return new CohortGenerationRequest(expression, source, sessionId, targetId, targetSchema, 
+                retainCohortCovariates, cohortId);
     }
 }

--- a/src/main/java/org/ohdsi/webapi/cohortdefinition/CohortGenerationRequestBuilder.java
+++ b/src/main/java/org/ohdsi/webapi/cohortdefinition/CohortGenerationRequestBuilder.java
@@ -10,11 +10,24 @@ public class CohortGenerationRequestBuilder {
     private String sessionId;
     private String targetSchema;
     private Integer targetId;
-
+    private Boolean retainCohortCovariates;
+    
     public CohortGenerationRequestBuilder(String sessionId, String targetSchema) {
 
         this.sessionId = sessionId;
         this.targetSchema = targetSchema;
+    }
+    
+    public CohortGenerationRequestBuilder(String sessionId, String targetSchema, Boolean retainCohortCovariates) {
+
+        this.sessionId = sessionId;
+        this.targetSchema = targetSchema;
+        this.retainCohortCovariates = retainCohortCovariates;
+    }
+
+    public Boolean getRetainCohortCovariates() {
+
+        return retainCohortCovariates;
     }
 
     public CohortGenerationRequestBuilder withSource(Source source) {
@@ -42,5 +55,14 @@ public class CohortGenerationRequestBuilder {
         }
 
         return new CohortGenerationRequest(expression, source, sessionId, targetId, targetSchema);
+    }
+    
+    public CohortGenerationRequest buildWithRetainCohortCovariates() {
+
+        if (this.source == null || this.expression == null || this.targetId == null || this.retainCohortCovariates == null) {
+            throw new RuntimeException("CohortGenerationRequest should contain non-null expression, source and targetId");
+        }
+
+        return new CohortGenerationRequest(expression, source, sessionId, targetId, targetSchema, retainCohortCovariates);
     }
 }

--- a/src/main/java/org/ohdsi/webapi/cohortdefinition/CohortGenerationRequestBuilder.java
+++ b/src/main/java/org/ohdsi/webapi/cohortdefinition/CohortGenerationRequestBuilder.java
@@ -71,6 +71,7 @@ public class CohortGenerationRequestBuilder {
 
         return new CohortGenerationRequest(expression, source, sessionId, targetId, targetSchema, 
                 retainCohortCovariates, cohortId);
+    }
     
     public boolean hasRetainCohortCovariates() {
     	return retainCohortCovariates != null ? retainCohortCovariates.booleanValue() : false;

--- a/src/main/java/org/ohdsi/webapi/cohortdefinition/CohortGenerationRequestBuilder.java
+++ b/src/main/java/org/ohdsi/webapi/cohortdefinition/CohortGenerationRequestBuilder.java
@@ -71,5 +71,8 @@ public class CohortGenerationRequestBuilder {
 
         return new CohortGenerationRequest(expression, source, sessionId, targetId, targetSchema, 
                 retainCohortCovariates, cohortId);
+    
+    public boolean hasRetainCohortCovariates() {
+    	return retainCohortCovariates != null ? retainCohortCovariates.booleanValue() : false;
     }
 }

--- a/src/main/java/org/ohdsi/webapi/cohortdefinition/CohortGenerationUtils.java
+++ b/src/main/java/org/ohdsi/webapi/cohortdefinition/CohortGenerationUtils.java
@@ -51,7 +51,6 @@ public class CohortGenerationUtils {
 
     String cdmSchema = SourceUtils.getCdmQualifier(source);
     String vocabSchema = SourceUtils.getVocabQualifierOrNull(source);
-    String resultSchema = SourceUtils.getResultsQualifier(source);
 
     CohortExpressionQueryBuilder expressionQueryBuilder = new CohortExpressionQueryBuilder();
     StringBuilder sqlBuilder = new StringBuilder();
@@ -59,10 +58,10 @@ public class CohortGenerationUtils {
     CohortExpressionQueryBuilder.BuildExpressionQueryOptions options = new CohortExpressionQueryBuilder.BuildExpressionQueryOptions();
     options.cohortIdFieldName = DESIGN_HASH;
     options.cohortId = request.getTargetId();
+    options.resultCohortId = request.getCohortId();
     options.cdmSchema = cdmSchema;
     options.vocabularySchema = vocabSchema;
     options.generateStats = true; // always generate with stats
-    options.resultSchema = resultSchema;
     options.retainCohortCovariates = !ObjectUtils.isEmpty(request.getRetainCohortCovariates()) && request.getRetainCohortCovariates(); // this field decides whether to retain cohort covariates
 
     final String oracleTempSchema = SourceUtils.getTempQualifier(source);
@@ -86,13 +85,13 @@ public class CohortGenerationUtils {
         "@target_database_schema.cohort_inclusion"
       }
     );
+    expressionSql = expressionSql.replaceAll("@results_database_schema", request.getTargetSchema());
     sqlBuilder.append(expressionSql);
-//    expressionSql = expressionSql.replaceAll("@results_database_schema", request.getTargetSchema());
 
     String renderedSql = SqlRender.renderSql(
       sqlBuilder.toString(),
-      new String[] {TARGET_DATABASE_SCHEMA, RESULTS_DATABASE_SCHEMA},
-      new String[]{request.getTargetSchema(), resultSchema}
+      new String[] {TARGET_DATABASE_SCHEMA},
+      new String[]{request.getTargetSchema()}
     );
     String translatedSql = SqlTranslate.translateSql(renderedSql, source.getSourceDialect(), request.getSessionId(), oracleTempSchema);
     return SqlSplit.splitSql(translatedSql);

--- a/src/main/java/org/ohdsi/webapi/cohortdefinition/CohortGenerationUtils.java
+++ b/src/main/java/org/ohdsi/webapi/cohortdefinition/CohortGenerationUtils.java
@@ -12,7 +12,6 @@ import org.ohdsi.webapi.util.SourceUtils;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.util.ObjectUtils;
 
-
 import java.util.Arrays;
 import java.util.List;
 

--- a/src/main/java/org/ohdsi/webapi/cohortdefinition/GenerateCohortTasklet.java
+++ b/src/main/java/org/ohdsi/webapi/cohortdefinition/GenerateCohortTasklet.java
@@ -67,13 +67,15 @@ public class GenerateCohortTasklet extends CancelableTasklet implements Stoppabl
     Integer sourceId = Integer.parseInt(jobParams.get(SOURCE_ID).toString());
     String targetSchema = jobParams.get(TARGET_DATABASE_SCHEMA).toString();
     String sessionId = jobParams.getOrDefault(SESSION_ID, SessionUtils.sessionId()).toString();
+    Boolean retainCohortCovariates = Boolean.valueOf(jobParams.get(RETAIN_COHORT_COVARIATES).toString());
 
     CohortDefinition cohortDefinition = cohortDefinitionRepository.findOneWithDetail(cohortDefinitionId);
     Source source = sourceService.findBySourceId(sourceId);
 
     CohortGenerationRequestBuilder generationRequestBuilder = new CohortGenerationRequestBuilder(
         sessionId,
-        targetSchema
+        targetSchema,
+        retainCohortCovariates
     );
 
     int designHash = this.generationCacheHelper.computeHash(cohortDefinition.getDetails().getExpression());

--- a/src/main/java/org/ohdsi/webapi/cohortdefinition/converter/CohortGenerationInfoToCohortGenerationInfoDTOConverter.java
+++ b/src/main/java/org/ohdsi/webapi/cohortdefinition/converter/CohortGenerationInfoToCohortGenerationInfoDTOConverter.java
@@ -22,6 +22,7 @@ public class CohortGenerationInfoToCohortGenerationInfoDTOConverter extends Base
         dto.setStartTime(info.getStartTime());
         dto.setStatus(info.getStatus());
         dto.setIsValid(info.isIsValid());
+        dto.setChooseCovariates(info.isChooseCovariates());
 
         return dto;
     }

--- a/src/main/java/org/ohdsi/webapi/cohortdefinition/dto/CohortGenerationInfoDTO.java
+++ b/src/main/java/org/ohdsi/webapi/cohortdefinition/dto/CohortGenerationInfoDTO.java
@@ -45,6 +45,8 @@ public class CohortGenerationInfoDTO {
 
     private UserDTO createdBy;
 
+    private boolean isChooseCovariates;
+
     public CohortGenerationInfoId getId() {
         return id;
     }
@@ -123,5 +125,13 @@ public class CohortGenerationInfoDTO {
 
     public void setCreatedBy(UserDTO createdBy) {
         this.createdBy = createdBy;
+    }
+
+    public boolean isChooseCovariates() {
+        return isChooseCovariates;
+    }
+
+    public void setChooseCovariates(boolean chooseCovariates) {
+        isChooseCovariates = chooseCovariates;
     }
 }

--- a/src/main/java/org/ohdsi/webapi/feasibility/FeasibilityStudyQueryBuilder.java
+++ b/src/main/java/org/ohdsi/webapi/feasibility/FeasibilityStudyQueryBuilder.java
@@ -76,7 +76,7 @@ public class FeasibilityStudyQueryBuilder {
   private String getInclusionRuleQuery(CriteriaGroup inclusionRule)
   {
     String resultSql = INCLUSION_RULE_QUERY_TEMPLATE;
-    String additionalCriteriaQuery = "\nJOIN (\n" + cohortExpressionQueryBuilder.getCriteriaGroupQuery(inclusionRule, "#primary_events") + ") AC on AC.event_id = pe.event_id";
+    String additionalCriteriaQuery = "\nJOIN (\n" + cohortExpressionQueryBuilder.getCriteriaGroupQuery(inclusionRule, "#primary_events", null, false) + ") AC on AC.event_id = pe.event_id";
     additionalCriteriaQuery = StringUtils.replace(additionalCriteriaQuery,"@indexId", "" + 0);
     resultSql = StringUtils.replace(resultSql, "@additionalCriteriaQuery", additionalCriteriaQuery);
     return resultSql;

--- a/src/main/java/org/ohdsi/webapi/feasibility/FeasibilityStudyQueryBuilder.java
+++ b/src/main/java/org/ohdsi/webapi/feasibility/FeasibilityStudyQueryBuilder.java
@@ -76,9 +76,9 @@ public class FeasibilityStudyQueryBuilder {
   private String getInclusionRuleQuery(CriteriaGroup inclusionRule)
   {
     String resultSql = INCLUSION_RULE_QUERY_TEMPLATE;
-    String additionalCriteriaQuery = "\nJOIN (\n" + cohortExpressionQueryBuilder.getCriteriaGroupQuery(inclusionRule, "#primary_events", null, false) + ") AC on AC.event_id = pe.event_id";
-    additionalCriteriaQuery = StringUtils.replace(additionalCriteriaQuery,"@indexId", "" + 0);
-    resultSql = StringUtils.replace(resultSql, "@additionalCriteriaQuery", additionalCriteriaQuery);
+    String additionalCriteriaQuery = "\nJOIN (\n"
+            + cohortExpressionQueryBuilder.getCriteriaGroupQuery(inclusionRule, "#primary_events", false)
+            + ") AC on AC.event_id = pe.event_id";    additionalCriteriaQuery = StringUtils.replace(additionalCriteriaQuery,"@indexId", "" + 0);    resultSql = StringUtils.replace(resultSql, "@additionalCriteriaQuery", additionalCriteriaQuery);
     return resultSql;
   }
   

--- a/src/main/java/org/ohdsi/webapi/generationcache/GenerationCacheHelper.java
+++ b/src/main/java/org/ohdsi/webapi/generationcache/GenerationCacheHelper.java
@@ -56,6 +56,9 @@ public class GenerationCacheHelper {
                     log.info(messagePrefix + " for cohort id = {}. Calculating with design hash = {}", cohortDefinition.getId(), designHash);
                     // Ensure that there are no records in results schema with which we could mess up
                     generationCacheService.removeCache(type, source, designHash);
+                    // the line below forces a cached entry to be really deleted and it is a bit unclear why this line was even present as the cache had to be null anyway
+                    // without it there is a constraint violation exception when there was a cache entry present and the retain covariates option is on  
+                    GenerationCache cachedResultsStillPresent = generationCacheService.getCacheOrEraseInvalid(type, designHash, source.getSourceId());
                     CohortGenerationRequest cohortGenerationRequest = requestBuilder
                             .withExpression(cohortDefinition.getDetails().getExpressionObject())
                             .withSource(source)

--- a/src/main/java/org/ohdsi/webapi/generationcache/GenerationCacheHelper.java
+++ b/src/main/java/org/ohdsi/webapi/generationcache/GenerationCacheHelper.java
@@ -59,6 +59,7 @@ public class GenerationCacheHelper {
                             .withExpression(cohortDefinition.getDetails().getExpressionObject())
                             .withSource(source)
                             .withTargetId(designHash)
+                            .withCohortId(cohortDefinition.getId())
                             .buildWithRetainCohortCovariates();
                     String[] sqls = CohortGenerationUtils.buildGenerationSql(cohortGenerationRequest);
                     sqlExecutor.accept(designHash, sqls);

--- a/src/main/java/org/ohdsi/webapi/generationcache/GenerationCacheHelper.java
+++ b/src/main/java/org/ohdsi/webapi/generationcache/GenerationCacheHelper.java
@@ -51,8 +51,9 @@ public class GenerationCacheHelper {
             return transactionTemplateRequiresNew.execute(s -> {
                 log.info("Retrieves or invalidates cache for cohort id = {}", cohortDefinition.getId());
                 GenerationCache cache = generationCacheService.getCacheOrEraseInvalid(type, designHash, source.getSourceId());
-                if (cache == null) {
-                    log.info("Cache is absent for cohort id = {}. Calculating with design hash = {}", cohortDefinition.getId(), designHash);
+                if (cache == null || requestBuilder.hasRetainCohortCovariates()) {
+                	String messagePrefix = (cache == null ? "Cache is absent" : "Cache will not be used because the retain cohort covariates option is switched on");
+                    log.info(messagePrefix + " for cohort id = {}. Calculating with design hash = {}", cohortDefinition.getId(), designHash);
                     // Ensure that there are no records in results schema with which we could mess up
                     generationCacheService.removeCache(type, source, designHash);
                     CohortGenerationRequest cohortGenerationRequest = requestBuilder

--- a/src/main/java/org/ohdsi/webapi/generationcache/GenerationCacheHelper.java
+++ b/src/main/java/org/ohdsi/webapi/generationcache/GenerationCacheHelper.java
@@ -59,7 +59,7 @@ public class GenerationCacheHelper {
                             .withExpression(cohortDefinition.getDetails().getExpressionObject())
                             .withSource(source)
                             .withTargetId(designHash)
-                            .build();
+                            .buildWithRetainCohortCovariates();
                     String[] sqls = CohortGenerationUtils.buildGenerationSql(cohortGenerationRequest);
                     sqlExecutor.accept(designHash, sqls);
                     cache = generationCacheService.cacheResults(CacheableGenerationType.COHORT, designHash, source.getSourceId());

--- a/src/main/java/org/ohdsi/webapi/ircalc/IRAnalysisQueryBuilder.java
+++ b/src/main/java/org/ohdsi/webapi/ircalc/IRAnalysisQueryBuilder.java
@@ -66,7 +66,7 @@ public class IRAnalysisQueryBuilder {
   private String getStrataQuery(CriteriaGroup strataCriteria)
   {
     String resultSql = STRATA_QUERY_TEMPLATE;
-    String additionalCriteriaQuery = "\nJOIN (\n" + cohortExpressionQueryBuilder.getCriteriaGroupQuery(strataCriteria, "#analysis_events") + ") AC on AC.person_id = pe.person_id AND AC.event_id = pe.event_id";
+    String additionalCriteriaQuery = "\nJOIN (\n" + cohortExpressionQueryBuilder.getCriteriaGroupQuery(strataCriteria, "#analysis_events", null, false) + ") AC on AC.person_id = pe.person_id AND AC.event_id = pe.event_id";
     additionalCriteriaQuery = StringUtils.replace(additionalCriteriaQuery,"@indexId", "" + 0);
     resultSql = StringUtils.replace(resultSql, "@additionalCriteriaQuery", additionalCriteriaQuery);
     return resultSql;

--- a/src/main/java/org/ohdsi/webapi/ircalc/IRAnalysisQueryBuilder.java
+++ b/src/main/java/org/ohdsi/webapi/ircalc/IRAnalysisQueryBuilder.java
@@ -66,7 +66,9 @@ public class IRAnalysisQueryBuilder {
   private String getStrataQuery(CriteriaGroup strataCriteria)
   {
     String resultSql = STRATA_QUERY_TEMPLATE;
-    String additionalCriteriaQuery = "\nJOIN (\n" + cohortExpressionQueryBuilder.getCriteriaGroupQuery(strataCriteria, "#analysis_events", null, false) + ") AC on AC.person_id = pe.person_id AND AC.event_id = pe.event_id";
+    String additionalCriteriaQuery = "\nJOIN (\n"
+            + cohortExpressionQueryBuilder.getCriteriaGroupQuery(strataCriteria, "#analysis_events", false)
+            + ") AC on AC.person_id = pe.person_id AND AC.event_id = pe.event_id";
     additionalCriteriaQuery = StringUtils.replace(additionalCriteriaQuery,"@indexId", "" + 0);
     resultSql = StringUtils.replace(resultSql, "@additionalCriteriaQuery", additionalCriteriaQuery);
     return resultSql;

--- a/src/main/java/org/ohdsi/webapi/service/CohortDefinitionService.java
+++ b/src/main/java/org/ohdsi/webapi/service/CohortDefinitionService.java
@@ -570,14 +570,14 @@ public class CohortDefinitionService extends AbstractDaoService implements HasTa
 	@Produces(MediaType.APPLICATION_JSON)
 	@Path("/{id}/generate/{sourceKey}")
 	@Transactional
-	public JobExecutionResource generateCohort(@PathParam("id") final int id, @PathParam("sourceKey") final String sourceKey) {
+	public JobExecutionResource generateCohort(@PathParam("id") final int id, @PathParam("sourceKey") final String sourceKey, @QueryParam("retainCohortCovariates") String retainCohortCovariates) {
 
 		Source source = getSourceRepository().findBySourceKey(sourceKey);
 		CohortDefinition currentDefinition = this.cohortDefinitionRepository.findOne(id);
 		UserEntity user = userRepository.findByLogin(security.getSubject());
-		return cohortGenerationService.generateCohortViaJob(user, currentDefinition, source);
+		return cohortGenerationService.generateCohortViaJob(user, currentDefinition, source, Boolean.parseBoolean(retainCohortCovariates));
 	}
-
+	
 	/**
 	 * Cancel a cohort generation task
 	 *

--- a/src/main/java/org/ohdsi/webapi/service/CohortGenerationService.java
+++ b/src/main/java/org/ohdsi/webapi/service/CohortGenerationService.java
@@ -41,6 +41,7 @@ import static org.ohdsi.webapi.Constants.Params.JOB_NAME;
 import static org.ohdsi.webapi.Constants.Params.SESSION_ID;
 import static org.ohdsi.webapi.Constants.Params.SOURCE_ID;
 import static org.ohdsi.webapi.Constants.Params.TARGET_DATABASE_SCHEMA;
+import static org.ohdsi.webapi.Constants.Params.RETAIN_COHORT_COVARIATES;
 
 @Component
 @DependsOn("flyway")
@@ -71,7 +72,7 @@ public class CohortGenerationService extends AbstractDaoService implements Gener
     this.generationCacheHelper = generationCacheHelper;
   }
 
-  public JobExecutionResource generateCohortViaJob(UserEntity userEntity, CohortDefinition cohortDefinition, Source source) {
+  public JobExecutionResource generateCohortViaJob(UserEntity userEntity, CohortDefinition cohortDefinition, Source source, Boolean retainCohortCovariates) {
 
     CohortGenerationInfo info = cohortDefinition.getGenerationInfoList().stream()
             .filter(val -> Objects.equals(val.getId().getSourceId(), source.getSourceId())).findFirst()
@@ -86,10 +87,10 @@ public class CohortGenerationService extends AbstractDaoService implements Gener
 
     cohortDefinitionRepository.save(cohortDefinition);
 
-    return runGenerateCohortJob(cohortDefinition, source);
+    return runGenerateCohortJob(cohortDefinition, source, retainCohortCovariates);
   }
 
-  private Job buildGenerateCohortJob(CohortDefinition cohortDefinition, Source source, JobParameters jobParameters) {
+  private Job buildGenerateCohortJob(CohortDefinition cohortDefinition, Source source, JobParameters jobParameters, Boolean retainCohortCovariates) {
 
     log.info("Beginning generate cohort for cohort definition id: {}", cohortDefinition.getId());
 
@@ -121,13 +122,13 @@ public class CohortGenerationService extends AbstractDaoService implements Gener
     return generateJobBuilder.build();
   }
 
-  private JobExecutionResource runGenerateCohortJob(CohortDefinition cohortDefinition, Source source) {
-    final JobParametersBuilder jobParametersBuilder = getJobParametersBuilder(source, cohortDefinition);
-    Job job = buildGenerateCohortJob(cohortDefinition, source, jobParametersBuilder.toJobParameters());
+  private JobExecutionResource runGenerateCohortJob(CohortDefinition cohortDefinition, Source source, Boolean retainCohortCovariates) {
+    final JobParametersBuilder jobParametersBuilder = getJobParametersBuilder(source, cohortDefinition, retainCohortCovariates);
+    Job job = buildGenerateCohortJob(cohortDefinition, source, jobParametersBuilder.toJobParameters(), retainCohortCovariates);
     return jobService.runJob(job, jobParametersBuilder.toJobParameters());
   }
 
-  private JobParametersBuilder getJobParametersBuilder(Source source, CohortDefinition cohortDefinition) {
+  private JobParametersBuilder getJobParametersBuilder(Source source, CohortDefinition cohortDefinition, Boolean retainCohortCovariates) {
 
     JobParametersBuilder builder = new JobParametersBuilder();
     builder.addString(JOB_NAME, String.format("Generating cohort %d : %s (%s)", cohortDefinition.getId(), source.getSourceName(), source.getSourceKey()));
@@ -136,6 +137,7 @@ public class CohortGenerationService extends AbstractDaoService implements Gener
     builder.addString(COHORT_DEFINITION_ID, String.valueOf(cohortDefinition.getId()));
     builder.addString(SOURCE_ID, String.valueOf(source.getSourceId()));
     builder.addString(GENERATE_STATS, Boolean.TRUE.toString());
+    builder.addString(RETAIN_COHORT_COVARIATES, String.valueOf(retainCohortCovariates));
     return builder;
   }
 

--- a/src/main/java/org/ohdsi/webapi/service/CohortGenerationService.java
+++ b/src/main/java/org/ohdsi/webapi/service/CohortGenerationService.java
@@ -11,7 +11,6 @@ import org.ohdsi.webapi.generationcache.GenerationCacheHelper;
 import org.ohdsi.webapi.job.GeneratesNotification;
 import org.ohdsi.webapi.job.JobExecutionResource;
 import org.ohdsi.webapi.shiro.Entities.UserEntity;
-import org.ohdsi.webapi.shiro.Entities.UserRepository;
 import org.ohdsi.webapi.source.Source;
 import org.ohdsi.webapi.source.SourceService;
 import org.ohdsi.webapi.util.SessionUtils;
@@ -38,10 +37,10 @@ import static org.ohdsi.webapi.Constants.GENERATE_COHORT;
 import static org.ohdsi.webapi.Constants.Params.COHORT_DEFINITION_ID;
 import static org.ohdsi.webapi.Constants.Params.GENERATE_STATS;
 import static org.ohdsi.webapi.Constants.Params.JOB_NAME;
+import static org.ohdsi.webapi.Constants.Params.RETAIN_COHORT_COVARIATES;
 import static org.ohdsi.webapi.Constants.Params.SESSION_ID;
 import static org.ohdsi.webapi.Constants.Params.SOURCE_ID;
 import static org.ohdsi.webapi.Constants.Params.TARGET_DATABASE_SCHEMA;
-import static org.ohdsi.webapi.Constants.Params.RETAIN_COHORT_COVARIATES;
 
 @Component
 @DependsOn("flyway")
@@ -79,6 +78,7 @@ public class CohortGenerationService extends AbstractDaoService implements Gener
             .orElse(new CohortGenerationInfo(cohortDefinition, source.getSourceId()));
 
     info.setCreatedBy(userEntity);
+    info.setChooseCovariates(retainCohortCovariates);
 
     cohortDefinition.getGenerationInfoList().add(info);
 

--- a/src/main/java/org/ohdsi/webapi/service/CohortGenerationService.java
+++ b/src/main/java/org/ohdsi/webapi/service/CohortGenerationService.java
@@ -90,7 +90,7 @@ public class CohortGenerationService extends AbstractDaoService implements Gener
     return runGenerateCohortJob(cohortDefinition, source, retainCohortCovariates);
   }
 
-  private Job buildGenerateCohortJob(CohortDefinition cohortDefinition, Source source, JobParameters jobParameters, Boolean retainCohortCovariates) {
+  private Job buildGenerateCohortJob(CohortDefinition cohortDefinition, Source source, JobParameters jobParameters) {
 
     log.info("Beginning generate cohort for cohort definition id: {}", cohortDefinition.getId());
 
@@ -124,7 +124,7 @@ public class CohortGenerationService extends AbstractDaoService implements Gener
 
   private JobExecutionResource runGenerateCohortJob(CohortDefinition cohortDefinition, Source source, Boolean retainCohortCovariates) {
     final JobParametersBuilder jobParametersBuilder = getJobParametersBuilder(source, cohortDefinition, retainCohortCovariates);
-    Job job = buildGenerateCohortJob(cohortDefinition, source, jobParametersBuilder.toJobParameters(), retainCohortCovariates);
+    Job job = buildGenerateCohortJob(cohortDefinition, source, jobParametersBuilder.toJobParameters());
     return jobService.runJob(job, jobParametersBuilder.toJobParameters());
   }
 

--- a/src/main/resources/db/migration/postgresql/V2.14.0.20240704000000__extend_cohort_generation_info_covariates.sql
+++ b/src/main/resources/db/migration/postgresql/V2.14.0.20240704000000__extend_cohort_generation_info_covariates.sql
@@ -1,0 +1,1 @@
+ALTER TABLE ${ohdsiSchema}.cohort_generation_info ADD is_choose_covariates BOOLEAN NOT NULL DEFAULT FALSE;


### PR DESCRIPTION
Depends on https://github.com/OHDSI/circe-be/pull/213
Addressing #2332

CohortGenerationInfo has been extended with a new attribute to store information if a Cohort Generation has been launched with the pertaining cohort covariates option