### PR TITLE
Fix role assignment across authentication origins and under concurrent logins

### DIFF
--- a/src/main/java/org/ohdsi/webapi/security/authc/LoginService.java
+++ b/src/main/java/org/ohdsi/webapi/security/authc/LoginService.java
@@ -117,14 +117,21 @@ public class LoginService {
       return;
     }
 
-    // Add roles present in target but not in current
-    for (String roleName : targetRoles) {
-      if (!currentOriginRoles.contains(roleName)) {
-        try {
-          authorizationService.addUserToRole(roleName, login, origin);
-          log.info("Sync roles: added role '{}' to user '{}' (origin: {})", roleName, login, origin);
-        } catch (Exception e) {
-          log.warn("Sync roles: could not add role '{}' to user '{}': {}", roleName, login, e.getMessage());
+    // Add roles present in target but not in current. Concurrent logins would otherwise both
+    // find a role missing and both add it, so the ones with work to do are serialised and then
+    // re-read what the winner committed.
+    if (!currentOriginRoles.containsAll(targetRoles)) {
+      authorizationService.lockRoleSync(login);
+      currentOriginRoles = authorizationService.getRolesByOrigin(login, origin);
+
+      for (String roleName : targetRoles) {
+        if (!currentOriginRoles.contains(roleName)) {
+          try {
+            authorizationService.addUserToRole(roleName, login, origin);
+            log.info("Sync roles: added role '{}' to user '{}' (origin: {})", roleName, login, origin);
+          } catch (Exception e) {
+            log.warn("Sync roles: could not add role '{}' to user '{}': {}", roleName, login, e.getMessage());
+          }
         }
       }
     }

--- a/src/main/java/org/ohdsi/webapi/security/authz/AuthorizationService.java
+++ b/src/main/java/org/ohdsi/webapi/security/authz/AuthorizationService.java
@@ -8,6 +8,8 @@ import org.ohdsi.webapi.security.authc.UserOrigin;
 import org.ohdsi.webapi.security.identity.WebApiPrincipal;
 import org.ohdsi.webapi.source.Source;
 import org.ohdsi.webapi.source.SourceRepository;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Service;
@@ -34,6 +36,12 @@ public class AuthorizationService {
   private final PermissionService permissionService;
   private final EntityAccessService entityAccessService;
   private final SourceRepository sourceRepository;
+
+  // Advisory lock namespace, so user registration cannot collide with other advisory locks.
+  private static final int USER_REGISTRATION_LOCK_NAMESPACE = 0x55534552;
+
+  @PersistenceContext
+  private EntityManager entityManager;
 
   public AuthorizationService(
       AuthorizationCacheService authorizationCacheService,
@@ -321,9 +329,24 @@ public class AuthorizationService {
    */
   @Transactional
   public User ensureUserExists(String login, String name, UserOrigin origin, List<String> defaultRoles) {
+    Optional<UserEntity> existing = userService.getUserByLogin(login);
+    if (existing.isPresent()) {
+      return updateIfNeeded(existing.get(), name, origin);
+    }
+
+    // Concurrent first logins for one principal would otherwise race the unique sec_user.login,
+    // and the loser would abort the caller's transaction. Serialise them instead. The lock is
+    // held on this transaction's own connection and released when the transaction ends, so the
+    // waiting logins observe the registration once it has been committed.
+    entityManager.createNativeQuery("SELECT pg_advisory_xact_lock(?1, ?2)")
+        .setParameter(1, USER_REGISTRATION_LOCK_NAMESPACE)
+        .setParameter(2, login.hashCode())
+        .getSingleResult();
+
     return userService.getUserByLogin(login)
         .map(entity -> updateIfNeeded(entity, name, origin))
-        .orElseGet(() -> registerUser(login, name, origin, new HashSet<>(defaultRoles == null ? List.of() : defaultRoles)));
+        .orElseGet(() -> registerUser(login, name, origin,
+            new HashSet<>(defaultRoles == null ? List.of() : defaultRoles)));
   }
 
   /**

--- a/src/main/java/org/ohdsi/webapi/security/authz/AuthorizationService.java
+++ b/src/main/java/org/ohdsi/webapi/security/authz/AuthorizationService.java
@@ -37,8 +37,10 @@ public class AuthorizationService {
   private final EntityAccessService entityAccessService;
   private final SourceRepository sourceRepository;
 
-  // Advisory lock namespace, so user registration cannot collide with other advisory locks.
+  // Advisory lock namespaces, so these locks cannot collide with each other or with any
+  // other advisory lock taken against this database.
   private static final int USER_REGISTRATION_LOCK_NAMESPACE = 0x55534552;
+  private static final int ROLE_SYNC_LOCK_NAMESPACE = 0x524f4c45;
 
   @PersistenceContext
   private EntityManager entityManager;
@@ -335,18 +337,41 @@ public class AuthorizationService {
     }
 
     // Concurrent first logins for one principal would otherwise race the unique sec_user.login,
-    // and the loser would abort the caller's transaction. Serialise them instead. The lock is
-    // held on this transaction's own connection and released when the transaction ends, so the
-    // waiting logins observe the registration once it has been committed.
-    entityManager.createNativeQuery("SELECT pg_advisory_xact_lock(?1, ?2)")
-        .setParameter(1, USER_REGISTRATION_LOCK_NAMESPACE)
-        .setParameter(2, login.hashCode())
-        .getSingleResult();
+    // and the loser would abort the caller's transaction. Serialise them instead.
+    lockLogin(USER_REGISTRATION_LOCK_NAMESPACE, login);
 
     return userService.getUserByLogin(login)
         .map(entity -> updateIfNeeded(entity, name, origin))
         .orElseGet(() -> registerUser(login, name, origin,
             new HashSet<>(defaultRoles == null ? List.of() : defaultRoles)));
+  }
+
+  /**
+   * Serialise the callers that are about to grant this login the roles an origin asserts.
+   *
+   * Role assignment is a lookup followed by an insert, so without this two logins can both
+   * find a role missing and both add it. Held only by the logins that actually have
+   * something to add, and released when the transaction ends.
+   *
+   * @param login the login whose role assignments are being changed
+   */
+  @Transactional
+  public void lockRoleSync(String login) {
+    lockLogin(ROLE_SYNC_LOCK_NAMESPACE, login);
+  }
+
+  /**
+   * Take a transaction scoped advisory lock keyed on a login.
+   *
+   * Runs through the EntityManager so that it is taken on the connection this transaction
+   * already holds; a JdbcTemplate would take a second one and lock in a different
+   * transaction. Requires an active transaction, or the lock is released immediately.
+   */
+  private void lockLogin(int namespace, String login) {
+    entityManager.createNativeQuery("SELECT pg_advisory_xact_lock(?1, ?2)")
+        .setParameter(1, namespace)
+        .setParameter(2, login.hashCode())
+        .getSingleResult();
   }
 
   /**

--- a/src/main/java/org/ohdsi/webapi/security/authz/RoleService.java
+++ b/src/main/java/org/ohdsi/webapi/security/authz/RoleService.java
@@ -205,12 +205,14 @@ class RoleService {
 
   public UserRoleEntity addUserToRole(final UserEntity user, final RoleEntity role,
       final UserOrigin userOrigin) {
-    UserRoleEntity relation = this.userRoleRepository.findByUserAndRole(user, role)
+    final UserOrigin origin = userOrigin != null ? userOrigin : UserOrigin.SYSTEM;
+
+    UserRoleEntity relation = this.userRoleRepository.findFirstByUserAndRoleAndOrigin(user, role, origin)
         .orElseGet(() -> {
           UserRoleEntity newRelation = new UserRoleEntity();
           newRelation.setUser(user);
           newRelation.setRole(role);
-          newRelation.setOrigin(userOrigin != null ? userOrigin : UserOrigin.SYSTEM);
+          newRelation.setOrigin(origin);
           newRelation = this.userRoleRepository.save(newRelation);
           authCacheService.evictUser(user.getId());
           return newRelation;
@@ -229,24 +231,26 @@ class RoleService {
     RoleEntity role = this.getSystemRoleByName(roleName).orElseThrow(() -> new RuntimeException("Role not found."));
     UserEntity user = userService.getUserByLogin(login).orElseThrow(() -> new RuntimeException("Login not found."));
 
-    this.userRoleRepository.findByUserAndRole(user, role)
-        .ifPresent((userRole) -> {
-          if (origin == null || origin.equals(userRole.getOrigin())) {
-            this.userRoleRepository.delete(userRole);
-            authCacheService.evictUser(user.getId());
-          }
-        });
+    List<UserRoleEntity> assignments = this.userRoleRepository.findAllByUserAndRole(user, role).stream()
+        .filter(userRole -> origin == null || origin.equals(userRole.getOrigin()))
+        .toList();
+
+    if (!assignments.isEmpty()) {
+      this.userRoleRepository.deleteAll(assignments);
+      authCacheService.evictUser(user.getId());
+    }
   }
 
   public void removeUser(Long userId, Long roleId) {
     UserEntity user = userService.getUserById(userId);
     RoleEntity role = this.getRole(roleId);
 
-    this.userRoleRepository.findByUserAndRole(user, role)
-      .ifPresent((userRole) -> {
-        this.userRoleRepository.delete(userRole);
-        authCacheService.evictUser(user.getId());
-      });
+    List<UserRoleEntity> assignments = this.userRoleRepository.findAllByUserAndRole(user, role);
+
+    if (!assignments.isEmpty()) {
+      this.userRoleRepository.deleteAll(assignments);
+      authCacheService.evictUser(user.getId());
+    }
   }
 
   public Set<RoleEntity> getUserRoles(Long userId) {

--- a/src/main/java/org/ohdsi/webapi/security/authz/RoleService.java
+++ b/src/main/java/org/ohdsi/webapi/security/authz/RoleService.java
@@ -203,6 +203,22 @@ class RoleService {
     this.addUserToRole(user, role, userOrigin);
   }
 
+  /**
+   * Grant a role to a user on behalf of one authentication origin.
+   *
+   * The same role may be held from several origins at once, so an existing grant from
+   * another origin does not satisfy this one. Callers may pass a null origin, which is
+   * recorded as SYSTEM.
+   *
+   * The lookup and the insert are not atomic, so concurrent callers can still create a
+   * duplicate assignment. Duplicates are tolerated rather than prevented; removing that
+   * race needs an upsert and a unique constraint on (user, role, origin).
+   *
+   * @param user the user to grant the role to
+   * @param role the role to grant
+   * @param userOrigin the authentication origin making the grant, null for SYSTEM
+   * @return the existing or newly created assignment
+   */
   public UserRoleEntity addUserToRole(final UserEntity user, final RoleEntity role,
       final UserOrigin userOrigin) {
     final UserOrigin origin = userOrigin != null ? userOrigin : UserOrigin.SYSTEM;
@@ -221,6 +237,16 @@ class RoleService {
     return relation;
   }
 
+  /**
+   * Revoke a role from a user, for one authentication origin or for all of them.
+   *
+   * Every assignment matching the origin is removed, so grants recorded more than once
+   * do not survive the call. Grants from other origins are left untouched.
+   *
+   * @param login the user to revoke the role from
+   * @param roleName the role to revoke
+   * @param origin the authentication origin to revoke for, null for every origin
+   */
   public void removeUserFromRole(String login, String roleName, UserOrigin origin) {
     Assert.hasLength(roleName, "roleName can not be empty.");
     Assert.hasLength(login, "login can not be empty");
@@ -241,6 +267,17 @@ class RoleService {
     }
   }
 
+  /**
+   * Revoke a role from a user across every authentication origin.
+   *
+   * This spans all origins so that the result matches what {@link #getRoleUsers(Long)}
+   * reports, which is not origin-scoped: leaving another origin's grant in place would
+   * keep the user listed in the role after being removed from it. An origin that still
+   * asserts the role re-grants it on the user's next login.
+   *
+   * @param userId the user to revoke the role from
+   * @param roleId the role to revoke
+   */
   public void removeUser(Long userId, Long roleId) {
     UserEntity user = userService.getUserById(userId);
     RoleEntity role = this.getRole(roleId);

--- a/src/main/java/org/ohdsi/webapi/security/authz/UserRoleRepository.java
+++ b/src/main/java/org/ohdsi/webapi/security/authz/UserRoleRepository.java
@@ -16,7 +16,12 @@ public interface UserRoleRepository extends CrudRepository<UserRoleEntity, Long>
 
   public List<UserRoleEntity> findByUser(UserEntity user);
 
-  public Optional<UserRoleEntity> findByUserAndRole(UserEntity user, RoleEntity role);
+  // findFirst, not a plain Optional query: databases predating the dedupe migration
+  // can still hold duplicate rows, which would raise IncorrectResultSizeDataAccessException.
+  public Optional<UserRoleEntity> findFirstByUserAndRoleAndOrigin(UserEntity user, RoleEntity role,
+      UserOrigin origin);
+
+  public List<UserRoleEntity> findAllByUserAndRole(UserEntity user, RoleEntity role);
 
 @Query("""
     select ur.user.id

--- a/src/main/resources/db/migration/postgresql/V2.99.0010__dedupe_sec_user_role.sql
+++ b/src/main/resources/db/migration/postgresql/V2.99.0010__dedupe_sec_user_role.sql
@@ -1,0 +1,13 @@
+-- Collapse duplicate role assignments left by the pre-origin-aware addUserToRole,
+-- keeping the lowest id of each (user_id, role_id, origin) group.
+
+DELETE FROM ${ohdsiSchema}.sec_user_role
+WHERE id IN (
+    SELECT id
+    FROM (
+        SELECT id,
+               row_number() OVER (PARTITION BY user_id, role_id, origin ORDER BY id) AS rn
+        FROM ${ohdsiSchema}.sec_user_role
+    ) ranked
+    WHERE ranked.rn > 1
+);

--- a/src/test/java/org/ohdsi/webapi/security/authz/UserRegistrationRaceTest.java
+++ b/src/test/java/org/ohdsi/webapi/security/authz/UserRegistrationRaceTest.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2026 p-hoffmann.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.ohdsi.webapi.security.authz;
+
+import java.util.List;
+import java.util.concurrent.Callable;
+import java.util.concurrent.CyclicBarrier;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+import org.junit.After;
+import org.junit.Test;
+import org.ohdsi.webapi.AbstractDatabaseTest;
+import org.ohdsi.webapi.security.authc.UserOrigin;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
+/**
+ * Concurrent first logins for the same principal must all succeed. sec_user.login is
+ * unique, so only one of them can insert the user and the rest have to fall back to it.
+ */
+public class UserRegistrationRaceTest extends AbstractDatabaseTest {
+
+  @Autowired
+  private AuthorizationService authorizationService;
+
+  private static final String LOGIN = "race_test_user";
+  private static final int THREADS = 16;
+
+  @After
+  public void deleteFixture() {
+    jdbcTemplate.update("DELETE FROM " + ohdsiSchema + ".sec_user_role WHERE user_id IN "
+        + "(SELECT id FROM " + ohdsiSchema + ".sec_user WHERE login = ?)", LOGIN);
+    jdbcTemplate.update("DELETE FROM " + ohdsiSchema + ".sec_user WHERE login = ?", LOGIN);
+    jdbcTemplate.update("DELETE FROM " + ohdsiSchema + ".sec_role WHERE name = ?", LOGIN);
+  }
+
+  @Test
+  public void testConcurrentFirstLoginsAllSucceed() throws Exception {
+    CyclicBarrier startTogether = new CyclicBarrier(THREADS);
+    ExecutorService pool = Executors.newFixedThreadPool(THREADS);
+
+    try {
+      List<Callable<Object>> logins = IntStream.range(0, THREADS)
+          .<Callable<Object>>mapToObj(i -> () -> {
+            startTogether.await(30, TimeUnit.SECONDS);
+            return authorizationService.ensureUserExists(LOGIN, LOGIN, UserOrigin.OIDC, List.of());
+          })
+          .collect(Collectors.toList());
+
+      List<Future<Object>> results = pool.invokeAll(logins, 60, TimeUnit.SECONDS);
+
+      for (Future<Object> result : results) {
+        try {
+          result.get();
+        } catch (Exception e) {
+          fail("Concurrent first login failed: " + e.getCause());
+        }
+      }
+    } finally {
+      pool.shutdownNow();
+    }
+
+    assertEquals("Exactly one user should have been registered", 1,
+        (int) jdbcTemplate.queryForObject(
+            "SELECT count(*) FROM " + ohdsiSchema + ".sec_user WHERE login = ?", Integer.class, LOGIN));
+  }
+}

--- a/src/test/java/org/ohdsi/webapi/security/authz/UserRegistrationRaceTest.java
+++ b/src/test/java/org/ohdsi/webapi/security/authz/UserRegistrationRaceTest.java
@@ -16,6 +16,7 @@
 package org.ohdsi.webapi.security.authz;
 
 import java.util.List;
+import java.util.Set;
 import java.util.concurrent.Callable;
 import java.util.concurrent.CyclicBarrier;
 import java.util.concurrent.ExecutorService;
@@ -28,6 +29,8 @@ import java.util.stream.IntStream;
 import org.junit.After;
 import org.junit.Test;
 import org.ohdsi.webapi.AbstractDatabaseTest;
+import org.ohdsi.webapi.security.authc.AuthenticatedLogin;
+import org.ohdsi.webapi.security.authc.LoginService;
 import org.ohdsi.webapi.security.authc.UserOrigin;
 import org.springframework.beans.factory.annotation.Autowired;
 
@@ -43,15 +46,21 @@ public class UserRegistrationRaceTest extends AbstractDatabaseTest {
   @Autowired
   private AuthorizationService authorizationService;
 
+  @Autowired
+  private LoginService loginService;
+
   private static final String LOGIN = "race_test_user";
+  private static final String ROLE_NAME = "RaceTestRole";
+  private static final Long ROLE_ID = 51003L;
   private static final int THREADS = 16;
 
   @After
   public void deleteFixture() {
     jdbcTemplate.update("DELETE FROM " + ohdsiSchema + ".sec_user_role WHERE user_id IN "
-        + "(SELECT id FROM " + ohdsiSchema + ".sec_user WHERE login = ?)", LOGIN);
+        + "(SELECT id FROM " + ohdsiSchema + ".sec_user WHERE login = ?) OR role_id = ?", LOGIN, ROLE_ID);
+    jdbcTemplate.update("DELETE FROM " + ohdsiSchema + ".sec_session WHERE login = ?", LOGIN);
     jdbcTemplate.update("DELETE FROM " + ohdsiSchema + ".sec_user WHERE login = ?", LOGIN);
-    jdbcTemplate.update("DELETE FROM " + ohdsiSchema + ".sec_role WHERE name = ?", LOGIN);
+    jdbcTemplate.update("DELETE FROM " + ohdsiSchema + ".sec_role WHERE name IN (?, ?)", LOGIN, ROLE_NAME);
   }
 
   @Test
@@ -83,5 +92,53 @@ public class UserRegistrationRaceTest extends AbstractDatabaseTest {
     assertEquals("Exactly one user should have been registered", 1,
         (int) jdbcTemplate.queryForObject(
             "SELECT count(*) FROM " + ohdsiSchema + ".sec_user WHERE login = ?", Integer.class, LOGIN));
+  }
+
+  @Test
+  public void testConcurrentLoginsDoNotDuplicateRoleAssignments() throws Exception {
+    jdbcTemplate.update("INSERT INTO " + ohdsiSchema + ".sec_role (id, name, system_role) VALUES (?, ?, true)",
+        ROLE_ID, ROLE_NAME);
+
+    // Register first, so the concurrent logins below race role assignment rather than
+    // queueing on the registration lock.
+    loginService.onSuccess(AuthenticatedLogin.builder()
+        .login(LOGIN).name(LOGIN).origin(UserOrigin.OIDC).roles(Set.of()).originAuthentication(null).build());
+
+    AuthenticatedLogin authenticated = AuthenticatedLogin.builder()
+        .login(LOGIN)
+        .name(LOGIN)
+        .origin(UserOrigin.OIDC)
+        .roles(Set.of(ROLE_NAME))
+        .originAuthentication(null)
+        .build();
+
+    CyclicBarrier startTogether = new CyclicBarrier(THREADS);
+    ExecutorService pool = Executors.newFixedThreadPool(THREADS);
+
+    try {
+      List<Callable<Object>> logins = IntStream.range(0, THREADS)
+          .<Callable<Object>>mapToObj(i -> () -> {
+            startTogether.await(30, TimeUnit.SECONDS);
+            return loginService.onSuccess(authenticated);
+          })
+          .collect(Collectors.toList());
+
+      for (Future<Object> result : pool.invokeAll(logins, 60, TimeUnit.SECONDS)) {
+        try {
+          result.get();
+        } catch (Exception e) {
+          fail("Concurrent login failed: " + e.getCause());
+        }
+      }
+    } finally {
+      pool.shutdownNow();
+    }
+
+    assertEquals("The role should be assigned exactly once", 1,
+        (int) jdbcTemplate.queryForObject(
+            "SELECT count(*) FROM " + ohdsiSchema + ".sec_user_role ur "
+                + "JOIN " + ohdsiSchema + ".sec_user u ON u.id = ur.user_id "
+                + "JOIN " + ohdsiSchema + ".sec_role r ON r.id = ur.role_id "
+                + "WHERE u.login = ? AND r.name = ?", Integer.class, LOGIN, ROLE_NAME));
   }
 }

--- a/src/test/java/org/ohdsi/webapi/security/authz/UserRoleOriginTest.java
+++ b/src/test/java/org/ohdsi/webapi/security/authz/UserRoleOriginTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 cknoll1.
+ * Copyright 2026 p-hoffmann.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/ohdsi/webapi/security/authz/UserRoleOriginTest.java
+++ b/src/test/java/org/ohdsi/webapi/security/authz/UserRoleOriginTest.java
@@ -1,0 +1,119 @@
+/*
+ * Copyright 2024 cknoll1.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.ohdsi.webapi.security.authz;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.ohdsi.webapi.AbstractDatabaseTest;
+import org.ohdsi.webapi.security.authc.UserOrigin;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Verifies that a role assignment is tracked per authentication origin, so a grant from
+ * one origin neither blocks nor is blocked by the same role granted from another.
+ */
+public class UserRoleOriginTest extends AbstractDatabaseTest {
+
+  @Autowired
+  private RoleService roleService;
+
+  @Autowired
+  private UserService userService;
+
+  private static final Long USER_ID = 51001L;
+  private static final Long ROLE_ID = 51002L;
+  private static final String LOGIN = "origin_test_user";
+  private static final String ROLE_NAME = "OriginTestRole";
+
+  @Before
+  public void insertFixture() {
+    deleteFixture();
+    jdbcTemplate.update("INSERT INTO " + ohdsiSchema + ".sec_user (id, login, name, origin) VALUES (?, ?, ?, 'SYSTEM')",
+        USER_ID, LOGIN, LOGIN);
+    jdbcTemplate.update("INSERT INTO " + ohdsiSchema + ".sec_role (id, name, system_role) VALUES (?, ?, true)",
+        ROLE_ID, ROLE_NAME);
+  }
+
+  @After
+  public void deleteFixture() {
+    jdbcTemplate.update("DELETE FROM " + ohdsiSchema + ".sec_user_role WHERE user_id = ? OR role_id = ?",
+        USER_ID, ROLE_ID);
+    jdbcTemplate.update("DELETE FROM " + ohdsiSchema + ".sec_user WHERE id = ?", USER_ID);
+    jdbcTemplate.update("DELETE FROM " + ohdsiSchema + ".sec_role WHERE id = ?", ROLE_ID);
+  }
+
+  private int countAssignments(String origin) {
+    String sql = "SELECT count(*) FROM " + ohdsiSchema + ".sec_user_role WHERE user_id = ? AND role_id = ?"
+        + (origin == null ? "" : " AND origin = '" + origin + "'");
+    return jdbcTemplate.queryForObject(sql, Integer.class, USER_ID, ROLE_ID);
+  }
+
+  private void insertAssignment(String origin) {
+    jdbcTemplate.update("INSERT INTO " + ohdsiSchema + ".sec_user_role (id, user_id, role_id, origin) "
+        + "VALUES (nextval('" + ohdsiSchema + ".sec_user_role_sequence'), ?, ?, ?)", USER_ID, ROLE_ID, origin);
+  }
+
+  @Test
+  public void testGrantFromSecondOriginIsNotShadowed() {
+    UserEntity user = userService.getUserById(USER_ID);
+    RoleEntity role = roleService.getRole(ROLE_ID);
+
+    roleService.addUserToRole(user, role, UserOrigin.SYSTEM);
+    roleService.addUserToRole(user, role, UserOrigin.OIDC);
+
+    assertEquals("SYSTEM grant should be recorded", 1, countAssignments("SYSTEM"));
+    assertEquals("OIDC grant must not be shadowed by the existing SYSTEM grant", 1, countAssignments("OIDC"));
+
+    roleService.addUserToRole(user, role, UserOrigin.OIDC);
+    assertEquals("Re-granting the same origin should not duplicate", 1, countAssignments("OIDC"));
+  }
+
+  @Test
+  public void testRemoveByOriginLeavesOtherOriginsIntact() {
+    UserEntity user = userService.getUserById(USER_ID);
+    RoleEntity role = roleService.getRole(ROLE_ID);
+
+    roleService.addUserToRole(user, role, UserOrigin.SYSTEM);
+    roleService.addUserToRole(user, role, UserOrigin.OIDC);
+
+    roleService.removeUserFromRole(LOGIN, ROLE_NAME, UserOrigin.OIDC);
+
+    assertEquals("OIDC grant should be removed", 0, countAssignments("OIDC"));
+    assertEquals("SYSTEM grant should survive", 1, countAssignments("SYSTEM"));
+
+    roleService.removeUser(USER_ID, ROLE_ID);
+    assertEquals("Removing the user from the role should clear every origin", 0, countAssignments(null));
+  }
+
+  @Test
+  public void testDuplicateRowsDoNotBreakAssignment() {
+    UserEntity user = userService.getUserById(USER_ID);
+    RoleEntity role = roleService.getRole(ROLE_ID);
+
+    // Duplicates predating the dedupe migration must not make the lookup throw.
+    insertAssignment("SYSTEM");
+    insertAssignment("SYSTEM");
+
+    roleService.addUserToRole(user, role, UserOrigin.SYSTEM);
+    assertEquals("Existing duplicates should be left alone, not added to", 2, countAssignments("SYSTEM"));
+
+    roleService.removeUser(USER_ID, ROLE_ID);
+    assertEquals("Removal should clear duplicates too", 0, countAssignments(null));
+  }
+}


### PR DESCRIPTION
Three defects in the login path, surfacing as roles silently failing to apply, as duplicated role assignments, or as a failed login.

## 1. Role assignments ignored their origin

`sec_user_role.origin` records which authentication source granted an assignment, and `LoginService.syncRoles` uses it to reconcile only the roles asserted by the origin the user just logged in from. `RoleService.addUserToRole` did not honour that: it resolved an existing assignment with `findByUserAndRole`, which ignores `origin`.

Effects:

1. A user who already held a role from one origin never received it from another. The lookup returned the existing row and inserted nothing, so the grant silently never took effect — while the caller still logged it as added. `getRolesByOrigin` continued not to see it, so it was retried on every subsequent login.
2. Concurrent logins racing the same check-then-insert left duplicate rows; there is no unique constraint on the table.
3. Once duplicated, the `Optional`-returning query threw `IncorrectResultSizeDataAccessException`. That broke role synchronisation for the affected role permanently, and made `DELETE /role/{roleId}/users/{userId}` return 500, so the duplicates could not be cleared through the API either.

Changes:

- `addUserToRole` resolves the assignment by `(user, role, origin)`.
- `removeUserFromRole` and `removeUser` delete every matching assignment instead of one arbitrary row. `removeUser` (the admin endpoint) intentionally spans all origins, so that it stays consistent with `getRoleUsers`, which is not origin-scoped; anything the identity provider still asserts is re-added on the next login.
- The repository query uses `findFirst` so databases already holding duplicates do not throw.
- `V2.99.0010__dedupe_sec_user_role.sql` collapses existing duplicates, keeping the lowest id per `(user_id, role_id, origin)`.

## 2. Concurrent first logins could not both register the user

`ensureUserExists` registered the user inside the caller's transaction. `sec_user.login` is unique, and so is the personal role name derived from it, so when two first logins for the same principal ran at once the loser marked the caller's transaction rollback-only and the login failed outright with `duplicate key value violates unique constraint "sec_user_login_unique"`.

Registration is now serialised on a transaction scoped advisory lock, taken on the connection the transaction already holds, after which the user is looked up again. Whoever waits observes the winner's row once that transaction commits, so the conflicting insert never happens.

Serialising was chosen over registering in a nested `REQUIRES_NEW` transaction. That alternative works for a single login, but it holds a second pooled connection for the duration of every in-flight first login while the caller's transaction still holds the first. Once simultaneous first logins reach the pool size (10 by default), none of them can obtain the second connection and none can release the first, so they all fail together after `spring.datasource.hikari.connection-timeout` rather than immediately. `UserRegistrationRaceTest` runs more threads than the default pool holds and reproduces exactly that.

This uses `pg_advisory_xact_lock`, which is Postgres specific. This branch ships Postgres migrations only, but say the word if a portable form is preferred.

Deployments that authenticate on every request rather than once per session hit the underlying race reliably.

## 3. Concurrent logins duplicated role assignments

Granting a role is a lookup followed by an insert and `sec_user_role` has no unique constraint, so two logins that both found a role missing both added it. A deployment that authenticates per request accumulated a row per concurrent request; the test below produces ten.

The logins that have roles to add now serialise on a transaction scoped advisory lock and re-read the assignments once it is held. Logins with nothing to add, which is all of them after the first, take no lock.

The lock is taken once per login rather than once per assignment deliberately. Locking per assignment, or adding a unique constraint and letting the insert conflict, would make a transaction hold several of these locks at once, and `syncRoles` iterates an unordered set — so two logins could take the same locks in opposite orders and deadlock.

A first login does hold two of these locks, the registration one and this one, but `onSuccess` always registers before it syncs and each lock is taken in exactly one place, so the acquisition order is the same in every transaction and no cycle is possible.

A unique constraint on `(user_id, role_id, origin)` would be a reasonable follow-up now that duplicates can no longer be created, but it is not needed to close this and is left out to keep the migration additive.

Two related things are deliberately left alone. `addUserToRole` remains unsynchronised for its non-login callers, the admin endpoint and the bulk user import; those grant at `SYSTEM` origin while login sync grants at the origin that authenticated, so they write different rows rather than duplicates. And `ExternalRoleMapService.syncUserRoles` repeats the pattern this fixes but has no callers at all — worth deleting or routing through the same lock before anything starts using it.

## Testing

`UserRoleOriginTest` covers a grant from a second origin, per-origin removal, and tolerance of pre-existing duplicates. `UserRegistrationRaceTest` releases sixteen concurrent logins for the same principal from a barrier — more than the default connection pool holds — and asserts that all succeed, that exactly one user is registered, and that a role asserted by all of them is assigned exactly once.

Each fails on the unmodified branch with the corresponding production symptom and passes with this change.

`ExternalRoleMappingTest` and `ExternalRoleMappingCsvTest` fail identically with and without this change on `webapi-3.0`.
