### PR TITLE
revert pac4j version to 4.0.0.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
   <groupId>org.ohdsi</groupId>
   <artifactId>WebAPI</artifactId>
   <packaging>war</packaging>
-  <version>2.15.0</version>
+  <version>2.15.1-SNAPSHOT</version>
   <name>WebAPI</name>
   <properties>
     <build.number>${BUILD_NUMBER}</build.number>
@@ -32,7 +32,7 @@
     <jersey.version>2.14</jersey.version>
     <SqlRender.version>1.19.1</SqlRender.version>
     <hive-jdbc.version>3.1.2</hive-jdbc.version>
-    <pac4j.version>4.5.5</pac4j.version>
+    <pac4j.version>4.0.0</pac4j.version>
     <jackson.version>2.12.7</jackson.version>
     <start-class>org.ohdsi.webapi.WebApi</start-class>
     <skipUnitTests>false</skipUnitTests>


### PR DESCRIPTION
Reverts dependabot update to 4.0.0 because the Shiro bridge buji-pac4j is set to version 5.0 which depends on pac4j 4.0.

Set WebAPI version to 2.15.1.