### PR TITLE
add jar build

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -4,9 +4,9 @@ name: CI
 # Run in master and dev branches and in all pull requests to those branches
 on:
   push:
-    branches: [ master ]
+    branches: [ master, webapi-3.0 ]
   pull_request:
-    branches: [ master ]
+    branches: [ master, webapi-3.0 ]
 
 env:
   DOCKER_IMAGE: ohdsi/webapi

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -82,14 +82,14 @@ jobs:
         id: build_params
         run: |
           echo "::set-output name=sha8::${GITHUB_SHA::8}"
-          if [ ${{ github.event_name == 'pull_request' }} ]; then
-            echo "::set-output name=push::false"
-            echo "::set-output name=load::true"
-            echo "::set-output name=platforms::linux/amd64"
-          else
+          if [ "${{ github.event_name }}" != "pull_request" ] && [ "${{ github.ref }}" == "refs/heads/master" ]; then
             echo "::set-output name=push::true"
             echo "::set-output name=load::false"
             echo "::set-output name=platforms::linux/amd64,linux/arm64"
+          else
+            echo "::set-output name=push::false"
+            echo "::set-output name=load::true"
+            echo "::set-output name=platforms::linux/amd64"
           fi
 
       - name: Login to DockerHub

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -36,14 +36,14 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-maven-
 
-      - name: Build code
-        run: mvn -B -DskipTests=true -DskipUnitTests=true -P${{ env.MAVEN_PROFILE }} package
+      - name: Build JAR and WAR
+        run: mvn -B -DskipTests=true -DskipUnitTests=true -P${{ env.MAVEN_PROFILE }},war package
 
-      # Upload it to GitHub
+      # Upload both JAR and WAR to GitHub release
       - name: Upload to GitHub
         uses: AButler/upload-release-assets@v2.0
         with:
-          files: 'target/WebAPI.jar'
+          files: 'target/WebAPI.jar;target/WebAPI.war'
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 
   # Build and push tagged release docker image to

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -36,7 +36,10 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-maven-
 
-      - name: Build JAR and WAR
+      - name: Build JAR
+        run: mvn -B -DskipTests=true -DskipUnitTests=true -P${{ env.MAVEN_PROFILE }} package
+
+      - name: Build WAR
         run: mvn -B -DskipTests=true -DskipUnitTests=true -P${{ env.MAVEN_PROFILE }},war package
 
       # Upload both JAR and WAR to GitHub release

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -43,7 +43,7 @@ jobs:
       - name: Upload to GitHub
         uses: AButler/upload-release-assets@v2.0
         with:
-          files: 'target/WebAPI.war'
+          files: 'target/WebAPI.jar'
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 
   # Build and push tagged release docker image to

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,22 +22,15 @@ COPY src /code/src
 RUN mvn package ${MAVEN_PARAMS} \
     -Dgit.branch=${GIT_BRANCH} \
     -Dgit.commit.id.abbrev=${GIT_COMMIT_ID_ABBREV} \
-    -P${MAVEN_PROFILE} \
-    && mkdir war \
-    && mv target/WebAPI.war war \
-    && cd war \
-    && jar -xf WebAPI.war \
-    && rm WebAPI.war
+    -P${MAVEN_PROFILE}
 
-# OHDSI WebAPI and ATLAS web application running as a Spring Boot application with Java 21
+# OHDSI WebAPI running as a Spring Boot executable JAR with Java 21
 FROM index.docker.io/library/eclipse-temurin:21-jre
 
 MAINTAINER Lee Evans - www.ltscomputingllc.com
 
 # Any Java options to pass along, e.g. memory, garbage collection, etc.
 ENV JAVA_OPTS=""
-# Additional classpath parameters to pass along. If provided, start with colon ":"
-ENV CLASSPATH=""
 # Default Java options. The first entry is a fix for when java reads secure random numbers:
 # in a containerized system using /dev/random may reduce entropy too much, causing slowdowns.
 # https://ruleoftech.com/2016/avoiding-jvm-delays-caused-by-random-number-generation
@@ -47,21 +40,13 @@ ENV DEFAULT_JAVA_OPTS="-Djava.security.egd=file:///dev/./urandom"
 WORKDIR /var/lib/ohdsi/webapi
 
 COPY --from=builder /code/opentelemetry-javaagent.jar .
