### PR TITLE
[issue-2375] [issue-2377] Re-enables PermissionTest and SecurityIT tests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -436,6 +436,7 @@
         <version>2.22.2</version>
         <configuration>
           <skipTests>${skipUnitTests}</skipTests>
+          <trimStackTrace>false</trimStackTrace>
         </configuration>
       </plugin>
       <plugin>
@@ -465,12 +466,14 @@
         <version>2.22.2</version>
         <configuration>
           <skipITs>${skipITtests}</skipITs>
+          <trimStackTrace>false</trimStackTrace>
         </configuration>
         <executions>
           <execution>
             <phase>test</phase>
             <goals>
               <goal>integration-test</goal>
+              <goal>verify</goal>
             </goals>
             <configuration>
               <includes>
@@ -583,6 +586,13 @@
         <artifactId>redshift-jdbc42-no-awssdk</artifactId>
         <version>1.2.10.1009</version>
       </dependency>
+			<dependency>
+				<groupId>io.zonky.test.postgres</groupId>
+				<artifactId>embedded-postgres-binaries-bom</artifactId>
+				<version>17.6.0</version>
+				<type>pom</type>
+				<scope>import</scope>
+			</dependency>
     </dependencies>
   </dependencyManagement>
 
@@ -1218,12 +1228,13 @@
       <groupId>org.ehcache</groupId>
       <artifactId>ehcache</artifactId>
       <version>3.9.11</version>
-    </dependency>    <dependency>
-      <groupId>com.opentable.components</groupId>
-      <artifactId>otj-pg-embedded</artifactId>
-      <version>0.13.1</version>
-      <scope>test</scope>
     </dependency>
+		<dependency>
+			<groupId>io.zonky.test</groupId>
+			<artifactId>embedded-postgres</artifactId>
+			<version>2.1.1</version>
+			<scope>test</scope>
+		</dependency>
     <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-test</artifactId>
@@ -2024,5 +2035,53 @@
         </plugins>
       </build>
     </profile>
+		<profile>
+			<id>windows-x86-zonky-postgres</id>
+			<activation>
+				<os>
+					<family>Windows</family>
+					<arch>amd64</arch>
+				</os>
+			</activation>
+			<dependencies>
+				<dependency>
+					<groupId>io.zonky.test.postgres</groupId>
+					<artifactId>embedded-postgres-binaries-windows-amd64</artifactId>
+					<scope>test</scope>
+				</dependency>
+			</dependencies>
+		</profile>
+		<profile>
+			<id>apple-silicon-zonky-postgres</id>
+			<activation>
+				<os>
+					<family>mac</family>
+					<arch>aarch64</arch>
+				</os>
+			</activation>
+			<dependencies>
+				<dependency>
+					<groupId>io.zonky.test.postgres</groupId>
+					<artifactId>embedded-postgres-binaries-darwin-arm64v8</artifactId>
+					<scope>test</scope>
+				</dependency>
+			</dependencies>
+		</profile>
+		<profile>
+			<id>linux-x86-zonky-postgres</id>
+			<activation>
+				<os>
+					<family>unix</family>
+					<arch>amd64</arch>
+				</os>
+			</activation>
+			<dependencies>
+				<dependency>
+					<groupId>io.zonky.test.postgres</groupId>
+					<artifactId>embedded-postgres-binaries-linux-amd64-alpine</artifactId>
+					<scope>test</scope>
+				</dependency>
+			</dependencies>
+		</profile>
   </profiles>
 </project>

--- a/src/test/java/org/ohdsi/webapi/PostgresSingletonRule.java
+++ b/src/test/java/org/ohdsi/webapi/PostgresSingletonRule.java
@@ -31,9 +31,10 @@ package org.ohdsi.webapi;
 import java.io.IOException;
 import java.sql.Connection;
 import java.sql.SQLException;
+
+import io.zonky.test.db.postgres.embedded.EmbeddedPostgres;
 import org.junit.rules.ExternalResource;
 
