### PR TITLE
Raised Snowflake JDBC Driver version to 3.26.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1862,7 +1862,7 @@
       <id>webapi-snowflake</id>
       <properties>
         <snowflake.enabled>true</snowflake.enabled>
-        <snowflake.driver.version>3.22.0</snowflake.driver.version>
+        <snowflake.driver.version>3.26.1</snowflake.driver.version>
       </properties>
       <dependencies>
         <dependency>


### PR DESCRIPTION
Raised Snowflake JDBC Driver version to 3.26.1 to support PAT (Programmatic Access Token) Authentication.
This version is also expected to contain a fix for a vulnerability which was present in 3.22.0