-
-# deploy the just built OHDSI WebAPI war file
-# copy resources in order of fewest changes to most changes.
-# This way, the libraries step is not duplicated if the dependencies
-# do not change.
-COPY --from=builder /code/war/WEB-INF/lib*/* WEB-INF/lib/
-COPY --from=builder /code/war/org org
-COPY --from=builder /code/war/WEB-INF/classes WEB-INF/classes
-COPY --from=builder /code/war/META-INF META-INF
+COPY --from=builder /code/target/WebAPI.jar .
 
 EXPOSE 8080
 
 USER 101
 
-# Directly run the code as a WAR.
+# Run the executable JAR
 CMD exec java ${DEFAULT_JAVA_OPTS} ${JAVA_OPTS} \
-    -cp ".:WebAPI.jar:WEB-INF/lib/*.jar${CLASSPATH}" \
-    org.springframework.boot.loader.WarLauncher
+    --add-opens java.naming/com.sun.jndi.ldap=ALL-UNNAMED \
+    -jar WebAPI.jar

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,7 @@ RUN curl -LSsO https://github.com/open-telemetry/opentelemetry-java-instrumentat
 COPY pom.xml /code/
 RUN mkdir .git \
     && mvn package \
+     -Dpackaging.type=jar \
      -P${MAVEN_PROFILE}
 
 ARG GIT_BRANCH=unknown
@@ -20,6 +21,7 @@ ARG GIT_COMMIT_ID_ABBREV=unknown
 # Compile code and repackage it
 COPY src /code/src
 RUN mvn package ${MAVEN_PARAMS} \
+    -Dpackaging.type=jar \
     -Dgit.branch=${GIT_BRANCH} \
     -Dgit.commit.id.abbrev=${GIT_COMMIT_ID_ABBREV} \
     -P${MAVEN_PROFILE}

--- a/README.md
+++ b/README.md
@@ -2,22 +2,6 @@
 
 OHDSI WebAPI contains all OHDSI RESTful services that can be called from OHDSI applications.
 
-## Getting Started
-
-**Download and run the latest release:**
-
-```bash
-# Download the JAR
-wget https://github.com/OHDSI/WebAPI/releases/latest/download/WebAPI.jar
-
-# Run with PostgreSQL
-java -jar WebAPI.jar --spring.profiles.active=webapi-postgresql
-```
-
-**That's it!** WebAPI is packaged as a self-contained executable JAR with embedded Tomcat server. No external application server required.
-
-For detailed setup instructions, see the [Quick Start Guide](#quick-start-guide) below.
-
 ## Features
 
 - Provides a centralized API for working with 1 or more databases converted to the [Common Data Model](https://github.com/OHDSI/CommonDataModel) (CDM) v5.
@@ -30,7 +14,7 @@ For detailed setup instructions, see the [Quick Start Guide](#quick-start-guide)
 
 ## Technology
 
-OHDSI WebAPI is a **Java 21** Spring Boot 3.5.6 application packaged as an **executable JAR** with embedded Tomcat server. It supports multiple databases including PostgreSQL, SQL Server, Oracle, and others.
+OHDSI WebAPI is a Java 8 web application that utilizes a PostgreSQL database for storage.
 
 ## API Documentation
 
@@ -39,6 +23,18 @@ The API Documentation is found at [http://webapidoc.ohdsi.org/](http://webapidoc
 ## System Requirements & Installation
 
 Documentation can be found a the [Web API Installation Guide](https://github.com/OHDSI/WebAPI/wiki) which covers the system requirements and installation instructions.
+
+## JAR Build (Executable)
+
+WebAPI can also be built as a self-contained executable JAR with embedded Tomcat:
+
+```bash
+# Build as JAR
+mvn clean package -DskipTests -Dpackaging.type=jar
+
+# Run
+java -jar target/WebAPI.jar --spring.profiles.active=webapi-postgresql
+```
 
 ## SAML Auth support
 
@@ -57,49 +53,22 @@ Sample idp metadata and sp metadata config files for okta:
 - `saml/dev/idp-metadata-okta.xml`
 - `saml/dev/sp-metadata-okta.xml`
 
-## Security Configuration
+## Managing auth providers
 
-### Managing Authentication Providers
+The following parameters are used to enable/disable certain provider:
 
-WebAPI supports multiple authentication providers that can be enabled/disabled via configuration:
+- `security.auth.windows.enabled`
+- `security.auth.kerberos.enabled`
+- `security.auth.openid.enabled`
+- `security.auth.facebook.enabled`
+- `security.auth.github.enabled`
+- `security.auth.google.enabled`
+- `security.auth.jdbc.enabled`
+- `security.auth.ldap.enabled`
+- `security.auth.ad.enabled`
+- `security.auth.cas.enabled`
 
-```bash
-java -jar WebAPI.jar \
-  --security.auth.google.enabled=true \
-  --security.oauth.google.apiKey=your-client-id \
-  --security.oauth.google.apiSecret=your-client-secret
-```
-
-Available authentication providers:
-
-| Provider | Property | Description |
-|----------|----------|-------------|
-| Windows Auth | `security.auth.windows.enabled` | Windows integrated authentication |
-| Kerberos | `security.auth.kerberos.enabled` | Kerberos authentication |
-| OpenID Connect | `security.auth.openid.enabled` | OpenID Connect (OIDC) |
-| OAuth - Google | `security.auth.google.enabled` | Google OAuth 2.0 |
-| OAuth - Facebook | `security.auth.facebook.enabled` | Facebook OAuth 2.0 |
-| OAuth - GitHub | `security.auth.github.enabled` | GitHub OAuth 2.0 |
-| LDAP | `security.auth.ldap.enabled` | LDAP authentication |
-| Active Directory | `security.auth.ad.enabled` | Active Directory |
-| JDBC | `security.auth.jdbc.enabled` | Database authentication |
-| CAS | `security.auth.cas.enabled` | Central Authentication Service |
-
-All properties accept `true` or `false`.
-
-**Example: Enable Google OAuth:**
-```properties
-security.auth.google.enabled=true
-security.oauth.google.apiKey=your-google-client-id
-security.oauth.google.apiSecret=your-google-client-secret
-security.oauth.callback.api=http://localhost:8080/WebAPI/user/oauth/callback
-security.oauth.callback.ui=http://localhost:8080/atlas/#/welcome
-```
-
-**Example: Disable all authentication (development only):**
-```bash
-java -jar WebAPI.jar --security.provider=DisabledSecurity
-```
+Acceptable values are `true` and `false`
 
 ## Geospatial support
 
@@ -121,194 +90,24 @@ It was chosen to use embedded PG instead of H2 for unit tests since H2 doesn't s
 - WebAPI follows [Semantic versioning](https://semver.org/);
 - Only Non-SNAPSHOT dependencies should be presented in POM.xml on release branches/tags.
 
-### Quick Start Guide
+### Development Quick Start Guide
 
-#### Prerequisites
+To start the application locally, the following quick steps (all commands are executed from repository root directory)
 
-- **Java 21** (OpenJDK recommended - get from [Adoptium](https://adoptium.net/))
-- **Maven 3.x** (check via `mvn -v`)
-- **Docker** (check via `docker -v`) - for local PostgreSQL
-- **PostgreSQL client** (optional - check via `psql --version`)
+1. Ensure that you have the following tools installed: Java 1.8, maven (check via `mvn -v`), docker-ce (check via `docker -v`), psql command line client
+(check via psql --version) or other tool that allows to connect to postgres DB.
+2. Run `mvn clean install` and make sure it completes successfully, resolve dependency issues if any.
+3. Create a new database in docker: `docker create --name postgres-webapi -p 8432:5432 -e POSTGRES_PASSWORD=ohdsi postgres:15.0-alpine`.
+4. Start DB container: `docker start postgres-webapi`.
+	 Verify that you can connect via psql console (`PGPASSWORD='ohdsi' psql -d postgresql://localhost:8432/?user=postgres`).
+5. If your default java version is too high (e.g. 17), set JAVA_HOME to point to 1.8 installaction, for example `export JAVA_HOME=/usr/lib/jvm/zulu8-ca-amd64`
+6. Start WebAPI `mvn clean install spring-boot:run -Dmaven.test.skip=true -P webapi-postgresql -s src/dev/settings.xml -f pom.xml`
+7. Log in with the username of your liking
+8. Grant this newly created user admin privileges by running the following sql `INSERT INTO sec_user_role (user_id, role_id, origin) VALUES (1000, 2, 'SYSTEM');`
+   and log in again.
 
-#### Installation & Running
-
-**Option 1: Using Pre-built JAR (Recommended)**
-
-1. **Download the latest release:**
-   ```bash
-   wget https://github.com/OHDSI/WebAPI/releases/latest/download/WebAPI.jar
-   ```
-
-2. **Set up PostgreSQL database:**
-   ```bash
-   docker create --name postgres-webapi -p 8432:5432 -e POSTGRES_PASSWORD=ohdsi postgres:15.0-alpine
-   docker start postgres-webapi
-   ```
-
-3. **Run WebAPI:**
-   ```bash
-   java -jar WebAPI.jar --spring.profiles.active=webapi-postgresql
-   ```
-
-4. **Access the API:**
-   - Open browser: http://localhost:8080/WebAPI/
-   - Log in with any username
-   - Grant admin privileges: `INSERT INTO sec_user_role (user_id, role_id, origin) VALUES (1000, 2, 'SYSTEM');`
-
-**Option 2: Building from Source**
-
-1. **Clone and build:**
-   ```bash
-   git clone https://github.com/OHDSI/WebAPI.git
-   cd WebAPI
-   export JAVA_HOME="/path/to/jdk-21"  # Adjust to your Java 21 installation
-   mvn clean package -DskipTests
-   ```
-
-2. **Set up database (same as above):**
-   ```bash
-   docker create --name postgres-webapi -p 8432:5432 -e POSTGRES_PASSWORD=ohdsi postgres:15.0-alpine
-   docker start postgres-webapi
-   ```
-
-3. **Run the JAR:**
-   ```bash
-   java -jar target/WebAPI.jar --spring.profiles.active=webapi-postgresql
-   ```
-
-**Option 3: Development Mode (Maven)**
-
-```bash
-mvn spring-boot:run -P webapi-postgresql
-```
-
-#### Configuration
-
-**No recompilation needed!** Override configuration via:
-
-**1. Command-line arguments:**
-```bash
-java -jar WebAPI.jar \
-  --spring.profiles.active=webapi-postgresql \
-  --datasource.url=jdbc:postgresql://localhost:8432/ohdsi \
-  --datasource.username=postgres \
-  --datasource.password=ohdsi
-```
-
-**2. External `application.properties` file** (in same directory as JAR):
-```properties
-spring.profiles.active=webapi-postgresql
-datasource.url=jdbc:postgresql://localhost:8432/ohdsi
-datasource.username=postgres
-datasource.password=ohdsi
-datasource.ohdsi.schema=webapi
-```
-
-**3. Environment variables:**
-```bash
-export DATASOURCE_URL=jdbc:postgresql://localhost:8432/ohdsi
-export DATASOURCE_USERNAME=postgres
-export DATASOURCE_PASSWORD=ohdsi
-java -jar WebAPI.jar --spring.profiles.active=webapi-postgresql
-```
-
-#### Database Profiles
-
-WebAPI supports multiple databases:
-
-```bash
-# PostgreSQL (recommended for development)
-java -jar WebAPI.jar --spring.profiles.active=webapi-postgresql
-
-# SQL Server
-java -jar WebAPI.jar --spring.profiles.active=webapi-sqlserver
-
-# Oracle
-java -jar WebAPI.jar --spring.profiles.active=webapi-oracle
-```
-
-#### Configuration Properties
-
-Common properties you can override:
-
-| Property | Description | Example |
-|----------|-------------|---------|
-| `datasource.url` | Database JDBC URL | `jdbc:postgresql://localhost:5432/ohdsi` |
-| `datasource.username` | Database username | `webapi_user` |
-| `datasource.password` | Database password | `secret123` |
-| `datasource.ohdsi.schema` | Schema for WebAPI tables | `webapi` |
-| `security.provider` | Security provider | `DisabledSecurity` or `AtlasRegularSecurity` |
-| `security.origin` | CORS origin | `http://localhost` |
-| `flyway.datasource.url` | Flyway migration database | `jdbc:postgresql://localhost:5432/ohdsi` |
-
-See `src/main/resources/application.properties` for all available properties.
-
-#### Next Steps
-
-At this point you have WebAPI running with an admin account. To use it effectively:
-
-1. **Set up security** - Configure authentication providers (see Security section below)
-2. **Add CDM database sources** - Connect to your OMOP CDM databases
-3. **Configure permissions** - Set up user roles and access controls
-
-See the [Installation Guide](https://github.com/OHDSI/WebAPI/wiki) for detailed setup instructions.
-
-### Deployment Options
-
-**Docker Container**
-
-```bash
-# Pull from Docker Hub (when available)
-docker pull ohdsi/webapi:latest
-
-# Or build from source
-docker build -t webapi:local .
-
-# Run container
-docker run -d \
-  --name webapi \
-  -p 8080:8080 \
-  -e DATASOURCE_URL=jdbc:postgresql://db-server:5432/ohdsi \
-  -e DATASOURCE_USERNAME=webapi_user \
-  -e DATASOURCE_PASSWORD=secret \
-  ohdsi/webapi:latest
-```
-
-### Performance Tuning
-
-**JVM Options:**
-
-```bash
-java -Xms2g -Xmx4g \
-  -XX:+UseG1GC \
-  -XX:MaxGCPauseMillis=200 \
-  -XX:+HeapDumpOnOutOfMemoryError \
-  -XX:HeapDumpPath=/var/log/webapi/heap_dump.hprof \
-  -jar WebAPI.jar
-```
-
-**Common JVM parameters:**
-- `-Xms2g` - Initial heap size (2GB)
-- `-Xmx4g` - Maximum heap size (4GB)
-- `-XX:+UseG1GC` - Use G1 garbage collector (recommended for Spring Boot)
-- `-XX:MaxGCPauseMillis=200` - Target max GC pause time
-
-### Troubleshooting
-
-**Check logs:**
-```bash
-# If running in Docker
-docker logs -f webapi
-
-# If running manually
-java -jar WebAPI.jar > webapi.log 2>&1
-```
-
-**Common issues:**
-- **Connection refused**: Check database connectivity and credentials
-- **Port already in use**: Change port with `--server.port=8081`
-- **Out of memory**: Increase heap size with `-Xmx` parameter
-- **Slow startup**: Ensure adequate resources (2GB+ RAM recommended)
+At this point you have the application running and admin account operational. To actually use it, additional steps are required to set up privileges
+and at least one CDM database. They are covered in the respective documentation sections.
 
 ## License
 OHDSI WebAPI is licensed under Apache License 2.0

--- a/README.md
+++ b/README.md
@@ -2,6 +2,22 @@
 
 OHDSI WebAPI contains all OHDSI RESTful services that can be called from OHDSI applications.
 
+## Getting Started
+
+**Download and run the latest release:**
+
+```bash
+# Download the JAR
+wget https://github.com/OHDSI/WebAPI/releases/latest/download/WebAPI.jar
+
+# Run with PostgreSQL
+java -jar WebAPI.jar --spring.profiles.active=webapi-postgresql
+```
+
+**That's it!** WebAPI is packaged as a self-contained executable JAR with embedded Tomcat server. No external application server required.
+
+For detailed setup instructions, see the [Quick Start Guide](#quick-start-guide) below.
+
 ## Features
 
 - Provides a centralized API for working with 1 or more databases converted to the [Common Data Model](https://github.com/OHDSI/CommonDataModel) (CDM) v5.
@@ -14,7 +30,7 @@ OHDSI WebAPI contains all OHDSI RESTful services that can be called from OHDSI a
 
 ## Technology
 
-OHDSI WebAPI is a Java 8 web application that utilizes a PostgreSQL database for storage.
+OHDSI WebAPI is a **Java 21** Spring Boot 3.5.6 application packaged as an **executable JAR** with embedded Tomcat server. It supports multiple databases including PostgreSQL, SQL Server, Oracle, and others.
 
 ## API Documentation
 
@@ -41,22 +57,49 @@ Sample idp metadata and sp metadata config files for okta:
 - `saml/dev/idp-metadata-okta.xml`
 - `saml/dev/sp-metadata-okta.xml`
 
-## Managing auth providers
+## Security Configuration
 
-The following parameters are used to enable/disable certain provider:
+### Managing Authentication Providers
 
-- `security.auth.windows.enabled`
-- `security.auth.kerberos.enabled`
-- `security.auth.openid.enabled`
-- `security.auth.facebook.enabled`
-- `security.auth.github.enabled`
-- `security.auth.google.enabled`
-- `security.auth.jdbc.enabled`
-- `security.auth.ldap.enabled`
-- `security.auth.ad.enabled`
-- `security.auth.cas.enabled`
+WebAPI supports multiple authentication providers that can be enabled/disabled via configuration:
 
-Acceptable values are `true` and `false`
+```bash
+java -jar WebAPI.jar \
+  --security.auth.google.enabled=true \
+  --security.oauth.google.apiKey=your-client-id \
+  --security.oauth.google.apiSecret=your-client-secret
+```
+
+Available authentication providers:
+
+| Provider | Property | Description |
+|----------|----------|-------------|
+| Windows Auth | `security.auth.windows.enabled` | Windows integrated authentication |
+| Kerberos | `security.auth.kerberos.enabled` | Kerberos authentication |
+| OpenID Connect | `security.auth.openid.enabled` | OpenID Connect (OIDC) |
+| OAuth - Google | `security.auth.google.enabled` | Google OAuth 2.0 |
+| OAuth - Facebook | `security.auth.facebook.enabled` | Facebook OAuth 2.0 |
+| OAuth - GitHub | `security.auth.github.enabled` | GitHub OAuth 2.0 |
+| LDAP | `security.auth.ldap.enabled` | LDAP authentication |
+| Active Directory | `security.auth.ad.enabled` | Active Directory |
+| JDBC | `security.auth.jdbc.enabled` | Database authentication |
+| CAS | `security.auth.cas.enabled` | Central Authentication Service |
+
+All properties accept `true` or `false`.
+
+**Example: Enable Google OAuth:**
+```properties
+security.auth.google.enabled=true
+security.oauth.google.apiKey=your-google-client-id
+security.oauth.google.apiSecret=your-google-client-secret
+security.oauth.callback.api=http://localhost:8080/WebAPI/user/oauth/callback
+security.oauth.callback.ui=http://localhost:8080/atlas/#/welcome
+```
+
+**Example: Disable all authentication (development only):**
+```bash
+java -jar WebAPI.jar --security.provider=DisabledSecurity
+```
 
 ## Geospatial support
 
@@ -78,24 +121,194 @@ It was chosen to use embedded PG instead of H2 for unit tests since H2 doesn't s
 - WebAPI follows [Semantic versioning](https://semver.org/);
 - Only Non-SNAPSHOT dependencies should be presented in POM.xml on release branches/tags.
 
-### Development Quick Start Guide
+### Quick Start Guide
 
-To start the application locally, the following quick steps (all commands are executed from repository root directory)
+#### Prerequisites
 
-1. Ensure that you have the following tools installed: Java 1.8, maven (check via `mvn -v`), docker-ce (check via `docker -v`), psql command line client 
-(check via psql --version) or other tool that allows to connect to postgres DB.
-2. Run `mvn clean install` and make sure it completes successfully, resolve dependency issues if any.
-3. Create a new database in docker: `docker create --name postgres-webapi -p 8432:5432 -e POSTGRES_PASSWORD=ohdsi postgres:15.0-alpine`.
-4. Start DB container: `docker start postgres-webapi`.
-	 Verify that you can connect via psql console (`PGPASSWORD='ohdsi' psql -d postgresql://localhost:8432/?user=postgres`).
-5. If your default java version is too high (e.g. 17), set JAVA_HOME to point to 1.8 installaction, for example `export JAVA_HOME=/usr/lib/jvm/zulu8-ca-amd64` 
-6. Start WebAPI `mvn clean install spring-boot:run -Dmaven.test.skip=true -P webapi-postgresql -s src/dev/settings.xml -f pom.xml`
-7. Log in with the username of your liking
-8. Grant this newly created user admin privileges by running the following sql `INSERT INTO sec_user_role (user_id, role_id, origin) VALUES (1000, 2, 'SYSTEM');`
-   and log in again.
+- **Java 21** (OpenJDK recommended - get from [Adoptium](https://adoptium.net/))
+- **Maven 3.x** (check via `mvn -v`)
+- **Docker** (check via `docker -v`) - for local PostgreSQL
+- **PostgreSQL client** (optional - check via `psql --version`)
 
-At this point you have the application running and admin account operational. To actually use it, additional steps are required to set up privileges 
-and at least one CDM database. They are covered in the respective documentation sections. 
-	 
+#### Installation & Running
+
+**Option 1: Using Pre-built JAR (Recommended)**
+
+1. **Download the latest release:**
+   ```bash
+   wget https://github.com/OHDSI/WebAPI/releases/latest/download/WebAPI.jar
+   ```
+
+2. **Set up PostgreSQL database:**
+   ```bash
+   docker create --name postgres-webapi -p 8432:5432 -e POSTGRES_PASSWORD=ohdsi postgres:15.0-alpine
+   docker start postgres-webapi
+   ```
+
+3. **Run WebAPI:**
+   ```bash
+   java -jar WebAPI.jar --spring.profiles.active=webapi-postgresql
+   ```
+
+4. **Access the API:**
+   - Open browser: http://localhost:8080/WebAPI/
+   - Log in with any username
+   - Grant admin privileges: `INSERT INTO sec_user_role (user_id, role_id, origin) VALUES (1000, 2, 'SYSTEM');`
+
+**Option 2: Building from Source**
+
+1. **Clone and build:**
+   ```bash
+   git clone https://github.com/OHDSI/WebAPI.git
+   cd WebAPI
+   export JAVA_HOME="/path/to/jdk-21"  # Adjust to your Java 21 installation
+   mvn clean package -DskipTests
+   ```
+
+2. **Set up database (same as above):**
+   ```bash
+   docker create --name postgres-webapi -p 8432:5432 -e POSTGRES_PASSWORD=ohdsi postgres:15.0-alpine
+   docker start postgres-webapi
+   ```
+
+3. **Run the JAR:**
+   ```bash
+   java -jar target/WebAPI.jar --spring.profiles.active=webapi-postgresql
+   ```
+
+**Option 3: Development Mode (Maven)**
+
+```bash
+mvn spring-boot:run -P webapi-postgresql
+```
+
+#### Configuration
+
+**No recompilation needed!** Override configuration via:
+
+**1. Command-line arguments:**
+```bash
+java -jar WebAPI.jar \
+  --spring.profiles.active=webapi-postgresql \
+  --datasource.url=jdbc:postgresql://localhost:8432/ohdsi \
+  --datasource.username=postgres \
+  --datasource.password=ohdsi
+```
+
+**2. External `application.properties` file** (in same directory as JAR):
+```properties
+spring.profiles.active=webapi-postgresql
+datasource.url=jdbc:postgresql://localhost:8432/ohdsi
+datasource.username=postgres
+datasource.password=ohdsi
+datasource.ohdsi.schema=webapi
+```
+
+**3. Environment variables:**
+```bash
+export DATASOURCE_URL=jdbc:postgresql://localhost:8432/ohdsi
+export DATASOURCE_USERNAME=postgres
+export DATASOURCE_PASSWORD=ohdsi
+java -jar WebAPI.jar --spring.profiles.active=webapi-postgresql
+```
+
+#### Database Profiles
+
+WebAPI supports multiple databases:
+
+```bash
+# PostgreSQL (recommended for development)
+java -jar WebAPI.jar --spring.profiles.active=webapi-postgresql
+
+# SQL Server
+java -jar WebAPI.jar --spring.profiles.active=webapi-sqlserver
+
+# Oracle
+java -jar WebAPI.jar --spring.profiles.active=webapi-oracle
+```
+
+#### Configuration Properties
+
+Common properties you can override:
+
+| Property | Description | Example |
+|----------|-------------|---------|
+| `datasource.url` | Database JDBC URL | `jdbc:postgresql://localhost:5432/ohdsi` |
+| `datasource.username` | Database username | `webapi_user` |
+| `datasource.password` | Database password | `secret123` |
+| `datasource.ohdsi.schema` | Schema for WebAPI tables | `webapi` |
+| `security.provider` | Security provider | `DisabledSecurity` or `AtlasRegularSecurity` |
+| `security.origin` | CORS origin | `http://localhost` |
+| `flyway.datasource.url` | Flyway migration database | `jdbc:postgresql://localhost:5432/ohdsi` |
+
+See `src/main/resources/application.properties` for all available properties.
+
+#### Next Steps
+
+At this point you have WebAPI running with an admin account. To use it effectively:
+
+1. **Set up security** - Configure authentication providers (see Security section below)
+2. **Add CDM database sources** - Connect to your OMOP CDM databases
+3. **Configure permissions** - Set up user roles and access controls
+
+See the [Installation Guide](https://github.com/OHDSI/WebAPI/wiki) for detailed setup instructions.
+
+### Deployment Options
+
+**Docker Container**
+
+```bash
+# Pull from Docker Hub (when available)
+docker pull ohdsi/webapi:latest
+
+# Or build from source
+docker build -t webapi:local .
+
+# Run container
+docker run -d \
+  --name webapi \
+  -p 8080:8080 \
+  -e DATASOURCE_URL=jdbc:postgresql://db-server:5432/ohdsi \
+  -e DATASOURCE_USERNAME=webapi_user \
+  -e DATASOURCE_PASSWORD=secret \
+  ohdsi/webapi:latest
+```
+
+### Performance Tuning
+
+**JVM Options:**
+
+```bash
+java -Xms2g -Xmx4g \
+  -XX:+UseG1GC \
+  -XX:MaxGCPauseMillis=200 \
+  -XX:+HeapDumpOnOutOfMemoryError \
+  -XX:HeapDumpPath=/var/log/webapi/heap_dump.hprof \
+  -jar WebAPI.jar
+```
+
+**Common JVM parameters:**
+- `-Xms2g` - Initial heap size (2GB)
+- `-Xmx4g` - Maximum heap size (4GB)
+- `-XX:+UseG1GC` - Use G1 garbage collector (recommended for Spring Boot)
+- `-XX:MaxGCPauseMillis=200` - Target max GC pause time
+
+### Troubleshooting
+
+**Check logs:**
+```bash
+# If running in Docker
+docker logs -f webapi
+
+# If running manually
+java -jar WebAPI.jar > webapi.log 2>&1
+```
+
+**Common issues:**
+- **Connection refused**: Check database connectivity and credentials
+- **Port already in use**: Change port with `--server.port=8081`
+- **Out of memory**: Increase heap size with `-Xmx` parameter
+- **Slow startup**: Ensure adequate resources (2GB+ RAM recommended)
+
 ## License
 OHDSI WebAPI is licensed under Apache License 2.0

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
   <version>3.0.0-SNAPSHOT</version>
   <name>WebAPI</name>
   <properties>
-    <packaging.type>jar</packaging.type>
+    <packaging.type>war</packaging.type>
     <build.number>${BUILD_NUMBER}</build.number>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <!-- Spring Boot manages spring.version as well -->

--- a/pom.xml
+++ b/pom.xml
@@ -477,15 +477,6 @@
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-war-plugin</artifactId>
-        <version>3.4.0</version>
-        <configuration>
-          <failOnMissingWebXml>false</failOnMissingWebXml>
-          <attachClasses>true</attachClasses>
-        </configuration>
-      </plugin>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-failsafe-plugin</artifactId>
         <version>3.5.2</version>
         <configuration>
@@ -694,9 +685,8 @@
       <artifactId>spring-boot-starter-batch</artifactId>
     </dependency>
 
-    <!-- We are intentionally overriding the Tomcat version from Spring Boot 1.5.22.RELEASE -->
-    <!-- and assuming tomcat-jdbc.jar will be in the Tomcat installation folder (\apache-tomcat-8.5.xxx\lib). -->
-    <!-- WebAPI.war.original should not contain overridden libraries -->
+    <!-- Embedded Tomcat dependencies for executable JAR -->
+    <!-- Note: WAR packaging is available via 'mvn package -Pwar' profile -->
     <dependency>
       <groupId>org.apache.tomcat.embed</groupId>
       <artifactId>tomcat-embed-el</artifactId>
@@ -1901,6 +1891,37 @@
           <type>jar</type>
         </dependency>
       </dependencies>
+    </profile>
+
+    <!-- WAR packaging profile - use with: mvn package -Pwar -->
+    <profile>
+      <id>war</id>
+      <properties>
+        <packaging.type>war</packaging.type>
+      </properties>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-war-plugin</artifactId>
+            <version>3.4.0</version>
+            <executions>
+              <execution>
+                <id>build-war</id>
+                <phase>package</phase>
+                <goals>
+                  <goal>war</goal>
+                </goals>
+                <configuration>
+                  <failOnMissingWebXml>false</failOnMissingWebXml>
+                  <attachClasses>true</attachClasses>
+                  <warName>WebAPI</warName>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
     </profile>
   </profiles>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -5,10 +5,11 @@
 
   <groupId>org.ohdsi</groupId>
   <artifactId>WebAPI</artifactId>
-  <packaging>jar</packaging>
+  <packaging>${packaging.type}</packaging>
   <version>3.0.0-SNAPSHOT</version>
   <name>WebAPI</name>
   <properties>
+    <packaging.type>jar</packaging.type>
     <build.number>${BUILD_NUMBER}</build.number>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <!-- Spring Boot manages spring.version as well -->
@@ -1899,6 +1900,19 @@
       <properties>
         <packaging.type>war</packaging.type>
       </properties>
+      <dependencies>
+        <!-- Mark embedded Tomcat as provided for external servlet container deployment -->
+        <dependency>
+          <groupId>org.springframework.boot</groupId>
+          <artifactId>spring-boot-starter-tomcat</artifactId>
+          <scope>provided</scope>
+        </dependency>
+        <dependency>
+          <groupId>org.apache.tomcat</groupId>
+          <artifactId>tomcat-jdbc</artifactId>
+          <scope>provided</scope>
+        </dependency>
+      </dependencies>
       <build>
         <plugins>
           <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
   <groupId>org.ohdsi</groupId>
   <artifactId>WebAPI</artifactId>
-  <packaging>war</packaging>
+  <packaging>jar</packaging>
   <version>3.0.0-SNAPSHOT</version>
   <name>WebAPI</name>
   <properties>
@@ -416,7 +416,6 @@
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-maven-plugin</artifactId>
         <version>${spring.boot.version}</version>
-        <!-- executable-war via 'java -jar WebAPI-exec.war' currently fails with Jersey FileNotFound exception. TODO -->
         <configuration>
           <!-- Since we filter properties files via Maven, do not add resources. -->
           <addResources>false</addResources>
@@ -689,7 +688,6 @@
     <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-tomcat</artifactId>
-      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>org.springframework.boot</groupId>
@@ -711,7 +709,6 @@
     <dependency>
       <groupId>org.apache.tomcat</groupId>
       <artifactId>tomcat-jdbc</artifactId>
-      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.tomcat</groupId>
@@ -779,12 +776,15 @@
         </exclusion>
       </exclusions>
     </dependency> -->
+    <!-- javax.servlet-api is now provided by spring-boot-starter-tomcat (Jakarta Servlet API) -->
+    <!-- This old javax.servlet dependency can be removed for JAR packaging -->
+    <!--
     <dependency>
       <groupId>javax.servlet</groupId>
       <artifactId>javax.servlet-api</artifactId>
       <version>3.1.0</version>
-      <scope>provided</scope>
     </dependency>
+    -->
     <dependency>
       <groupId>javax.cache</groupId>
       <artifactId>cache-api</artifactId>

--- a/src/main/java/org/ohdsi/webapi/WebApi.java
+++ b/src/main/java/org/ohdsi/webapi/WebApi.java
@@ -3,6 +3,8 @@ package org.ohdsi.webapi;
 import org.apache.catalina.webresources.TomcatURLStreamHandlerFactory;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.builder.SpringApplicationBuilder;
+import org.springframework.boot.web.servlet.support.SpringBootServletInitializer;
 import org.springframework.boot.autoconfigure.orm.jpa.HibernateJpaAutoConfiguration;
 import org.springframework.boot.autoconfigure.web.servlet.error.ErrorMvcAutoConfiguration;
 import org.springframework.context.annotation.EnableAspectJAutoProxy;
@@ -14,12 +16,20 @@ import java.util.TimeZone;
 
 /**
  * OHDSI WebAPI Spring Boot Application
- * Launch as standalone JAR: java -jar WebAPI.jar
+ *
+ * Supports both JAR and WAR deployment:
+ * - JAR: java -jar WebAPI.jar (embedded Tomcat)
+ * - WAR: Deploy to external servlet container (mvn package -Pwar)
  */
 @EnableScheduling
 @SpringBootApplication(exclude={HibernateJpaAutoConfiguration.class, ErrorMvcAutoConfiguration.class})
 @EnableAspectJAutoProxy(proxyTargetClass = true)
