### PR TITLE
Update miredot license. This will expire 2030.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -489,7 +489,7 @@
           </execution>
         </executions>
         <configuration>
-          <licence>cHJvamVjdHxvcmcub2hkc2kuV2ViQVBJfDIwMjUtMDEtMDF8ZmFsc2V8LTEjTUN3Q0ZDZkowMkZrVmVSeVlBazZVbTBmNThIbE15SjRBaFEwcVZyRUZuamZMTzJ0KzFtR3E3U3lMMkFESHc9PQ==</licence>
+          <licence>cHJvamVjdHxvcmcub2hkc2kuV2ViQVBJfDIwMzAtMDEtMDF8ZmFsc2V8LTEjTUN3Q0ZDOEFFWEdzU0lISUJiMzBBWC9WazlGcmdPME1BaFI4MVM5bkViQUpXN0tiWE9zR1NpRFlPam5zaXc9PQ==</licence>
           <restModel>
             <httpStatusCodes>
               <httpStatusCode>


### PR DESCRIPTION
Fixes #2420.