### PR TITLE
Preserve supplied oracle temp schema in SqlRenderService

### DIFF
--- a/src/main/java/org/ohdsi/webapi/service/SqlRenderService.java
+++ b/src/main/java/org/ohdsi/webapi/service/SqlRenderService.java
@@ -36,7 +36,9 @@ public class SqlRenderService {
         if (sourceStatement == null) {
             return new TranslatedStatement();
         }
-        sourceStatement.setOracleTempSchema(TEMP_DATABASE_SCHEMA_PLACEHOLDER);
+        if (StringUtils.isBlank(sourceStatement.getOracleTempSchema())) {
+            sourceStatement.setOracleTempSchema(TEMP_DATABASE_SCHEMA_PLACEHOLDER);
+        }
         return translatedStatement(sourceStatement);
     }
 

--- a/src/test/java/org/ohdsi/webapi/service/SqlRenderServiceTest.java
+++ b/src/test/java/org/ohdsi/webapi/service/SqlRenderServiceTest.java
@@ -40,6 +40,17 @@ public class SqlRenderServiceTest {
     }
 
     @Test
+    public void translateSQLFromSourceStatement_keepsProvidedOracleTempSchema() {
+
+        SourceStatement statement = createSourceStatement(TEST_SQL, "oracle");
+        statement.setOracleTempSchema("custom_schema");
+        sqlRenderService.translateSQLFromSourceStatement(statement);
+
+        verify(sqlRenderService).translatedStatement(sourceStatementCaptor.capture());
+        assertEquals("custom_schema", sourceStatementCaptor.getValue().getOracleTempSchema());
+    }
+
+    @Test
     public void translateSQL_sourceStatementIsNull() {
         assertEquals(new TranslatedStatement(), SqlRenderService.translateSQL(null));
     }


### PR DESCRIPTION
Fix: Preserve custom oracleTempSchema instead of overwriting with default

- Only set default placeholder when oracleTempSchema is not provided
- Add test case for custom schema preservation