### PR TITLE
Allow global source read permission to fetch a patient profile

### DIFF
--- a/src/main/java/org/ohdsi/webapi/person/PersonService.java
+++ b/src/main/java/org/ohdsi/webapi/person/PersonService.java
@@ -55,7 +55,7 @@ public class PersonService extends AbstractDaoService {
    * @return All records in a patient profile with start and end days relative to cohort start date or initial date of
    * observation
    */
-  @PreAuthorize("hasSourceAccess(#sourceKey, READ)")
+  @PreAuthorize("isAnyPermitted(anyOf('read:source','write:source')) or hasSourceAccess(#sourceKey, READ)")
   @GetMapping(value = "/{personId}", produces = MediaType.APPLICATION_JSON_VALUE)
   public PersonProfile getPersonProfile(@PathVariable("sourceKey") String sourceKey, @PathVariable("personId") String personId,
                                         @RequestParam(value = "cohort", defaultValue = "0") Long cohortId)


### PR DESCRIPTION
## Problem

Reported as [OHDSI/Atlas3#206](https://github.com/OHDSI/Atlas3/issues/206). After generating a sample of a generated cohort, the person list renders, but opening any person's profile returns access denied. The reporting user has global read and write permission on sources.

## Cause

`AuthorizationService.hasSourceAccess` resolves the source key to an id and delegates to `hasEntityAccess`. Its `SOURCE` branch reads only the per-source ACL map:

```java
case SOURCE -> {
  Set<AccessType> granted = authz.sourceAccess.get(entityId);
  yield granted != null && EntityGrant.hasAccess(accessType, granted);
}
```

It never consults the global `read:source` / `write:source` entitlement. Every other source-scoped read endpoint therefore pairs it with an `isAnyPermitted` check:

```java
@PreAuthorize("isAnyPermitted(anyOf('read:source','write:source')) or hasSourceAccess(#sourceKey, READ)")
```

69 read endpoints use that paired form. `PersonService.getPersonProfile` was the only one in production code carrying the ACL half on its own, so a user entitled globally but without a per-source ACL row is refused there and nowhere else. The only other bare uses are inside the `SourceAccessIT` test fixture, where they are deliberate. It has been that way since the endpoint was introduced in "Migrated Person service for patient profiles" (#2506), so it reads as an oversight in the migration rather than an intentional tightening.

The Atlas3 client performs no permission check of its own before opening a profile, so this response is what the user sees.

## Fix

Use the same paired expression as the other read endpoints. After the change no source-scoped read endpoint in production code carries the ACL-only form.
