### PR TITLE
fix(security): Upgrade pac4j-jwt to 4.5.9 (CVE-2026-29000)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -32,7 +32,7 @@
     <jersey.version>2.14</jersey.version>
     <SqlRender.version>1.19.1</SqlRender.version>
     <hive-jdbc.version>3.1.2</hive-jdbc.version>
-    <pac4j.version>4.0.0</pac4j.version>
+    <pac4j.version>4.5.9</pac4j.version>
     <jackson.version>2.12.7</jackson.version>
     <start-class>org.ohdsi.webapi.WebApi</start-class>
     <skipUnitTests>false</skipUnitTests>


### PR DESCRIPTION
## Summary

This PR upgrades pac4j from version 4.0.0 to 4.5.9 to address **CVE-2026-29000**, a critical authentication bypass vulnerability.

## Vulnerability Details

| Field | Value |
|-------|-------|
| **CVE** | CVE-2026-29000 |
| **CVSS Score** | 9.1 (Critical) |
| **Affected Component** | pac4j-jwt JwtAuthenticator |
| **CWE** | CWE-347 (Improper Verification of Cryptographic Signature) |
| **Fixed In** | pac4j 4.5.9+, 5.7.9+, 6.3.3+ |

### Description

The vulnerability in pac4j-jwt allows remote attackers to forge authentication tokens. An attacker with access to the server's RSA public key can create a JWE-wrapped PlainJWT with arbitrary subject and role claims, bypassing signature verification to authenticate as any user, including administrators.

### Impact

Given that WebAPI is a healthcare research platform handling sensitive patient data and cohort definitions, this authentication bypass vulnerability poses a significant risk. Attackers could potentially:

- Access sensitive healthcare data without authorization
- Modify cohort definitions and study parameters
- Impersonate administrators to gain full system control

## Changes

- Updated `pac4j.version` property from `4.0.0` to `4.5.9` in `pom.xml`
- This affects all pac4j modules (pac4j-oauth, pac4j-oidc, pac4j-http, pac4j-saml-opensamlv3, pac4j-cas) used by WebAPI

## Testing

- [x] Dependencies resolve successfully with the new version
- [ ] CI builds pass (to be verified)
- [ ] Authentication flows work correctly (requires manual testing in staging environment)

## References

- [CVE-2026-29000 on NVD](https://nvd.nist.gov/vuln/detail/CVE-2026-29000)
- [pac4j Security Advisory](https://github.com/pac4j/pac4j/security/advisories)