### PR TITLE
[issue-2455] Fetching only relevant related mapped standard concepts

### DIFF
--- a/src/main/resources/resources/vocabulary/sql/getRelatedStandardMappedConcepts.sql
+++ b/src/main/resources/resources/vocabulary/sql/getRelatedStandardMappedConcepts.sql
@@ -26,6 +26,7 @@ FROM (
         cr.CONCEPT_ID_1 IN (@conceptIdList)
         AND COALESCE(c.STANDARD_CONCEPT, 'N') IN ('S', 'C')
         AND cr.INVALID_REASON IS NULL
+        AND cr.relationship_id = 'Maps to'
 ) c
 GROUP BY
    c.CONCEPT_ID,

--- a/src/main/resources/resources/vocabulary/sql/getRelatedStandardMappedConcepts_getMappedFromIds.sql
+++ b/src/main/resources/resources/vocabulary/sql/getRelatedStandardMappedConcepts_getMappedFromIds.sql
@@ -15,6 +15,7 @@ FROM (
         cr.CONCEPT_ID_1 IN (@conceptIdList)
         AND COALESCE(c.STANDARD_CONCEPT, 'N') IN ('S', 'C')
         AND cr.INVALID_REASON IS NULL
+        AND cr.relationship_id = 'Maps to'
 ) c
 ORDER BY
    c.CONCEPT_ID;


### PR DESCRIPTION
[issue-2455] Added condition to the related non-standards concepts-fetching queries that restrict the search only to 'Maps to' relationships

<img width="3445" height="1041" alt="image" src="https://github.com/user-attachments/assets/c84c8c6b-ed3c-465a-a208-f8e95a2d5525" />