-public class WebApi {
+public class WebApi extends SpringBootServletInitializer {
+
+    @Override
+    protected SpringApplicationBuilder configure(SpringApplicationBuilder builder) {
+        return builder.sources(WebApi.class);
+    }
 
     public static void main(final String[] args) throws Exception
     {

--- a/src/main/java/org/ohdsi/webapi/WebApi.java
+++ b/src/main/java/org/ohdsi/webapi/WebApi.java
@@ -1,12 +1,10 @@
 package org.ohdsi.webapi;
 
 import org.apache.catalina.webresources.TomcatURLStreamHandlerFactory;
+import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.autoconfigure.orm.jpa.HibernateJpaAutoConfiguration;
 import org.springframework.boot.autoconfigure.web.servlet.error.ErrorMvcAutoConfiguration;
-import org.springframework.boot.builder.SpringApplicationBuilder;
-import org.springframework.boot.web.servlet.support.SpringBootServletInitializer;
-import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.EnableAspectJAutoProxy;
 import org.springframework.scheduling.annotation.EnableScheduling;
 
@@ -15,25 +13,18 @@ import java.util.TimeZone;
 
 
 /**
- * Launch as java application or deploy as WAR (@link {@link WebApplication}
- * will source this file).
+ * OHDSI WebAPI Spring Boot Application
+ * Launch as standalone JAR: java -jar WebAPI.jar
  */
 @EnableScheduling
 @SpringBootApplication(exclude={HibernateJpaAutoConfiguration.class, ErrorMvcAutoConfiguration.class})
 @EnableAspectJAutoProxy(proxyTargetClass = true)
-public class WebApi extends SpringBootServletInitializer {
-
-
-
-    @Override
-    protected SpringApplicationBuilder configure(final SpringApplicationBuilder application) {
-        return application.sources(WebApi.class);
-    }
+public class WebApi {
 
     public static void main(final String[] args) throws Exception
     {
         TomcatURLStreamHandlerFactory.disable();
-        new SpringApplicationBuilder(WebApi.class).run(args);
+        SpringApplication.run(WebApi.class, args);
     }
 
     @PostConstruct


### PR DESCRIPTION
This pull request modernizes the OHDSI WebAPI project by switching its primary packaging from a deployable WAR to an executable Spring Boot JAR with embedded Tomcat, and updates the build, Docker, and documentation accordingly. The changes simplify deployment (no external app server required), streamline configuration, and improve the developer experience. WAR packaging is still available via a Maven profile for legacy use cases.
