### PR TITLE
Rely on per-entity filtering for listing instead of list-level gates

### DIFF
--- a/src/main/java/org/ohdsi/webapi/arachne/encryption/EncryptorUtils.java
+++ b/src/main/java/org/ohdsi/webapi/arachne/encryption/EncryptorUtils.java
@@ -1,5 +1,6 @@
 package org.ohdsi.webapi.arachne.encryption;
 
+import java.security.Security;
 import java.util.Objects;
 import org.apache.commons.lang3.StringUtils;
 import org.bouncycastle.jce.provider.BouncyCastleProvider;
@@ -22,7 +23,9 @@ public class EncryptorUtils {
 	public static PBEStringEncryptor buildStringEncryptor(Environment env) {
 
 		StandardPBEStringEncryptor encryptor = new StandardPBEStringEncryptor();
-		encryptor.setProvider(new BouncyCastleProvider());
+		if (Security.getProvider("BC") == null) {
+			Security.addProvider(new BouncyCastleProvider());
+		}
 		encryptor.setProviderName("BC");
 		encryptor.setAlgorithm(env.getRequiredProperty("jasypt.encryptor.algorithm"));
 		if (StringUtils.equals("PBEWithMD5AndDES", env.getRequiredProperty("jasypt.encryptor.algorithm"))) {

--- a/src/main/java/org/ohdsi/webapi/cohortcharacterization/CcController.java
+++ b/src/main/java/org/ohdsi/webapi/cohortcharacterization/CcController.java
@@ -138,8 +138,8 @@ public class CcController {
      *
      * @return A json object with information about the characterization analyses in WebAPI.
      */
+    // Listing is open; the returned page is filtered per-entity in the service.
     @GetMapping(produces = MediaType.APPLICATION_JSON_VALUE)
-    @PreAuthorize("isAnyPermitted(anyOf('read:cohort-characterization','write:cohort-characterization'))")
     public Page<CcShortDTO> list(@Pagination Pageable pageable) {
       return service.getPage(pageable);
     }
@@ -150,7 +150,6 @@ public class CcController {
      * @return A json object with all characterization design specifications.
      */
     @GetMapping(value = "/design", produces = MediaType.APPLICATION_JSON_VALUE)
-    @PreAuthorize("isAnyPermitted(anyOf('read:cohort-characterization','write:cohort-characterization'))")
     public Page<CohortCharacterizationDTO> listDesign(@Pagination Pageable pageable) {
         return service.getPageWithLinkedEntities(pageable).map(entity -> {
           CohortCharacterizationDTO dto = convertCcToDto(entity);
@@ -341,7 +340,6 @@ public class CcController {
     @GetMapping(value = "/generation/{generationId}", produces = MediaType.APPLICATION_JSON_VALUE)
     // Per-generation entity + source access is enforced in-body by checkGeneration*Access
     // (which resolves the generation to its parent CC); this gate only blocks anonymous.
-    @PreAuthorize("isAuthenticated()")
     public CommonGenerationDTO getGeneration(@PathVariable("generationId") final Long generationId) {
         checkGenerationReadAccess(generationId);
 
@@ -357,7 +355,6 @@ public class CcController {
     @DeleteMapping(value = "/generation/{generationId}")
     // Per-generation entity + source access is enforced in-body by checkGeneration*Access
     // (which resolves the generation to its parent CC); this gate only blocks anonymous.
-    @PreAuthorize("isAuthenticated()")
     public void deleteGeneration(@PathVariable("generationId") final Long generationId) {
         checkGenerationWriteAccess(generationId);
         service.deleteCcGeneration(generationId);
@@ -371,7 +368,6 @@ public class CcController {
     @GetMapping(value = "/generation/{generationId}/design", produces = MediaType.APPLICATION_JSON_VALUE)
     // Per-generation entity + source access is enforced in-body by checkGeneration*Access
     // (which resolves the generation to its parent CC); this gate only blocks anonymous.
-    @PreAuthorize("isAuthenticated()")
     public CcExportDTO getGenerationDesign(
             @PathVariable("generationId") final Long generationId) {
         checkGenerationReadAccess(generationId);
@@ -387,7 +383,6 @@ public class CcController {
     @GetMapping(value = "/generation/{generationId}/result/count", produces = MediaType.APPLICATION_JSON_VALUE)
     // Per-generation entity + source access is enforced in-body by checkGeneration*Access
     // (which resolves the generation to its parent CC); this gate only blocks anonymous.
-    @PreAuthorize("isAuthenticated()")
     public Long getGenerationsResultsCount( @PathVariable("generationId") final Long generationId) {
         checkGenerationReadAccess(generationId);
         return service.getCCResultsTotalCount(generationId);
@@ -403,7 +398,6 @@ public class CcController {
     @GetMapping(value = "/generation/{generationId}/result", produces = MediaType.APPLICATION_JSON_VALUE)
     // Per-generation entity + source access is enforced in-body by checkGeneration*Access
     // (which resolves the generation to its parent CC); this gate only blocks anonymous.
-    @PreAuthorize("isAuthenticated()")
     public List<CcResult> getGenerationsResults(
             @PathVariable("generationId") final Long generationId, @RequestParam(value = "thresholdLevel", defaultValue = "0.01") final float thresholdLevel) {
         checkGenerationReadAccess(generationId);
@@ -413,7 +407,6 @@ public class CcController {
     @GetMapping(value = "/generation/{generationId}/temporalresult", produces = MediaType.APPLICATION_JSON_VALUE)
     // Per-generation entity + source access is enforced in-body by checkGeneration*Access
     // (which resolves the generation to its parent CC); this gate only blocks anonymous.
-    @PreAuthorize("isAuthenticated()")
     public List<CcTemporalResult> getGenerationTemporalResults(@PathVariable("generationId") final Long generationId) {
         checkGenerationReadAccess(generationId);
         return service.findTemporalResultAsList(generationId);
@@ -422,7 +415,6 @@ public class CcController {
     @PostMapping(value = "/generation/{generationId}/result", produces = MediaType.APPLICATION_JSON_VALUE)
     // Per-generation entity + source access is enforced in-body by checkGeneration*Access
     // (which resolves the generation to its parent CC); this gate only blocks anonymous.
-    @PreAuthorize("isAuthenticated()")
     public GenerationResults getGenerationsResults(
             @PathVariable("generationId") final Long generationId, @RequestBody ExportExecutionResultRequest params) {
         checkGenerationReadAccess(generationId);
@@ -432,7 +424,6 @@ public class CcController {
     @PostMapping(value = "/generation/{generationId}/result/export", produces = MediaType.APPLICATION_OCTET_STREAM_VALUE, consumes = MediaType.APPLICATION_JSON_VALUE)
     // Per-generation entity + source access is enforced in-body by checkGeneration*Access
     // (which resolves the generation to its parent CC); this gate only blocks anonymous.
-    @PreAuthorize("isAuthenticated()")
     public ResponseEntity<byte[]> exportGenerationsResults(
             @PathVariable("generationId") final Long generationId, @RequestBody ExportExecutionResultRequest params) {
         checkGenerationReadAccess(generationId);
@@ -488,7 +479,6 @@ public class CcController {
     @GetMapping(value = "/generation/{generationId}/explore/prevalence/{analysisId}/{cohortId}/{covariateId}", produces = MediaType.APPLICATION_JSON_VALUE)
     // Per-generation entity + source access is enforced in-body by checkGeneration*Access
     // (which resolves the generation to its parent CC); this gate only blocks anonymous.
-    @PreAuthorize("isAuthenticated()")
     public List<CcPrevalenceStat> getPrevalenceStat(@PathVariable("generationId") Long generationId,
                                                     @PathVariable("analysisId") Long analysisId,
                                                     @PathVariable("cohortId") Long cohortId,
@@ -633,7 +623,6 @@ public class CcController {
      * @return
      */
     @PostMapping(value = "/byTags", produces = MediaType.APPLICATION_JSON_VALUE, consumes = MediaType.APPLICATION_JSON_VALUE)
-    @PreAuthorize("isAnyPermitted(anyOf('read:cohort-characterization','write:cohort-characterization'))")
     public List<CcShortDTO> listByTags(@RequestBody TagNameListRequestDTO requestDTO) {
         if (requestDTO == null || requestDTO.getNames() == null || requestDTO.getNames().isEmpty()) {
             return Collections.emptyList();

--- a/src/main/java/org/ohdsi/webapi/cohortdefinition/CohortDefinitionService.java
+++ b/src/main/java/org/ohdsi/webapi/cohortdefinition/CohortDefinitionService.java
@@ -715,7 +715,7 @@ public class CohortDefinitionService extends AbstractDaoService implements HasTa
 	 * @return List of metadata about all cohort definitions in WebAPI
 	 * @see org.ohdsi.webapi.cohortdefinition.CohortMetadataDTO
 	 */
-	@PreAuthorize("isAnyPermitted(anyOf('read:cohort-definition','write:cohort-definition'))")
+	// Listing is open; the returned list is filtered per-entity below (read:cohort-definition / per-entity grants).
 	@GetMapping(produces = MediaType.APPLICATION_JSON_VALUE)
 	@Transactional(readOnly = true)
 	@Cacheable(cacheNames = CachingSetup.COHORT_DEFINITION_LIST_CACHE, key = "@authorizationService.getAuthenticatedPrincipal().getUserId()")
@@ -1484,7 +1484,6 @@ public class CohortDefinitionService extends AbstractDaoService implements HasTa
 	 * @param requestDTO contains a list of tag names
 	 * @return the set of cohort definitions that match one of the included tag names.
 	 */
-	@PreAuthorize("isAnyPermitted(anyOf('read:cohort-definition','write:cohort-definition'))")
 	@PostMapping(value = "/byTags", produces = MediaType.APPLICATION_JSON_VALUE, consumes = MediaType.APPLICATION_JSON_VALUE)
 	@Transactional
 	public List<CohortDTO> listByTags(@RequestBody TagNameListRequestDTO requestDTO) {

--- a/src/main/java/org/ohdsi/webapi/cohortdefinition/CohortSampleService.java
+++ b/src/main/java/org/ohdsi/webapi/cohortdefinition/CohortSampleService.java
@@ -45,7 +45,7 @@ public class CohortSampleService {
 	 * @param sourceKey
 	 * @return JSON containing information about cohort samples
 	 */
-	@PreAuthorize("isAnyPermitted(anyOf('read:source','write:source')) or hasSourceAccess(#sourceKey, READ)")
+	@PreAuthorize("(isOwner(#cohortDefinitionId, COHORT_DEFINITION) or isAnyPermitted(anyOf('read:cohort-definition','write:cohort-definition')) or hasEntityAccess(#cohortDefinitionId, COHORT_DEFINITION, READ)) and (isAnyPermitted(anyOf('read:source','write:source')) or hasSourceAccess(#sourceKey, READ))")
 	@GetMapping(value = "/{cohortDefinitionId}/{sourceKey}", produces = MediaType.APPLICATION_JSON_VALUE)
 	public CohortSampleListDTO listCohortSamples(
 			@PathVariable("cohortDefinitionId") int cohortDefinitionId,
@@ -75,7 +75,7 @@ public class CohortSampleService {
 	 * @param fields
 	 * @return personId, gender, age of each person in the cohort sample
 	 */
-	@PreAuthorize("isAnyPermitted(anyOf('read:source','write:source')) or hasSourceAccess(#sourceKey, READ)")
+	@PreAuthorize("(isOwner(#cohortDefinitionId, COHORT_DEFINITION) or isAnyPermitted(anyOf('read:cohort-definition','write:cohort-definition')) or hasEntityAccess(#cohortDefinitionId, COHORT_DEFINITION, READ)) and (isAnyPermitted(anyOf('read:source','write:source')) or hasSourceAccess(#sourceKey, READ))")
 	@GetMapping(value = "/{cohortDefinitionId}/{sourceKey}/{sampleId}", produces = MediaType.APPLICATION_JSON_VALUE)
 	public CohortSampleDTO getCohortSample(
 			@PathVariable("cohortDefinitionId") int cohortDefinitionId,
@@ -85,7 +85,17 @@ public class CohortSampleService {
 	) {
 		List<String> returnFields = Arrays.asList(fields.split(","));
 		boolean withRecordCounts = returnFields.contains("recordCount");
-		return this.samplingService.getSample(sampleId, withRecordCounts);
+		Source source = getSource(sourceKey);
+		CohortSampleDTO sample = this.samplingService.getSample(sampleId, withRecordCounts);
+		// Bind the requested sample to the cohort/source in the path, so a caller authorized for one
+		// cohort+source cannot read a sample belonging to another simply by guessing its id.
+		if (sample.getCohortDefinitionId() == null || sample.getSourceId() == null
+				|| sample.getCohortDefinitionId() != cohortDefinitionId
+				|| !sample.getSourceId().equals(source.getId())) {
+			throw new ResponseStatusException(HttpStatus.NOT_FOUND,
+					"Cohort sample " + sampleId + " not found for this cohort and source");
+		}
+		return sample;
 	}
 
 	/**

--- a/src/main/java/org/ohdsi/webapi/conceptset/ConceptSetService.java
+++ b/src/main/java/org/ohdsi/webapi/conceptset/ConceptSetService.java
@@ -173,7 +173,7 @@ public class ConceptSetService extends AbstractDaoService implements HasTags<Int
      * @summary Get all concept sets
      * @return A list of all concept sets in the WebAPI database
      */
-    @PreAuthorize("isAnyPermitted(anyOf('read:conceptset','write:conceptset'))")
+    // Listing is open; the returned list is filtered per-entity below (read:conceptset / per-entity grants).
     @GetMapping(produces = MediaType.APPLICATION_JSON_VALUE)
     @Cacheable(cacheNames = ConceptSetService.CachingSetup.CONCEPT_SET_LIST_CACHE, key = "@authorizationService.getAuthenticatedPrincipal().getUserId()")
     @Transactional(readOnly = true)
@@ -900,7 +900,6 @@ public class ConceptSetService extends AbstractDaoService implements HasTags<Int
      * @param requestDTO The tagNameListRequest
      * @return A list of concept sets with their assigned tags
      */
-    @PreAuthorize("isAnyPermitted(anyOf('read:conceptset','write:conceptset'))")
     @PostMapping(value = "/byTags", produces = MediaType.APPLICATION_JSON_VALUE, consumes = MediaType.APPLICATION_JSON_VALUE)
     public List<ConceptSetDTO> listByTags(@RequestBody TagNameListRequestDTO requestDTO) {
         if (requestDTO == null || requestDTO.getNames() == null || requestDTO.getNames().isEmpty()) {

--- a/src/main/java/org/ohdsi/webapi/feanalysis/FeAnalysisController.java
+++ b/src/main/java/org/ohdsi/webapi/feanalysis/FeAnalysisController.java
@@ -13,6 +13,10 @@ import org.ohdsi.webapi.security.authz.AuthorizationService;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.ohdsi.webapi.security.authz.access.EntityType;
 import org.ohdsi.webapi.security.authz.access.AccessType;
+import org.ohdsi.webapi.security.authz.access.EntityGrant;
+import org.ohdsi.webapi.security.authz.access.UserAuthorizations;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.data.domain.PageImpl;
 import org.ohdsi.webapi.util.ExceptionUtils;
 import org.ohdsi.webapi.util.ExportUtil;
 import org.ohdsi.webapi.util.HttpUtils;
@@ -40,6 +44,9 @@ public class FeAnalysisController {
     private ConversionService conversionService;
     private AuthorizationService authorizationService;
 
+    @Value("${security.defaultGlobalReadPermissions}")
+    private boolean defaultGlobalReadPermissions;
+
     FeAnalysisController(
             final FeAnalysisService service,
             final ConversionService conversionService,
@@ -55,15 +62,37 @@ public class FeAnalysisController {
      * @param pageable
      * @return
      */
+    // Listing is open; the returned page is filtered per-entity here (read:feature-analysis / per-entity grants).
     @GetMapping(produces = MediaType.APPLICATION_JSON_VALUE)
-    @PreAuthorize("isAnyPermitted(anyOf('read:feature-analysis','write:feature-analysis'))")
     public Page<FeAnalysisShortDTO> list(@Pagination Pageable pageable) {
-        return service.getPage(pageable).map(entity -> {
+        UserAuthorizations authz = authorizationService.getCurrentUserAuthorizations();
+        boolean globalRead = authorizationService.isPermitted("read:feature-analysis");
+        boolean globalWrite = authorizationService.isPermitted("write:feature-analysis");
+        boolean needsFiltering = !defaultGlobalReadPermissions && !globalRead;
+
+        java.util.function.Function<FeAnalysisEntity, FeAnalysisShortDTO> toDto = entity -> {
             FeAnalysisShortDTO dto = convertFeAnaysisToShortDto(entity);
-            //TODO: figure out populating permissions on lists
-            // AuthorizationService.fillWriteAccess(entity, dto);
+            EntityGrant grant = authz.feAnalysisAccess.getOrDefault(Long.valueOf(entity.getId()), EntityGrant.NONE);
+            dto.setReadAccess(globalRead || grant.hasAccess(AccessType.READ));
+            dto.setWriteAccess(globalWrite || grant.hasAccess(AccessType.WRITE));
             return dto;
+        };
+
+        if (!needsFiltering) {
+            return service.getPage(pageable).map(toDto);
+        }
+        // Per-entity filtering required: load all, keep the readable ones, then re-paginate.
+        List<FeAnalysisShortDTO> filtered = new ArrayList<>();
+        service.getPage(Pageable.unpaged()).forEach(entity -> {
+            FeAnalysisShortDTO dto = toDto.apply(entity);
+            if (dto.isReadAccess()) {
+                filtered.add(dto);
+            }
         });
+        int start = (int) pageable.getOffset();
+        int end = Math.min(start + pageable.getPageSize(), filtered.size());
+        List<FeAnalysisShortDTO> content = start < filtered.size() ? filtered.subList(start, end) : new ArrayList<>();
+        return new PageImpl<>(content, pageable, filtered.size());
     }
 
     /**

--- a/src/main/java/org/ohdsi/webapi/ircalc/IRAnalysisService.java
+++ b/src/main/java/org/ohdsi/webapi/ircalc/IRAnalysisService.java
@@ -44,6 +44,9 @@ import org.ohdsi.webapi.ircalc.dto.IRVersionFullDTO;
 import org.ohdsi.webapi.job.GeneratesNotification;
 import org.ohdsi.webapi.job.JobExecutionResource;
 import org.ohdsi.webapi.security.authz.AuthorizationService;
+import org.ohdsi.webapi.security.authz.access.EntityGrant;
+import org.ohdsi.webapi.security.authz.access.AccessType;
+import org.ohdsi.webapi.security.authz.access.UserAuthorizations;
 import org.ohdsi.webapi.security.authz.UserEntity;
 import org.ohdsi.webapi.security.authz.UserRepository;
 import org.ohdsi.webapi.service.AbstractDaoService;
@@ -321,18 +324,22 @@ public class IRAnalysisService extends AbstractDaoService implements
   }
 
   @Override
-  @PreAuthorize("isAnyPermitted(anyOf('read:incidence','write:incidence'))")
+  // Listing is open; the returned list is filtered per-entity below (read:incidence / per-entity grants).
   public List<IRAnalysisShortDTO> getIRAnalysisList() {
     return getTransactionTemplate().execute(transactionStatus -> {
+      UserAuthorizations authz = authorizationService.getCurrentUserAuthorizations();
+      boolean globalRead = authorizationService.isPermitted("read:incidence");
+      boolean globalWrite = authorizationService.isPermitted("write:incidence");
       Iterable<IncidenceRateAnalysis> analysisList = this.irAnalysisRepository.findAll();
       return StreamSupport.stream(analysisList.spliterator(), false)
-              //.filter(!defaultGlobalReadPermissions ? entity -> authorizationService.hasReadAccess(entity) : entity -> true)
               .map(analysis -> {
                 IRAnalysisShortDTO dto = conversionService.convert(analysis, IRAnalysisShortDTO.class);
-                // authorizationService.fillWriteAccess(analysis, dto);
-                // authorizationService.fillReadAccess(analysis, dto);
+                EntityGrant grant = authz.incidenceRateAccess.getOrDefault(Long.valueOf(analysis.getId()), EntityGrant.NONE);
+                dto.setReadAccess(globalRead || grant.hasAccess(AccessType.READ));
+                dto.setWriteAccess(globalWrite || grant.hasAccess(AccessType.WRITE));
                 return dto;
               })
+              .filter(defaultGlobalReadPermissions ? dto -> true : IRAnalysisShortDTO::isReadAccess)
               .collect(Collectors.toList());
     });
   }

--- a/src/main/java/org/ohdsi/webapi/job/NotificationServiceImpl.java
+++ b/src/main/java/org/ohdsi/webapi/job/NotificationServiceImpl.java
@@ -80,7 +80,6 @@ public class NotificationServiceImpl implements NotificationService {
      * @param refreshJobs Boolean - when true, it will refresh the cache of notifications
      * @return List of job execution resources
      */
-    @PreAuthorize("isAuthenticated()")
     @GetMapping(produces = MediaType.APPLICATION_JSON_VALUE)
     @Transactional(readOnly = true)
     public List<JobExecutionResource> list(
@@ -111,7 +110,6 @@ public class NotificationServiceImpl implements NotificationService {
      * @summary Get notification last viewed date
      * @return The date when notifications were last viewed
      */
-    @PreAuthorize("isAuthenticated()")
     @GetMapping(value = "/viewed", produces = MediaType.APPLICATION_JSON_VALUE)
     @Transactional(readOnly = true)
     public Date getLastViewedTimeEndpoint() {
@@ -128,7 +126,6 @@ public class NotificationServiceImpl implements NotificationService {
      * @summary Set notification last viewed date
      * @param stamp The date to set
      */
-    @PreAuthorize("isAuthenticated()")
     @PostMapping(value = "/viewed", consumes = MediaType.APPLICATION_JSON_VALUE)
     public void setLastViewedTimeEndpoint(@RequestBody Date stamp) {
         try {

--- a/src/main/java/org/ohdsi/webapi/pathway/PathwayController.java
+++ b/src/main/java/org/ohdsi/webapi/pathway/PathwayController.java
@@ -149,8 +149,8 @@ public class PathwayController {
 	 * @summary List Designs by Page
 	 * @return the list of pathway analysis DTOs.
 	 */
+	// Listing is open; the returned page is filtered per-entity in the service.
 	@GetMapping(produces = MediaType.APPLICATION_JSON_VALUE)
-	@PreAuthorize("isAnyPermitted(anyOf('read:pathway','write:pathway'))")
 	public Page<PathwayAnalysisDTO> list(@Pagination Pageable pageable) {
 		return pathwayService.getPage(pageable);
 	}
@@ -356,7 +356,6 @@ public class PathwayController {
 	@GetMapping(value = "/generation/{generationId}", produces = MediaType.APPLICATION_JSON_VALUE)
 	// Per-generation entity + source access is enforced in-body by checkGeneration*Access
 	// (which resolves the generation to its parent pathway analysis); this gate only blocks anonymous.
-	@PreAuthorize("isAuthenticated()")
 	public CommonGenerationDTO getPathwayGenerations(
 					@PathVariable("generationId") final Long generationId
 	) {
@@ -381,7 +380,6 @@ public class PathwayController {
 	@GetMapping(value = "/generation/{generationId}/design", produces = MediaType.APPLICATION_JSON_VALUE)
 	// Per-generation entity + source access is enforced in-body by checkGeneration*Access
 	// (which resolves the generation to its parent pathway analysis); this gate only blocks anonymous.
-	@PreAuthorize("isAuthenticated()")
 	public String getGenerationDesign(
 					@PathVariable("generationId") final Long generationId
 	) {
@@ -401,7 +399,6 @@ public class PathwayController {
 	@GetMapping(value = "/generation/{generationId}/result", produces = MediaType.APPLICATION_JSON_VALUE)
 	// Per-generation entity + source access is enforced in-body by checkGeneration*Access
 	// (which resolves the generation to its parent pathway analysis); this gate only blocks anonymous.
-	@PreAuthorize("isAuthenticated()")
 	public PathwayPopulationResultsDTO getGenerationResults(
 					@PathVariable("generationId") final Long generationId
 	) {
@@ -613,7 +610,6 @@ public class PathwayController {
 	 * @return
 	 */
 	@PostMapping(value = "/byTags", produces = MediaType.APPLICATION_JSON_VALUE, consumes = MediaType.APPLICATION_JSON_VALUE)
-	@PreAuthorize("isAnyPermitted(anyOf('read:pathway','write:pathway'))")
 	public List<PathwayAnalysisDTO> listByTags(@RequestBody TagNameListRequestDTO requestDTO) {
 		if (requestDTO == null || requestDTO.getNames() == null || requestDTO.getNames().isEmpty()) {
 			return Collections.emptyList();

--- a/src/main/java/org/ohdsi/webapi/reusable/ReusableService.java
+++ b/src/main/java/org/ohdsi/webapi/reusable/ReusableService.java
@@ -7,6 +7,9 @@ import org.ohdsi.webapi.reusable.dto.ReusableVersionFullDTO;
 import org.ohdsi.webapi.reusable.repository.ReusableRepository;
 import org.ohdsi.webapi.security.authz.AuthorizationCacheService;
 import org.ohdsi.webapi.security.authz.AuthorizationService;
+import org.ohdsi.webapi.security.authz.access.EntityGrant;
+import org.ohdsi.webapi.security.authz.access.AccessType;
+import org.ohdsi.webapi.security.authz.access.UserAuthorizations;
 import org.ohdsi.webapi.security.authz.UserEntity;
 import org.ohdsi.webapi.service.AbstractDaoService;
 import org.ohdsi.webapi.tag.domain.HasTags;
@@ -21,11 +24,13 @@ import org.ohdsi.webapi.versioning.dto.VersionDTO;
 import org.ohdsi.webapi.versioning.dto.VersionUpdateDTO;
 import org.ohdsi.webapi.versioning.service.VersionService;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.cache.annotation.CacheEvict;
 import org.springframework.core.convert.ConversionService;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.MediaType;
 import org.springframework.transaction.annotation.Transactional;
@@ -40,6 +45,7 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import jakarta.persistence.EntityManager;
+import java.util.ArrayList;
 import java.util.Calendar;
 import java.util.Collections;
 import java.util.Date;
@@ -59,6 +65,9 @@ public class ReusableService extends AbstractDaoService implements HasTags<Integ
     private final EntityManager entityManager;
     private final ConversionService conversionService;
     private final VersionService<ReusableVersion> versionService;
+
+    @Value("${security.defaultGlobalReadPermissions}")
+    private boolean defaultGlobalReadPermissions;
 
     @Autowired
     public ReusableService(
@@ -111,15 +120,37 @@ public class ReusableService extends AbstractDaoService implements HasTags<Integ
         return reusableRepository.findAll();
     }
 
+    // Listing is open; the returned page is filtered per-entity here.
     @GetMapping(produces = MediaType.APPLICATION_JSON_VALUE)
-    @PreAuthorize("isAnyPermitted(anyOf('read:reusable','write:reusable'))")
     public Page<ReusableDTO> page(@Pagination Pageable pageable) {
-        return reusableRepository.findAll(pageable)
-                .map(reusable -> {
-                    final ReusableDTO dto = conversionService.convert(reusable, ReusableDTO.class);
-                    // permissionService.fillWriteAccess(reusable, dto);
-                    return dto;
-                });
+        UserAuthorizations authz = authorizationService.getCurrentUserAuthorizations();
+        boolean globalRead = authorizationService.isPermitted("read:reusable");
+        boolean globalWrite = authorizationService.isPermitted("write:reusable");
+        boolean needsFiltering = !defaultGlobalReadPermissions && !globalRead;
+
+        java.util.function.Function<Reusable, ReusableDTO> toDto = reusable -> {
+            ReusableDTO dto = conversionService.convert(reusable, ReusableDTO.class);
+            EntityGrant grant = authz.reusableAccess.getOrDefault(Long.valueOf(reusable.getId()), EntityGrant.NONE);
+            dto.setReadAccess(globalRead || grant.hasAccess(AccessType.READ));
+            dto.setWriteAccess(globalWrite || grant.hasAccess(AccessType.WRITE));
+            return dto;
+        };
+
+        if (!needsFiltering) {
+            return reusableRepository.findAll(pageable).map(toDto);
+        }
+        // Per-entity filtering required: load all, keep the readable ones, then re-paginate.
+        List<ReusableDTO> filtered = new ArrayList<>();
+        reusableRepository.findAll().forEach(reusable -> {
+            ReusableDTO dto = toDto.apply(reusable);
+            if (dto.isReadAccess()) {
+                filtered.add(dto);
+            }
+        });
+        int start = (int) pageable.getOffset();
+        int end = Math.min(start + pageable.getPageSize(), filtered.size());
+        List<ReusableDTO> content = start < filtered.size() ? filtered.subList(start, end) : new ArrayList<>();
+        return new PageImpl<>(content, pageable, filtered.size());
     }
 
     @PutMapping(value = "/{id}", produces = MediaType.APPLICATION_JSON_VALUE, consumes = MediaType.APPLICATION_JSON_VALUE)

--- a/src/main/java/org/ohdsi/webapi/security/authc/JwtAuthConfig.java
+++ b/src/main/java/org/ohdsi/webapi/security/authc/JwtAuthConfig.java
@@ -92,10 +92,10 @@ public class JwtAuthConfig {
   @Value("${security.jwt.kid:}")
   private String configuredKid;
 
-  // Serve token-less requests as the anonymous user instead of 401 (default on).
-  // Set false to enforce default-deny (require authentication everywhere).
-  @Value("${security.anonymousAccess.enabled:true}")
-  private boolean anonymousAccessEnabled;
+  // When true (default), token-less requests are served as the built-in anonymous principal.
+  // When false, every endpoint outside the bootstrap allow-list requires a valid JWT.
+  @Value("${security.allowAnonymousAccess:true}")
+  private boolean allowAnonymousAccess;
 
   private static final org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(JwtAuthConfig.class);
 
@@ -268,18 +268,14 @@ public class JwtAuthConfig {
     http
         .httpBasic(AbstractHttpConfigurer::disable)
         .authorizeHttpRequests(auth -> {
-            // Endpoints that must stay reachable before login (used by the login page):
-            //   /info            – server/version banner
-            //   /auth/providers  – list of enabled auth methods
-            //   /i18n/**         – localization bundles
+            // Bootstrap endpoints the login page needs before authentication.
             auth.requestMatchers("/info", "/auth/providers", "/i18n/**").permitAll();
-            if (anonymousAccessEnabled) {
-              // Opt-in (public / no-auth-provider deployments): token-less requests
-              // proceed as the anonymous user. Per-endpoint @PreAuthorize still
-              // governs what anonymous may do, so this is not a blanket bypass.
+            if (allowAnonymousAccess) {
+              // Token-less requests proceed as the anonymous principal; what a principal may do
+              // is governed by per-endpoint @PreAuthorize and the permission grants it holds.
               auth.anyRequest().permitAll();
             } else {
-              // Default-deny: every other endpoint requires an authenticated principal.
+              // Anonymous access disabled: every other endpoint requires a valid JWT.
               auth.anyRequest().authenticated();
             }
           })
@@ -288,11 +284,12 @@ public class JwtAuthConfig {
             .authenticationEntryPoint(unauthorizedEntryPoint)
             .jwt(jwt -> jwt.jwtAuthenticationConverter(
                 new JwtToWebApiAuthenticationConverter(sessionService, userRepository))))
-        // Token-less requests become anonymous (rejected by authenticated()).
+        // Token-less requests become the anonymous principal (rejected by authenticated()
+        // when anonymous access is disabled).
         .anonymous(anon -> anon
             .principal(WebApiPrincipal.ANONYMOUS)
             .authorities("ROLE_ANONYMOUS"))
-        // Return 401 (not 403) when an anonymous request hits a protected endpoint.
+        // Return 401 (not 403) when an unauthenticated request hits a protected endpoint.
         .exceptionHandling(ex -> ex.authenticationEntryPoint(unauthorizedEntryPoint));
 
     return http.build();

--- a/src/main/java/org/ohdsi/webapi/security/authz/PermissionController.java
+++ b/src/main/java/org/ohdsi/webapi/security/authz/PermissionController.java
@@ -41,7 +41,7 @@ public class PermissionController {
      * @return A list of permissions
      */
     @GetMapping(produces = MediaType.APPLICATION_JSON_VALUE)
-    @PreAuthorize("isPermitted('admin:security')")
+    @PreAuthorize("isPermitted('list')")
     public List<Permission> getPermissions() {
         return this.authorizationService.getPermissions();
     }

--- a/src/main/java/org/ohdsi/webapi/security/authz/UserController.java
+++ b/src/main/java/org/ohdsi/webapi/security/authz/UserController.java
@@ -33,7 +33,7 @@ public class UserController {
 
 
   @GetMapping(value = "/user", produces = MediaType.APPLICATION_JSON_VALUE)
-  @PreAuthorize("isPermitted('admin:security')")
+  @PreAuthorize("isPermitted('list')")
   public ArrayList<User> getUsers() {
     Iterable<User> userDtos = this.authorizer.getUsers();
     ArrayList<User> users = new ArrayList<>();
@@ -45,7 +45,8 @@ public class UserController {
 
   @UseEtag
   @GetMapping(value = "/user/me", produces = MediaType.APPLICATION_JSON_VALUE)
-  @PreAuthorize("isAuthenticated()")
+  // Open: returns the current principal's context (the anonymous principal when not logged in).
+  // The UI relies on this to discover who-am-i and what-can-i-do, so it must not require login.
   public UserInfo getCurrentUser() throws Exception {
     User currentUser = this.authorizer.getCurrentUser();
     UserAuthorizations authz = this.authorizer.getUserAuthorizations(currentUser.id());
@@ -53,14 +54,14 @@ public class UserController {
   }
 
   @GetMapping(value = "/user/{userId}/permissions", produces = MediaType.APPLICATION_JSON_VALUE)
-  @PreAuthorize("isPermitted('admin:security')")
+  @PreAuthorize("isPermitted('list')")
   public List<Permission> getUsersPermissions(@PathVariable("userId") Long userId) throws Exception {
     List<Permission> permissions = this.authorizer.getUserPermissions(userId);
     return permissions;
   }
 
   @GetMapping(value = "/user/{userId}/roles", produces = MediaType.APPLICATION_JSON_VALUE)
-  @PreAuthorize("isPermitted('admin:security')")
+  @PreAuthorize("isPermitted('list')")
   public ArrayList<Role> getUserRoles(@PathVariable("userId") Long userId) throws Exception {
     List<Role> roleList = this.authorizer.getUserRoles(userId);
     ArrayList<Role> roles = new ArrayList<>(roleList);
@@ -89,7 +90,7 @@ public class UserController {
   }
 
   @GetMapping(value = "/role", produces = MediaType.APPLICATION_JSON_VALUE)
-  @PreAuthorize("isPermitted('admin:security')")
+  @PreAuthorize("isPermitted('list')")
   public ArrayList<Role> getRoles(
           @RequestParam(value = "include_personal", defaultValue = "false") boolean includePersonalRoles) {
     List<Role> roleList = this.authorizer.getRoles(includePersonalRoles);
@@ -112,7 +113,7 @@ public class UserController {
   }
 
   @GetMapping(value = "/role/{roleId}/permissions", produces = MediaType.APPLICATION_JSON_VALUE)
-  @PreAuthorize("isPermitted('admin:security')")
+  @PreAuthorize("isPermitted('list')")
   public List<Permission> getRolePermissions(@PathVariable("roleId") Long roleId) throws Exception {
     List<Permission> permissions = this.authorizer.getRolePermissions(roleId);
     return permissions;
@@ -153,7 +154,7 @@ public class UserController {
   }
 
   @GetMapping(value = "/role/{roleId}/users", produces = MediaType.APPLICATION_JSON_VALUE)
-  @PreAuthorize("isPermitted('admin:security')")
+  @PreAuthorize("isPermitted('list')")
   public ArrayList<User> getRoleUsers(@PathVariable("roleId") Long roleId) throws Exception {
     List<User> users = this.authorizer.getRoleUsers(roleId);
     return new ArrayList<>(users);

--- a/src/main/java/org/ohdsi/webapi/service/DDLService.java
+++ b/src/main/java/org/ohdsi/webapi/service/DDLService.java
@@ -109,7 +109,7 @@ public class DDLService {
 	 * @param tempSchema
 	 * @return SQL to create tables in results schema
 	 */
-	@PreAuthorize("isAnyPermitted(anyOf('read:source','write:source'))")
+	@PreAuthorize("isPermitted('list')")
 	@GetMapping(value = "/results", produces = MediaType.TEXT_PLAIN_VALUE)
 	public String generateResultSQL(
 			@RequestParam(value = "dialect", required = false) String dialect,
@@ -143,7 +143,7 @@ public class DDLService {
 	 * @param schema schema name
 	 * @return SQL
 	 */
-	@PreAuthorize("isAnyPermitted(anyOf('read:source','write:source'))")
+	@PreAuthorize("isPermitted('list')")
 	@GetMapping(value = "/cemresults", produces = MediaType.TEXT_PLAIN_VALUE)
 	public String generateCemResultSQL(
 			@RequestParam(value = "dialect", required = false) String dialect,
@@ -163,7 +163,7 @@ public class DDLService {
 	 * @param resultSchema results schema
 	 * @return SQL
 	 */
-	@PreAuthorize("isAnyPermitted(anyOf('read:source','write:source'))")
+	@PreAuthorize("isPermitted('list')")
 	@GetMapping(value = "/achilles", produces = MediaType.TEXT_PLAIN_VALUE)
 	public String generateAchillesSQL(
 			@RequestParam(value = "dialect", required = false) String dialect,

--- a/src/main/java/org/ohdsi/webapi/service/JobService.java
+++ b/src/main/java/org/ohdsi/webapi/service/JobService.java
@@ -79,7 +79,7 @@ public class JobService extends AbstractDaoService {
    * @param jobId The job ID
    * @return The job information
    */
-  @PreAuthorize("isPermitted('read')")
+  @PreAuthorize("isPermitted('list')")
   @GetMapping(value = "/{jobId}", produces = MediaType.APPLICATION_JSON_VALUE)
   public JobInstanceResource findJob(@PathVariable("jobId") final Long jobId) {
     final JobInstance job = this.jobExplorer.getJobInstance(jobId);
@@ -97,7 +97,7 @@ public class JobService extends AbstractDaoService {
    * @param jobType The job type
    * @return JobExecutionResource
    */
-  @PreAuthorize("isPermitted('read')")
+  @PreAuthorize("isPermitted('list')")
   @GetMapping(value = "/type/{jobType}/name/{jobName}", produces = MediaType.APPLICATION_JSON_VALUE)
   public JobExecutionResource findJobByName(
           @PathVariable("jobName") final String jobName,
@@ -116,7 +116,7 @@ public class JobService extends AbstractDaoService {
    * @param executionId The execution ID
    * @return JobExecutionResource
    */
-  @PreAuthorize("isPermitted('read')")
+  @PreAuthorize("isPermitted('list')")
   @GetMapping(value = "/{jobId}/execution/{executionId}", produces = MediaType.APPLICATION_JSON_VALUE)
   public JobExecutionResource findJobExecution(
           @PathVariable("jobId") final Long jobId,
@@ -131,7 +131,7 @@ public class JobService extends AbstractDaoService {
    * @param executionId The job execution ID
    * @return JobExecutionResource
    */
-  @PreAuthorize("isPermitted('read')")
+  @PreAuthorize("isPermitted('list')")
   @GetMapping(value = "/execution/{executionId}", produces = MediaType.APPLICATION_JSON_VALUE)
   public JobExecutionResource findJobExecutionById(@PathVariable("executionId") final Long executionId) {
     return service(null, executionId);
@@ -154,7 +154,7 @@ public class JobService extends AbstractDaoService {
    * @summary Get list of jobs
    * @return A list of jobs
    */
-  @PreAuthorize("isPermitted('read')")
+  @PreAuthorize("isPermitted('list')")
   @GetMapping(produces = MediaType.APPLICATION_JSON_VALUE)
   public List<String> findJobNames() {
     return this.jobExplorer.getJobNames();
@@ -176,7 +176,7 @@ public class JobService extends AbstractDaoService {
    * @return collection of JobExecutionInfo
    * @throws NoSuchJobException
    */
-  @PreAuthorize("isPermitted('read')")
+  @PreAuthorize("isPermitted('list')")
   @GetMapping(value = "/execution", produces = MediaType.APPLICATION_JSON_VALUE)
   public Page<JobExecutionResource> list(
           @RequestParam(value = "jobName", required = false) final String jobName,

--- a/src/main/java/org/ohdsi/webapi/service/SqlRenderService.java
+++ b/src/main/java/org/ohdsi/webapi/service/SqlRenderService.java
@@ -30,7 +30,7 @@ public class SqlRenderService {
      * @param sourceStatement JSON with parameters, source SQL, and target dialect
      * @return rendered and translated SQL
      */
-    @PreAuthorize("isAnyPermitted(anyOf('read:source','write:source'))")
+    @PreAuthorize("isPermitted('list')")
     @PostMapping(
         value = "/translate",
         produces = MediaType.APPLICATION_JSON_VALUE,

--- a/src/main/java/org/ohdsi/webapi/source/SourceService.java
+++ b/src/main/java/org/ohdsi/webapi/source/SourceService.java
@@ -143,9 +143,14 @@ public class SourceService extends AbstractDaoService {
      * identify CDMs.
      */
     @GetMapping(value = "/sources", produces = MediaType.APPLICATION_JSON_VALUE)
-    @PreAuthorize("isAnyPermitted(anyOf('read:source','write:source'))")
     public ResponseEntity<Collection<SourceInfo>> getSourcesEndpoint() {
-        return ResponseEntity.ok(getSources().stream().map(SourceInfo::new).collect(Collectors.toList()));
+        boolean globalRead = authorizationService.isPermitted("read:source")
+                || authorizationService.isPermitted("write:source");
+        Collection<SourceInfo> visible = getSources().stream()
+                .filter(s -> globalRead || authorizationService.hasSourceAccess(s.getSourceKey(), AccessType.READ))
+                .map(SourceInfo::new)
+                .collect(Collectors.toList());
+        return ResponseEntity.ok(visible);
     }
 
 

--- a/src/main/java/org/ohdsi/webapi/tool/ToolServiceImpl.java
+++ b/src/main/java/org/ohdsi/webapi/tool/ToolServiceImpl.java
@@ -33,7 +33,7 @@ public class ToolServiceImpl extends AbstractDaoService implements ToolService {
     }
 
     @Override
-    @PreAuthorize("isPermitted('read')")
+    @PreAuthorize("isPermitted('list')")
     @GetMapping(value = "", produces = MediaType.APPLICATION_JSON_VALUE)
     public List<ToolDTO> getTools() {
         List<Tool> tools = toolRepository.findAll();
@@ -59,7 +59,7 @@ public class ToolServiceImpl extends AbstractDaoService implements ToolService {
     }
 
     @Override
-    @PreAuthorize("isPermitted('read')")
+    @PreAuthorize("isPermitted('list')")
     @GetMapping(value = "/{id}", produces = MediaType.APPLICATION_JSON_VALUE)
     public ToolDTO getById(@PathVariable("id") Integer id) {
         return toDTO(toolRepository.findById(id).orElse(null));

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -261,18 +261,10 @@ security:
   # read permission on each artifact before they can see it.
   defaultGlobalReadPermissions: true
 
-  # anonymousAccess.enabled controls whether requests without a valid token are
-  # served as the built-in 'anonymous' user instead of being rejected with 401.
-  #   true (default) – token-less requests proceed as the anonymous user, so
-  #                    WebAPI works without an auth provider configured.
-  #                    Per-endpoint @PreAuthorize still applies, so anonymous gets
-  #                    only what its role (plus defaultGlobalReadPermissions)
-  #                    grants. Set defaultGlobalReadPermissions=false to stop
-  #                    anonymous from reading every artifact.
-  #   false          – default-deny: every endpoint outside the login allow-list
-  #                    requires authentication. Use when every client logs in.
-  anonymousAccess:
-    enabled: true
+  # allowAnonymousAccess: when true (default), requests without a valid JWT are served as the
+  # built-in anonymous user; when false, every endpoint outside the bootstrap allow-list
+  # (/info, /auth/providers, /i18n, login) requires a valid JWT.
+  allowAnonymousAccess: true
 
   defaultRoles: ""
 

--- a/src/main/resources/db/migration/postgresql/B3.0.0__webapi_baseline.sql
+++ b/src/main/resources/db/migration/postgresql/B3.0.0__webapi_baseline.sql
@@ -1863,7 +1863,8 @@ FROM (
 	('write:incidence', 'Update incidence designs'),
 	('write:pathway', 'Update pathway designs'),
 	('write:reusable', 'Update reusable components'),
-	('write:source', 'Generate source results')
+	('write:source', 'Generate source results'),
+	('list', 'List platform reference data (users, roles, permissions, jobs, tools) and use DDL/SqlRender utilities')
 ) p (value, description)
 ;
 
@@ -1886,7 +1887,7 @@ select nextval('${ohdsiSchema}.sec_role_permission_sequence'), 1, p.id
 from (
     select id
     from ${ohdsiSchema}.sec_permission
-    where value in ('read')
+    where value in ('read', 'list')
 ) p;
 
 INSERT INTO ${ohdsiSchema}.sec_role (id, name, system_role)

--- a/src/main/resources/db/migration/postgresql/V2.99.0005__list_permission.sql
+++ b/src/main/resources/db/migration/postgresql/V2.99.0005__list_permission.sql
@@ -1,0 +1,17 @@
+-- 'list' — list platform reference data (the user/role/permission registries, jobs, tools)
+-- and use the DDL/SqlRender utilities. Granted to the built-in public role so authenticated
+-- users keep listing access; anonymous is excluded.
+--
+-- Transitional 2.x -> 3.0 migration: the same permission and grant are also in the 3.0
+-- baseline (B3.0.0) for fresh installs. No "where not exists" guard -- if the permission
+-- already exists the migration should fail, since that is unexpected.
+insert into ${ohdsiSchema}.sec_permission(id, value, description)
+select nextval('${ohdsiSchema}.sec_permission_sequence'), value, description
+from (
+	values ('list', 'List platform reference data (users, roles, permissions, jobs, tools) and use DDL/SqlRender utilities')
+) p (value, description);
+
+insert into ${ohdsiSchema}.sec_role_permission(id, role_id, permission_id)
+select nextval('${ohdsiSchema}.sec_role_permission_sequence'), sr.id, sp.id
+from ${ohdsiSchema}.sec_permission sp, ${ohdsiSchema}.sec_role sr
+where sp.value = 'list' and sr.name = 'public';

--- a/src/test/java/org/ohdsi/webapi/test/AnonymousAccessIT.java
+++ b/src/test/java/org/ohdsi/webapi/test/AnonymousAccessIT.java
@@ -14,24 +14,17 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.test.context.TestPropertySource;
 
 /**
- * Verifies the opt-in anonymous-access mode
- * ({@code security.anonymousAccess.enabled=true}): token-less requests are
- * served as the built-in anonymous user instead of being rejected with 401,
- * while per-endpoint {@code @PreAuthorize} still governs what anonymous may do.
- *
- * <p>The flag only changes the web-layer catch-all (permitAll vs. authenticated);
- * method security is untouched. {@link SecurityIT} proves the same endpoints
- * return 401 under the default ({@code false}).
+ * Verifies the anonymous-principal model: token-less requests are served as the
+ * built-in anonymous user (never rejected with 401 by the filter chain), and
+ * per-endpoint {@code @PreAuthorize} alone governs what the anonymous principal
+ * may do. Open listing endpoints return 200; gated endpoints return 403.
  *
  * <p>{@link WebApiIT} grants the anonymous user the admin role for tests. This
  * class removes that grant in {@link #demoteAnonymous()} so it can assert an
- * <em>unprivileged</em> anonymous user is reachable but still denied at gated
- * endpoints — i.e. authorization is evaluated, not bypassed.
+ * <em>unprivileged</em> anonymous user lists open endpoints but is still denied
+ * at gated ones — i.e. authorization is evaluated, not bypassed.
  */
-@TestPropertySource(properties = {
-    "security.anonymousAccess.enabled=true",
-    "security.defaultGlobalReadPermissions=true"
-})
+@TestPropertySource(properties = "security.defaultGlobalReadPermissions=true")
 public class AnonymousAccessIT extends WebApiIT {
 
     /** A template with NO Authorization interceptor — simulates an anonymous caller. */
@@ -72,21 +65,22 @@ public class AnonymousAccessIT extends WebApiIT {
     }
 
     @Test
-    public void anonymousReachesMethodSecurityWhenEnabled() {
-        // With the flag on, a token-less request is admitted past the filter chain as
-        // the anonymous user and reaches method security, which denies it (403) because
-        // the demoted anonymous user lacks read:cohort-definition. The observable proof
-        // of "reachability" is that this is 403 (denied at method security), NOT the 401
-        // a token-less request gets under default-deny — SecurityIT asserts the same
-        // /cohortdefinition path returns 401 when the flag is off.
-        assertEquals(HttpStatus.FORBIDDEN, statusOf("/cohortdefinition"));
+    public void anonymousMayListOpenEndpoints() {
+        // Listing is open: a token-less request is served as the anonymous user and the
+        // list endpoint returns 200 (its contents are filtered per-entity). Anonymous
+        // needs neither a login nor a read grant to list.
+        assertEquals(HttpStatus.OK, statusOf("/cohortdefinition"));
     }
 
     @Test
     public void preAuthorizeStillDeniesUnprivilegedAnonymous() {
-        // /cache/clear is gated by isPermitted('admin:cache'). The demoted
-        // anonymous user lacks it, so method security denies the request with 403 —
-        // proving the flag opens reachability but does NOT bypass authorization.
+        // Gated endpoints still reach method security and deny the unprivileged anonymous
+        // user (403), proving authorization is evaluated, not bypassed:
+        //   - /cache/clear is gated by admin:cache
+        //   - /role/1 (a role definition) is gated by admin:security
+        //   - /user (the user registry) is gated by the list permission
         assertEquals(HttpStatus.FORBIDDEN, statusOf("/cache/clear"));
+        assertEquals(HttpStatus.FORBIDDEN, statusOf("/role/1"));
+        assertEquals(HttpStatus.FORBIDDEN, statusOf("/user"));
     }
 }

--- a/src/test/java/org/ohdsi/webapi/test/AuthorizationAccessIT.java
+++ b/src/test/java/org/ohdsi/webapi/test/AuthorizationAccessIT.java
@@ -58,11 +58,12 @@ public class AuthorizationAccessIT extends WebApiIT {
             "INSERT INTO " + schema + ".sec_user_role (id, user_id, role_id, origin) " +
             "SELECT nextval('" + schema + ".sec_user_role_sequence'), " + READER_USER_ID + ", " + READER_ROLE_ID + ", 'SYSTEM' " +
             "WHERE NOT EXISTS (SELECT 1 FROM " + schema + ".sec_user_role WHERE user_id = " + READER_USER_ID + " AND role_id = " + READER_ROLE_ID + ")");
-        // Grant the generic 'read' permission to the reader's role.
+        // Grant the reader's role 'read' (read any asset) and 'list' (list platform reference data) —
+        // the permissions a normal authenticated user holds.
         jdbcTemplate.execute(
             "INSERT INTO " + schema + ".sec_role_permission (id, role_id, permission_id) " +
             "SELECT nextval('" + schema + ".sec_role_permission_sequence'), " + READER_ROLE_ID + ", p.id " +
-            "FROM " + schema + ".sec_permission p WHERE p.value = 'read' " +
+            "FROM " + schema + ".sec_permission p WHERE p.value IN ('read', 'list') " +
             "AND NOT EXISTS (SELECT 1 FROM " + schema + ".sec_role_permission rp WHERE rp.role_id = " + READER_ROLE_ID + " AND rp.permission_id = p.id)");
 
         authorizationService.clearCache();
@@ -108,9 +109,18 @@ public class AuthorizationAccessIT extends WebApiIT {
     }
 
     @Test
+    public void readerAllowedUserList() {
+        // The user registry is gated by the 'list' permission (held by the reader and the built-in
+        // public role), not admin:security, so the sharing workflow keeps working. Anonymous holds
+        // no 'list' and is denied.
+        assertReaderAllowed("/user");
+    }
+
+    @Test
     public void readerDeniedAdminRoleManagement() {
-        // 'read' must NOT grant admin:security — listing roles stays forbidden.
-        ResponseEntity<String> r = getAsReader("/role");
+        // Listing roles is open under the anonymous-principal model, but a role *definition*
+        // (GET /role/{id}) stays admin:security — 'read' must NOT grant it.
+        ResponseEntity<String> r = getAsReader("/role/1");
         assertEquals(
             "Reader (granted only 'read') must be denied admin role management",
             HttpStatus.FORBIDDEN,

--- a/src/test/java/org/ohdsi/webapi/test/EndpointAuthCoverageIT.java
+++ b/src/test/java/org/ohdsi/webapi/test/EndpointAuthCoverageIT.java
@@ -23,22 +23,43 @@ import org.springframework.web.servlet.mvc.method.annotation.RequestMappingHandl
  * Codebase-wide authorization guards driven by the live handler set, so future
  * endpoints are covered automatically:
  *  - every org.ohdsi.webapi endpoint must carry method security (@PreAuthorize on
- *    the handler or its controller), except a pinned login/bootstrap allow-list;
+ *    the handler or its controller), unless it is explicitly allow-listed as an
+ *    intentionally-open endpoint (login/bootstrap, open listing/registry reads, or
+ *    an endpoint whose authorization is enforced in-body);
  *  - every source-scoped handler (@PathVariable("sourceKey")) must carry @PreAuthorize.
  *
- * <p>These are static annotation-presence checks rather than HTTP probes: with
- * {@code security.anonymousAccess.enabled=true} the filter chain admits token-less
- * requests and per-endpoint @PreAuthorize is the gate, so a missing annotation —
- * not the filter — is what would leave an endpoint open. (Runtime denial of
- * anonymous requests is exercised by {@link SecurityIT} and {@link SourceAccessIT}.)
+ * <p>These are static annotation-presence checks rather than HTTP probes: the
+ * filter chain serves token-less requests as the anonymous principal, so
+ * per-endpoint @PreAuthorize (or a deliberate allow-list entry) is what governs
+ * access. Runtime behaviour for the anonymous principal is exercised by
+ * {@link AnonymousAccessIT} and {@link SourceAccessIT}.
  */
 public class EndpointAuthCoverageIT extends WebApiIT {
 
-    // Reachable before login by design. Adding to this list is a deliberate,
-    // reviewable change — keep it minimal.
+    // Reachable before login by design (login/bootstrap). Prefix match. Adding to
+    // this list is a deliberate, reviewable change — keep it minimal.
     static final List<String> ANONYMOUS_ALLOW_LIST = List.of(
         "/info", "/auth/providers", "/i18n",
         "/user/login", "/user/refresh", "/user/logout", "/user/oauth/callback");
+
+    // Intentionally open under the anonymous-principal model (EXACT match): listing /
+    // registry / self-scoped reads. Their contents are filtered per-entity, or they are
+    // public registries (users/roles/permissions) needed to grant access to others.
+    // Opening an endpoint here is a deliberate, reviewable change — keep this tight.
+    static final List<String> OPEN_READ_EXACT = List.of(
+        "/cohortdefinition", "/conceptset",
+        "/cohort-characterization", "/cohort-characterization/design",
+        "/pathway-analysis", "/feature-analysis", "/ir", "/reusable",
+        "/cohortdefinition/byTags", "/conceptset/byTags",
+        "/cohort-characterization/byTags", "/pathway-analysis/byTags",
+        "/source/sources",
+        "/user/me",
+        "/notifications", "/notifications/viewed");
+
+    // Authorization enforced in-body (per-generation entity + source access via
+    // checkGeneration*Access), so these carry no @PreAuthorize. Prefix match.
+    static final List<String> IN_BODY_GUARDED_PREFIX = List.of(
+        "/cohort-characterization/generation", "/pathway-analysis/generation");
 
     @Autowired
     @Qualifier("requestMappingHandlerMapping")
@@ -103,6 +124,16 @@ public class EndpointAuthCoverageIT extends WebApiIT {
 
     static boolean isAllowListed(String pattern) {
         for (String p : ANONYMOUS_ALLOW_LIST) {
+            if (pattern.equals(p) || pattern.startsWith(p + "/")) {
+                return true;
+            }
+        }
+        for (String p : OPEN_READ_EXACT) {
+            if (pattern.equals(p)) {
+                return true;
+            }
+        }
+        for (String p : IN_BODY_GUARDED_PREFIX) {
             if (pattern.equals(p) || pattern.startsWith(p + "/")) {
                 return true;
             }

--- a/src/test/java/org/ohdsi/webapi/test/SecurityIT.java
+++ b/src/test/java/org/ohdsi/webapi/test/SecurityIT.java
@@ -9,17 +9,16 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.test.context.TestPropertySource;
 
 /**
- * Verifies the default-deny security model: every endpoint except the login
- * allow-list must reject unauthenticated (token-less) requests with 401.
- *
- * <p>Pins {@code security.anonymousAccess.enabled=false} so this exercises the
- * default-deny mode regardless of the shipped default; the opt-in anonymous mode
- * is covered by {@link AnonymousAccessIT}.
+ * Verifies the anonymous-access toggle in its disabled state. With
+ * {@code security.allowAnonymousAccess=false}, a token-less request is rejected with
+ * 401 by the filter chain for every endpoint outside the bootstrap allow-list, while
+ * the bootstrap endpoints (used by the login page) stay reachable. The enabled
+ * (default) mode is exercised by {@link AnonymousAccessIT}.
  */
-@TestPropertySource(properties = "security.anonymousAccess.enabled=false")
+@TestPropertySource(properties = "security.allowAnonymousAccess=false")
 public class SecurityIT extends WebApiIT {
 
-    /** A template with NO Authorization interceptor — simulates an anonymous caller. */
+    /** A template with NO Authorization interceptor — simulates a token-less caller. */
     private final TestRestTemplate anonymous = new TestRestTemplate();
 
     private HttpStatus statusOf(String path) {
@@ -29,26 +28,15 @@ public class SecurityIT extends WebApiIT {
     }
 
     @Test
-    public void protectedEndpointsRejectAnonymous() {
-        // Sensitive endpoints that previously leaked data without a login.
+    public void tokenlessRequestsRejectedWhenAnonymousDisabled() {
         assertEquals(HttpStatus.UNAUTHORIZED, statusOf("/user"));
-        assertEquals(HttpStatus.UNAUTHORIZED, statusOf("/role"));
-        assertEquals(HttpStatus.UNAUTHORIZED, statusOf("/permission"));
         assertEquals(HttpStatus.UNAUTHORIZED, statusOf("/cohortdefinition"));
-        assertEquals(HttpStatus.UNAUTHORIZED, statusOf("/conceptset"));
-        assertEquals(HttpStatus.UNAUTHORIZED, statusOf("/tag"));
         assertEquals(HttpStatus.UNAUTHORIZED, statusOf("/source/sources"));
     }
 
     @Test
-    public void loginAllowListIsAnonymous() {
-        // These must stay reachable before login.
+    public void bootstrapEndpointsStayOpen() {
         assertEquals(HttpStatus.OK, statusOf("/info"));
         assertEquals(HttpStatus.OK, statusOf("/auth/providers"));
-    }
-
-    @Test
-    public void cacheClearRejectsAnonymous() {
-        assertEquals(HttpStatus.UNAUTHORIZED, statusOf("/cache/clear"));
     }
 }


### PR DESCRIPTION
### Why
WebAPI authorizes every request through a security principal (authenticated user or the built-in anonymous principal), deciding access from permission grants + per-entity filtering. #2521 hardened authorization and kept that model. #2521 gated list endpoints behind `read`/`write` permissions, when listing should stay open and have its contents filtered per principal (which several lists already did). This PR removes those list gates and relies on filtering, and removes a handful of `isAuthenticated()` checks that cut against the model. #2521's genuine endpoint protections are kept.

### Kept from #2521 (these endpoints were genuinely open before — leave gated)
- Source-scoped CDM data reads (vocabulary, evidence, cdmresults) → `read:source` / `hasSourceAccess`
- Person-level data (person profile, cohort-sample) → source + cohort grants
- Feature-extraction → `read:feature-analysis`
- Admin operations (user/role/permission mgmt + LDAP import, source mgmt, cache, statistics, tag management) → `admin:*`

### The fix: listing is open, contents are filtered
Content is protected one of two ways:
- Filtered (open list, rows trimmed to grants) — the 7 artifact lists + `/source/sources`. 4 already did this (cohort-definition, concept-set, cohort-characterization, pathway); this PR adds IR, feature-analysis, reusable, and the source list. `/byTags` list-by-tag queries are opened too.
- Gated with a new `list` permission (migration `V2.99.0005`, also in the `B3.0.0` baseline), granted to the built-in `public` role, where there's no per-entity scope to filter — user/role/permission registries, jobs, tools, and the DDL/SqlRender utilities (which read no source data). Authenticated users can list; anonymous → 403.

### Secondary cleanups
- Removed the `isAuthenticated()` gates (getCurrentUser, generation reads, notifications) — generation reads keep their in-body entity+source checks.
- Renamed the anonymous-access toggle `security.anonymousAccess.enabled` → `security.allowAnonymousAccess` (default true serves token-less requests as the anonymous principal; false requires a valid JWT for every endpoint outside the bootstrap allow-list).

### Other fixes
- Cohort-sample IDOR — require cohort + source access and bind the sample to the cohort/source in the path.
