### PR TITLE
Remove @preAuth from getPriorityDaimonsEndpoint

### DIFF
--- a/src/main/java/org/ohdsi/webapi/source/SourceService.java
+++ b/src/main/java/org/ohdsi/webapi/source/SourceService.java
@@ -378,7 +378,6 @@ public class SourceService extends AbstractDaoService {
      * @return
      */
     @GetMapping(value = "/daimon/priority", produces = MediaType.APPLICATION_JSON_VALUE)
-    @PreAuthorize("isAnyPermitted(anyOf('read:source','write:source'))")
     public ResponseEntity<Map<SourceDaimon.DaimonType, SourceInfo>> getPriorityDaimonsEndpoint() {
         return ResponseEntity.ok(getPriorityDaimons()
                 .entrySet().stream()


### PR DESCRIPTION
It is a simple filter function and does not require permissons.

The previous check required read or write access to all sources.