### PR TITLE
Add Development Quick Start Guide and settings.xml file ready to be used with docker postgres container

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,5 +78,24 @@ It was chosen to use embedded PG instead of H2 for unit tests since H2 doesn't s
 - WebAPI follows [Semantic versioning](https://semver.org/);
 - Only Non-SNAPSHOT dependencies should be presented in POM.xml on release branches/tags.
 
+### Development Quick Start Guide
+
+To start the application locally, the following quick steps (all commands are executed from repository root directory)
+
+1. Ensure that you have the following tools installed: Java 1.8, maven (check via `mvn -v`), docker-ce (check via `docker -v`), psql command line client 
+(check via psql --version) or other tool that allows to connect to postgres DB.
+2. Run `mvn clean install` and make sure it completes successfully, resolve dependency issues if any.
+3. Create a new database in docker: `docker create --name postgres-webapi -p 8432:5432 -e POSTGRES_PASSWORD=ohdsi postgres:15.0-alpine`.
+4. Start DB container: `docker start postgres-webapi`.
+	 Verify that you can connect via psql console (`PGPASSWORD='ohdsi' psql -d postgresql://localhost:8432/?user=postgres`).
+5. If your default java version is too high (e.g. 17), set JAVA_HOME to point to 1.8 installaction, for example `export JAVA_HOME=/usr/lib/jvm/zulu8-ca-amd64` 
+6. Start WebAPI `mvn clean install spring-boot:run -Dmaven.test.skip=true -P webapi-postgresql -s src/dev/settings.xml -f pom.xml`
+7. Log in with the username of your liking
+8. Grant this newly created user admin privileges by running the following sql `INSERT INTO sec_user_role (user_id, role_id, origin) VALUES (1000, 2, 'SYSTEM');`
+   and log in again.
+
+At this point you have the application running and admin account operational. To actually use it, additional steps are required to set up privileges 
+and at least one CDM database. They are covered in the respective documentation sections. 
+	 
 ## License
 OHDSI WebAPI is licensed under Apache License 2.0

--- a/dev/settings.xml
+++ b/dev/settings.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Sample ready-to-use configuration file for Maven to configure WebAPI in development environment. -->
+<settings xmlns="http://maven.apache.org/SETTINGS/1.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0 http://maven.apache.org/xsd/settings-1.0.0.xsd">
+	<profiles>
+		<profile>
+			<id>webapi-postgresql</id>
+			<properties>
+				<datasource.driverClassName>org.postgresql.Driver</datasource.driverClassName>
+				<datasource.url>jdbc:postgresql://localhost:8432/</datasource.url>
+				<datasource.username>postgres</datasource.username>
+				<datasource.password>ohdsi</datasource.password>
+				<datasource.dialect>postgresql</datasource.dialect>
+				<datasource.ohdsi.schema>public</datasource.ohdsi.schema>
+				<flyway.datasource.driverClassName>${datasource.driverClassName}</flyway.datasource.driverClassName>
+				<flyway.datasource.url>${datasource.url}</flyway.datasource.url>
+				<flyway.datasource.username>${datasource.username}</flyway.datasource.username>
+				<flyway.datasource.password>${datasource.password}</flyway.datasource.password>
+				<flyway.locations>classpath:db/migration/postgresql</flyway.locations>
+
+				<security.enabled>true</security.enabled>
+				<security.provider>AtlasRegularSecurity</security.provider>
+				<security.origin>http://localhost:8081</security.origin>
+				<!--	
+					'password'. Obviously not secure in any way, intended for local environment only.
+				  The configuration below allows you to spawn as many users as needed and test for behaviour when user is not found using 'notfound' username 
+				-->
+				<security.db.datasource.authenticationQuery>SELECT '$2a$10$a.oAKDX3Yy9uz1WQUSuaSOSuPDCpvjMo3uG27z0Pnds.NA1pm7WTq' WHERE ? != 'notfound'</security.db.datasource.authenticationQuery>
+				<profiles.allow.physicalDates>true</profiles.allow.physicalDates>
+<!--				<spring.jpa.show-sql>true</spring.jpa.show-sql>-->
+				<cache.invalidation.period>3600000</cache.invalidation.period>
+			</properties>
+		</profile>
+	</profiles>
+</settings>


### PR DESCRIPTION
I think this helps developers starting to work with webapi to save an hour or 2 on the initial setup.