### PR TITLE
Migration of JDBC Google BigQuery driver to v1.6.1.1002

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1530,67 +1530,67 @@
         <dependency>
           <groupId>com.google.api-client</groupId>
           <artifactId>google-api-client</artifactId>
-          <version>1.33.4</version>
+          <version>2.3.0</version>
         </dependency>
         <dependency>
           <groupId>com.google.apis</groupId>
           <artifactId>google-api-services-bigquery</artifactId>
-          <version>v2-rev20220326-1.32.1</version>
+          <version>v2-rev20240211-2.0.0</version>
         </dependency>
         <dependency>
-          <groupId>com.google.cloud</groupId>
-          <artifactId>google-cloud-bigquery</artifactId>
-          <version>1.2.15</version>
+            <groupId>com.google.cloud</groupId>
+            <artifactId>google-cloud-bigquery</artifactId>
+            <version>1.6.1.1002</version>
         </dependency>
         <dependency>
           <groupId>com.google.http-client</groupId>
           <artifactId>google-http-client</artifactId>
-          <version>1.41.5</version>
+          <version>1.44.1</version>
         </dependency>
         <dependency>
           <groupId>com.google.http-client</groupId>
           <artifactId>google-http-client-gson</artifactId>
-          <version>1.41.5</version>
+          <version>1.44.1</version>
         </dependency>
         <dependency>
           <groupId>com.google.oauth-client</groupId>
           <artifactId>google-oauth-client</artifactId>
-          <version>1.33.3</version>
+          <version>1.35.0</version>
         </dependency>
         <dependency>
           <groupId>com.google.cloud</groupId>
           <artifactId>google-cloud-bigquerystorage</artifactId>
-          <version>2.12.0</version>
+          <version>3.2.0</version>
         </dependency>
         <dependency>
           <groupId>com.google.auth</groupId>
           <artifactId>google-auth-library-oauth2-http</artifactId>
-          <version>1.6.0</version>
+          <version>1.23.0</version>
         </dependency>
         <dependency>
           <groupId>com.google.auth</groupId>
           <artifactId>google-auth-library-credentials</artifactId>
-          <version>1.6.0</version>
+          <version>1.23.0</version>
         </dependency>
         <dependency>
           <groupId>com.google.api</groupId>
           <artifactId>gax</artifactId>
-          <version>2.13.0</version>
+          <version>2.43.0</version>
         </dependency>
         <dependency>
           <groupId>com.google.api</groupId>
           <artifactId>gax-grpc</artifactId>
-          <version>2.13.0</version>
+          <version>2.43.0</version>
         </dependency>
         <dependency>
           <groupId>com.google.api.grpc</groupId>
           <artifactId>proto-google-cloud-bigquerystorage-v1</artifactId>
-          <version>2.12.0</version>
+          <version>3.2.0</version>
         </dependency>
         <dependency>
           <groupId>io.opencensus</groupId>
           <artifactId>opencensus-contrib-http-util</artifactId>
-          <version>0.31.0</version>
+          <version>0.31.1</version>
         </dependency>
       </dependencies>
       <build>
@@ -1609,9 +1609,9 @@
                 <configuration>
                   <groupId>com.google.api-client</groupId>
                   <artifactId>google-api-client</artifactId>
-                  <version>1.33.4</version>
+                  <version>2.3.0</version>
                   <packaging>jar</packaging>
-                  <file>${bigquery.classpath}/google-api-client-1.33.4.jar</file>
+                  <file>${bigquery.classpath}/google-api-client-2.3.0.jar</file>
                 </configuration>
               </execution>
               <execution>
@@ -1623,9 +1623,9 @@
                 <configuration>
                   <groupId>com.google.apis</groupId>
                   <artifactId>google-api-services-bigquery</artifactId>
-                  <version>v2-rev20220326-1.32.1</version>
+                  <version>v2-rev20240211-2.0.0</version>
                   <packaging>jar</packaging>
-                  <file>${bigquery.classpath}/google-api-services-bigquery-v2-rev20220326-1.32.1.jar</file>
+                  <file>${bigquery.classpath}/google-api-services-bigquery-v2-rev20240211-2.0.0.jar</file>
                 </configuration>
               </execution>
               <execution>
@@ -1637,7 +1637,7 @@
                 <configuration>
                   <groupId>com.google.cloud</groupId>
                   <artifactId>google-cloud-bigquery</artifactId>
-                  <version>1.2.15</version>
+                  <version>1.6.1.1002</version>
                   <packaging>jar</packaging>
                   <file>${bigquery.classpath}/GoogleBigQueryJDBC42.jar</file>
                 </configuration>
@@ -1651,9 +1651,9 @@
                 <configuration>
                   <groupId>com.google.http-client</groupId>
                   <artifactId>google-http-client</artifactId>
-                  <version>1.41.5</version>
+                  <version>1.44.1</version>
                   <packaging>jar</packaging>
-                  <file>${bigquery.classpath}/google-http-client-1.41.5.jar</file>
+                  <file>${bigquery.classpath}/google-http-client-1.44.1.jar</file>
                 </configuration>
               </execution>
               <execution>
@@ -1665,9 +1665,9 @@
                 <configuration>
                   <groupId>com.google.http-client</groupId>
                   <artifactId>google-http-client-gson</artifactId>
-                  <version>1.41.5</version>
+                  <version>1.44.1</version>
                   <packaging>jar</packaging>
-                  <file>${bigquery.classpath}/google-http-client-gson-1.41.5.jar</file>
+                  <file>${bigquery.classpath}/google-http-client-gson-1.44.1.jar</file>
                 </configuration>
               </execution>
               <execution>
@@ -1679,9 +1679,9 @@
                 <configuration>
                   <groupId>com.google.oauth-client</groupId>
                   <artifactId>google-oauth-client</artifactId>
-                  <version>1.33.1</version>
+                  <version>1.35.0</version>
                   <packaging>jar</packaging>
-                  <file>${bigquery.classpath}/google-oauth-client-1.33.1.jar</file>
+                  <file>${bigquery.classpath}/google-oauth-client-1.35.0.jar</file>
                 </configuration>
               </execution>
               <execution>
@@ -1693,9 +1693,9 @@
                 <configuration>
                   <groupId>com.google.cloud</groupId>
                   <artifactId>google-cloud-bigquerystorage</artifactId>
-                  <version>2.12.0</version>
+                  <version>3.2.0</version>
                   <packaging>jar</packaging>
-                  <file>${bigquery.classpath}/google-cloud-bigquerystorage-2.12.0.jar</file>
+                  <file>${bigquery.classpath}/google-cloud-bigquerystorage-3.2.0.jar</file>
                 </configuration>
               </execution>
             </executions>


### PR DESCRIPTION
This PR addresses #2408 updating BigQuery JDBC driver