### PR TITLE
Fixed missing authorship regression for Concept Set Annotations

### DIFF
--- a/src/main/java/org/ohdsi/webapi/conceptset/annotation/ConceptSetAnnotation.java
+++ b/src/main/java/org/ohdsi/webapi/conceptset/annotation/ConceptSetAnnotation.java
@@ -3,13 +3,18 @@ package org.ohdsi.webapi.conceptset.annotation;
 import org.hibernate.annotations.GenericGenerator;
 import org.hibernate.annotations.Parameter;
 import org.ohdsi.webapi.model.CommonEntity;
+import org.ohdsi.webapi.shiro.Entities.UserEntity;
 
 import javax.persistence.Column;
 import javax.persistence.Entity;
+import javax.persistence.FetchType;
 import javax.persistence.GeneratedValue;
 import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
 import javax.persistence.Table;
 import java.io.Serializable;
+import java.util.Date;
 
 @Entity(name = "ConceptSetAnnotation")
 @Table(name = "concept_set_annotation")
@@ -49,6 +54,57 @@ public class ConceptSetAnnotation implements Serializable {
 
     @Column(name = "copied_from_concept_set_ids")
     private String copiedFromConceptSetIds;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "created_by_id", updatable = false)
+    private UserEntity createdBy;
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "modified_by_id")
+    private UserEntity modifiedBy;
+    @Column(name = "created_date", updatable = false)
+    private Date createdDate;
+    @Column(name = "modified_date")
+    private Date modifiedDate;
+
+    public UserEntity getCreatedBy() {
+
+        return createdBy;
+    }
+
+    public void setCreatedBy(UserEntity createdBy) {
+
+        this.createdBy = createdBy;
+    }
+
+    public UserEntity getModifiedBy() {
+
+        return modifiedBy;
+    }
+
+    public void setModifiedBy(UserEntity modifiedBy) {
+
+        this.modifiedBy = modifiedBy;
+    }
+
+    public Date getCreatedDate() {
+
+        return createdDate;
+    }
+
+    public void setCreatedDate(Date createdDate) {
+
+        this.createdDate = createdDate;
+    }
+
+    public Date getModifiedDate() {
+
+        return modifiedDate;
+    }
+
+    public void setModifiedDate(Date modifiedDate) {
+
+        this.modifiedDate = modifiedDate;
+    }
 
     public Integer getId() {
         return id;

--- a/src/main/java/org/ohdsi/webapi/service/ConceptSetService.java
+++ b/src/main/java/org/ohdsi/webapi/service/ConceptSetService.java
@@ -942,6 +942,8 @@ public class ConceptSetService extends AbstractDaoService implements HasTags<Int
                 conceptSetAnnotation.setVocabularyVersion(newAnnotationData.getVocabularyVersion());
                 conceptSetAnnotation.setConceptSetVersion(newAnnotationData.getConceptSetVersion());
                 conceptSetAnnotation.setConceptId(newAnnotationData.getConceptId());
+                conceptSetAnnotation.setCreatedBy(getCurrentUser());
+                conceptSetAnnotation.setCreatedDate(new Date());
                 return conceptSetAnnotation;
             }).collect(Collectors.toList());
 
@@ -975,6 +977,10 @@ public class ConceptSetService extends AbstractDaoService implements HasTags<Int
         targetConceptSetAnnotation.setAnnotationDetails(sourceConceptSetAnnotation.getAnnotationDetails());
         targetConceptSetAnnotation.setConceptId(sourceConceptSetAnnotation.getConceptId());
         targetConceptSetAnnotation.setVocabularyVersion(sourceConceptSetAnnotation.getVocabularyVersion());
+        targetConceptSetAnnotation.setCreatedBy(sourceConceptSetAnnotation.getCreatedBy());
+        targetConceptSetAnnotation.setCreatedDate(sourceConceptSetAnnotation.getCreatedDate());
+        targetConceptSetAnnotation.setModifiedBy(sourceConceptSetAnnotation.getModifiedBy());
+        targetConceptSetAnnotation.setModifiedDate(sourceConceptSetAnnotation.getModifiedDate());
         targetConceptSetAnnotation.setCopiedFromConceptSetIds(appendCopiedFromConceptSetId(sourceConceptSetAnnotation.getCopiedFromConceptSetIds(), sourceConceptSetId));
         return targetConceptSetAnnotation;
     }
@@ -1017,6 +1023,8 @@ public class ConceptSetService extends AbstractDaoService implements HasTags<Int
            annotationDTO.setVocabularyVersion(conceptSetAnnotation.getVocabularyVersion());
            annotationDTO.setConceptSetVersion(conceptSetAnnotation.getConceptSetVersion());
            annotationDTO.setCopiedFromConceptSetIds(conceptSetAnnotation.getCopiedFromConceptSetIds());
+           annotationDTO.setCreatedBy(conceptSetAnnotation.getCreatedBy() != null ? conceptSetAnnotation.getCreatedBy().getName() : null);
+           annotationDTO.setCreatedDate(conceptSetAnnotation.getCreatedDate() != null ? conceptSetAnnotation.getCreatedDate().toString() : null);
            return annotationDTO;
     }
 


### PR DESCRIPTION
Fixed a regression where Concept Set Annotation field CreatedBy, CreatedDate, ModifiedBy, ModifiedDate were not handled correctly after moving away from a per-annotation entity permission schema. 

We can not use a separate permission schema for ConceptSetAnnotation entity because of a significant performance overhead. CommonEntity was not extended by ConceptSetAnnotation entity because it then becomes a marker that a security schema is expected for ConceptSetAnnotation. 