-import com.opentable.db.postgres.embedded.EmbeddedPostgres;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/src/test/java/org/ohdsi/webapi/pathway/PathwayAnalysisTest.java
+++ b/src/test/java/org/ohdsi/webapi/pathway/PathwayAnalysisTest.java
@@ -42,14 +42,19 @@ import org.ohdsi.sql.SqlSplit;
 import org.ohdsi.sql.SqlTranslate;
 import org.ohdsi.webapi.AbstractDatabaseTest;
 import org.ohdsi.webapi.job.JobExecutionResource;
+import org.ohdsi.webapi.pathway.converter.PathwayAnalysisToPathwayVersionConverter;
+import org.ohdsi.webapi.pathway.converter.PathwayVersionToPathwayVersionFullDTOConverter;
 import org.ohdsi.webapi.pathway.converter.SerializedPathwayAnalysisToPathwayAnalysisConverter;
 import org.ohdsi.webapi.pathway.domain.PathwayAnalysisEntity;
 import org.ohdsi.webapi.pathway.domain.PathwayAnalysisGenerationEntity;
+import org.ohdsi.webapi.pathway.dto.PathwayAnalysisExportDTO;
 import org.ohdsi.webapi.source.Source;
 import org.ohdsi.webapi.source.SourceDaimon;
 import org.ohdsi.webapi.source.SourceRepository;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.core.convert.ConversionService;
+import org.springframework.core.convert.support.DefaultConversionService;
 
 /**
  *
@@ -87,6 +92,9 @@ public class PathwayAnalysisTest extends AbstractDatabaseTest {
   @Autowired
   private PathwayService pathwayService;
 
+	@Autowired
+	private ConversionService conversionService;
+
   @Value("${datasource.ohdsi.schema}")
   private String ohdsiSchema;
 
@@ -110,7 +118,8 @@ public class PathwayAnalysisTest extends AbstractDatabaseTest {
     resetSequence(String.format("%s.%s", ohdsiSchema, "pathway_analysis_sequence"));
     truncateTable(String.format("%s.%s", ohdsiSchema, "generation_cache"));
     prepareCdmSchema();
-    prepareResultSchema();    
+    prepareResultSchema();
+		SerializedPathwayAnalysisToPathwayAnalysisConverter.setConversionService(conversionService);
   }
 
   @After

--- a/src/test/java/org/ohdsi/webapi/security/PermissionTest.java
+++ b/src/test/java/org/ohdsi/webapi/security/PermissionTest.java
@@ -25,7 +25,6 @@ import org.dbunit.operation.DatabaseOperation;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.ohdsi.webapi.AbstractDatabaseTest;
 import org.ohdsi.webapi.shiro.PermissionManager;
@@ -65,7 +64,6 @@ public class PermissionTest extends AbstractDatabaseTest {
     ThreadContext.bind(subject);    
   }
 
-//  @Ignore
   @Test
   public void permsTest() throws Exception {
     // need to clear authorization cache before each test
@@ -88,7 +86,6 @@ public class PermissionTest extends AbstractDatabaseTest {
     
   }
   
-//  @Ignore
   @Test
   public void wildcardTest() throws Exception {
     // need to clear authorization cache before each test

--- a/src/test/java/org/ohdsi/webapi/test/ITStarter.java
+++ b/src/test/java/org/ohdsi/webapi/test/ITStarter.java
@@ -1,6 +1,6 @@
 package org.ohdsi.webapi.test;
 
-import com.opentable.db.postgres.embedded.EmbeddedPostgres;
+import io.zonky.test.db.postgres.embedded.EmbeddedPostgres;
 import org.apache.shiro.subject.SimplePrincipalCollection;
 import org.apache.shiro.subject.Subject;
 import org.junit.AfterClass;


### PR DESCRIPTION
* Adds the verify goal to the default set of goals for the Maven failsafe plugin to ensure integration test failures are caught by `mvn test`
* Upgrades to otj-pg-embedded-1.0.0 to take advantage of Docker support so that embedded postgres can run on Apple Silicon