### PR TITLE
Dependabot updates

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -28,12 +28,12 @@
 
     <commons-fileupload.version>1.5</commons-fileupload.version>
 
-    <circe.version>1.12.0</circe.version>
+    <circe.version>1.12.1</circe.version>
     <jersey.version>2.14</jersey.version>
     <SqlRender.version>1.19.1</SqlRender.version>
     <hive-jdbc.version>3.1.2</hive-jdbc.version>
     <pac4j.version>4.5.5</pac4j.version>
-    <jackson.version>2.12.7.1</jackson.version>
+    <jackson.version>2.12.7</jackson.version>
     <start-class>org.ohdsi.webapi.WebApi</start-class>
     <skipUnitTests>false</skipUnitTests>
     <skipITtests>false</skipITtests>
@@ -590,7 +590,7 @@
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
-      <version>${jackson.version}</version>
+      <version>2.12.7.1</version>
       <exclusions>
         <exclusion>
           <groupId>com.fasterxml.jackson.core</groupId>


### PR DESCRIPTION
This PR groups the individual dependabot updates into a single PR.

One point of note: the jackson databind from 2.12.7 to 2.12.7.1 is not a global (jackson-wide) version change, so in that case we're not using the POM variable to assign the version. We have to explicitly add the version in that case.