### PR TITLE
fix baseline migration script

### DIFF
--- a/src/main/resources/db/migration/postgresql/B3.0.0__webapi_baseline.sql
+++ b/src/main/resources/db/migration/postgresql/B3.0.0__webapi_baseline.sql
@@ -1130,73 +1130,9 @@ CREATE TABLE ${ohdsiSchema}.sec_source
 
 -- END sec_{entity} tables
 
--- FK constraints for sec_{entity} tables: role and entity references.
--- Both FKs use ON DELETE CASCADE: deleting a role or a parent entity automatically
--- removes its permission grants in the corresponding sec_* table.
-
-ALTER TABLE ${ohdsiSchema}.sec_cohort_characterization
-    ADD CONSTRAINT fk_scc_sec_role_id
-        FOREIGN KEY (role_id) REFERENCES ${ohdsiSchema}.sec_role(id)
-        ON DELETE CASCADE,
-    ADD CONSTRAINT fk_scc_cohort_characterization_id
-        FOREIGN KEY (cohort_characterization_id) REFERENCES ${ohdsiSchema}.cohort_characterization(id)
-        ON DELETE CASCADE;
-
-ALTER TABLE ${ohdsiSchema}.sec_cohort_definition
-    ADD CONSTRAINT fk_scd_sec_role_id
-        FOREIGN KEY (role_id) REFERENCES ${ohdsiSchema}.sec_role(id)
-        ON DELETE CASCADE,
-    ADD CONSTRAINT fk_scd_cohort_definition_id
-        FOREIGN KEY (cohort_definition_id) REFERENCES ${ohdsiSchema}.cohort_definition(id)
-        ON DELETE CASCADE;
-
-ALTER TABLE ${ohdsiSchema}.sec_concept_set
-    ADD CONSTRAINT fk_scs_sec_role_id
-        FOREIGN KEY (role_id) REFERENCES ${ohdsiSchema}.sec_role(id)
-        ON DELETE CASCADE,
-    ADD CONSTRAINT fk_scs_concept_set_id
-        FOREIGN KEY (concept_set_id) REFERENCES ${ohdsiSchema}.concept_set(concept_set_id)
-        ON DELETE CASCADE;
-
-ALTER TABLE ${ohdsiSchema}.sec_fe_analysis
-    ADD CONSTRAINT fk_sfa_sec_role_id
-        FOREIGN KEY (role_id) REFERENCES ${ohdsiSchema}.sec_role(id)
-        ON DELETE CASCADE,
-    ADD CONSTRAINT fk_sfa_fe_analysis_id
-        FOREIGN KEY (fe_analysis_id) REFERENCES ${ohdsiSchema}.fe_analysis(id)
-        ON DELETE CASCADE;
-
-ALTER TABLE ${ohdsiSchema}.sec_ir_analysis
-    ADD CONSTRAINT fk_sia_sec_role_id
-        FOREIGN KEY (role_id) REFERENCES ${ohdsiSchema}.sec_role(id)
-        ON DELETE CASCADE,
-    ADD CONSTRAINT fk_sia_ir_analysis_id
-        FOREIGN KEY (ir_id) REFERENCES ${ohdsiSchema}.ir_analysis(id)
-        ON DELETE CASCADE;
-
-ALTER TABLE ${ohdsiSchema}.sec_pathway_analysis
-    ADD CONSTRAINT fk_spa_sec_role_id
-        FOREIGN KEY (role_id) REFERENCES ${ohdsiSchema}.sec_role(id)
-        ON DELETE CASCADE,
-    ADD CONSTRAINT fk_spa_pathway_analysis_id
-        FOREIGN KEY (pathway_analysis_id) REFERENCES ${ohdsiSchema}.pathway_analysis(id)
-        ON DELETE CASCADE;
-
-ALTER TABLE ${ohdsiSchema}.sec_reusable
-    ADD CONSTRAINT fk_sr_sec_role_id
-        FOREIGN KEY (role_id) REFERENCES ${ohdsiSchema}.sec_role(id)
-        ON DELETE CASCADE,
-    ADD CONSTRAINT fk_sr_reusable_id
-        FOREIGN KEY (reusable_id) REFERENCES ${ohdsiSchema}.reusable(id)
-        ON DELETE CASCADE;
-
-ALTER TABLE ${ohdsiSchema}.sec_source
-    ADD CONSTRAINT fk_ss_sec_role_id
-        FOREIGN KEY (role_id) REFERENCES ${ohdsiSchema}.sec_role(id)
-        ON DELETE CASCADE,
-    ADD CONSTRAINT fk_ss_source_id
-        FOREIGN KEY (source_id) REFERENCES ${ohdsiSchema}.source(source_id)
-        ON DELETE CASCADE;
+-- NOTE: FK constraints for the sec_{entity} tables above are declared further
+-- down (search for "fk_scc_sec_role_id") because they reference primary keys
+-- on sec_role and other tables that are not added until later in this script.
 
 CREATE TABLE ${ohdsiSchema}.sec_session
 (
@@ -1789,6 +1725,74 @@ ALTER TABLE ONLY ${ohdsiSchema}.sec_user_role
 
 ALTER TABLE ONLY ${ohdsiSchema}.sec_user_role
     ADD CONSTRAINT fk_user_role_to_user FOREIGN KEY (user_id) REFERENCES ${ohdsiSchema}.sec_user(id);
+
+-- FK constraints for sec_{entity} tables: role and entity references.
+-- Both FKs use ON DELETE CASCADE: deleting a role or a parent entity automatically
+-- removes its permission grants in the corresponding sec_* table.
+
+ALTER TABLE ${ohdsiSchema}.sec_cohort_characterization
+    ADD CONSTRAINT fk_scc_sec_role_id
+        FOREIGN KEY (role_id) REFERENCES ${ohdsiSchema}.sec_role(id)
+        ON DELETE CASCADE,
+    ADD CONSTRAINT fk_scc_cohort_characterization_id
+        FOREIGN KEY (cohort_characterization_id) REFERENCES ${ohdsiSchema}.cohort_characterization(id)
+        ON DELETE CASCADE;
+
+ALTER TABLE ${ohdsiSchema}.sec_cohort_definition
+    ADD CONSTRAINT fk_scd_sec_role_id
+        FOREIGN KEY (role_id) REFERENCES ${ohdsiSchema}.sec_role(id)
+        ON DELETE CASCADE,
+    ADD CONSTRAINT fk_scd_cohort_definition_id
+        FOREIGN KEY (cohort_definition_id) REFERENCES ${ohdsiSchema}.cohort_definition(id)
+        ON DELETE CASCADE;
+
+ALTER TABLE ${ohdsiSchema}.sec_concept_set
+    ADD CONSTRAINT fk_scs_sec_role_id
+        FOREIGN KEY (role_id) REFERENCES ${ohdsiSchema}.sec_role(id)
+        ON DELETE CASCADE,
+    ADD CONSTRAINT fk_scs_concept_set_id
+        FOREIGN KEY (concept_set_id) REFERENCES ${ohdsiSchema}.concept_set(concept_set_id)
+        ON DELETE CASCADE;
+
+ALTER TABLE ${ohdsiSchema}.sec_fe_analysis
+    ADD CONSTRAINT fk_sfa_sec_role_id
+        FOREIGN KEY (role_id) REFERENCES ${ohdsiSchema}.sec_role(id)
+        ON DELETE CASCADE,
+    ADD CONSTRAINT fk_sfa_fe_analysis_id
+        FOREIGN KEY (fe_analysis_id) REFERENCES ${ohdsiSchema}.fe_analysis(id)
+        ON DELETE CASCADE;
+
+ALTER TABLE ${ohdsiSchema}.sec_ir_analysis
+    ADD CONSTRAINT fk_sia_sec_role_id
+        FOREIGN KEY (role_id) REFERENCES ${ohdsiSchema}.sec_role(id)
+        ON DELETE CASCADE,
+    ADD CONSTRAINT fk_sia_ir_analysis_id
+        FOREIGN KEY (ir_id) REFERENCES ${ohdsiSchema}.ir_analysis(id)
+        ON DELETE CASCADE;
+
+ALTER TABLE ${ohdsiSchema}.sec_pathway_analysis
+    ADD CONSTRAINT fk_spa_sec_role_id
+        FOREIGN KEY (role_id) REFERENCES ${ohdsiSchema}.sec_role(id)
+        ON DELETE CASCADE,
+    ADD CONSTRAINT fk_spa_pathway_analysis_id
+        FOREIGN KEY (pathway_analysis_id) REFERENCES ${ohdsiSchema}.pathway_analysis(id)
+        ON DELETE CASCADE;
+
+ALTER TABLE ${ohdsiSchema}.sec_reusable
+    ADD CONSTRAINT fk_sr_sec_role_id
+        FOREIGN KEY (role_id) REFERENCES ${ohdsiSchema}.sec_role(id)
+        ON DELETE CASCADE,
+    ADD CONSTRAINT fk_sr_reusable_id
+        FOREIGN KEY (reusable_id) REFERENCES ${ohdsiSchema}.reusable(id)
+        ON DELETE CASCADE;
+
+ALTER TABLE ${ohdsiSchema}.sec_source
+    ADD CONSTRAINT fk_ss_sec_role_id
+        FOREIGN KEY (role_id) REFERENCES ${ohdsiSchema}.sec_role(id)
+        ON DELETE CASCADE,
+    ADD CONSTRAINT fk_ss_source_id
+        FOREIGN KEY (source_id) REFERENCES ${ohdsiSchema}.source(source_id)
+        ON DELETE CASCADE;
 
 ALTER TABLE ONLY ${ohdsiSchema}.source
     ADD CONSTRAINT source_created_by_id_fkey FOREIGN KEY (created_by_id) REFERENCES ${ohdsiSchema}.sec_user(id);


### PR DESCRIPTION
This pull request reorganizes where the foreign key (FK) constraints for the `sec_{entity}` tables are declared in the `B3.0.0__webapi_baseline.sql` migration script. The FK constraints, which enforce referential integrity and use `ON DELETE CASCADE`, have been moved to a later section of the script to ensure that all referenced tables and primary keys exist before the constraints are added. No logic has changed, but the order of operations has been adjusted.
