### PR TITLE
Report a rejected argument as 400 with its reason, not an opaque 500

### DIFF
--- a/src/main/java/org/ohdsi/webapi/mvc/GlobalExceptionHandler.java
+++ b/src/main/java/org/ohdsi/webapi/mvc/GlobalExceptionHandler.java
@@ -142,6 +142,46 @@ public class GlobalExceptionHandler {
     }
 
     /**
+     * Handle rejected arguments.
+     *
+     * <p>The service layer uses {@link IllegalArgumentException} for conditions
+     * the caller caused and can act on: a generation, characterization, analysis
+     * or preset that does not exist. Without a handler these reached the generic
+     * fallback, which reports 500 and replaces the message with the exception's
+     * class name, so a request naming a missing generation came back as
+     * {@code {"message":"An exception occurred: java.lang.IllegalArgumentException"}}
+     * and the caller could not tell what had been rejected, or that the fault was
+     * theirs. Reported in OHDSI/Atlas3#291.
+     *
+     * <p>These messages are written by this codebase for exactly this purpose, so
+     * they are passed through. Everything the service layer does not raise
+     * deliberately still ends up at the generic handler and is still sanitised.
+     */
+    @ExceptionHandler(IllegalArgumentException.class)
+    public ResponseEntity<ErrorMessage> handleIllegalArgument(IllegalArgumentException ex) {
+        logException(ex);
+        return badRequest(ex);
+    }
+
+    private static ResponseEntity<ErrorMessage> badRequest(Throwable ex) {
+        RuntimeException sanitizedException = new RuntimeException(describeRejection(ex));
+        sanitizedException.setStackTrace(new StackTraceElement[0]);
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(new ErrorMessage(sanitizedException));
+    }
+
+    /**
+     * An argument rejection is only worth reporting if it says what was rejected.
+     * A message-less exception would otherwise produce a null body, which tells
+     * the caller even less than the class name did.
+     */
+    private static String describeRejection(Throwable ex) {
+        String message = ex.getMessage();
+        return message != null && !message.trim().isEmpty()
+                ? message
+                : "Request rejected: " + ex.getClass().getName();
+    }
+
+    /**
      * Handle concept not installed exceptions
      */
     @ExceptionHandler(ConceptRecommendedNotInstalledException.class)
@@ -174,9 +214,14 @@ public class GlobalExceptionHandler {
                 status = HttpStatus.BAD_REQUEST;
                 // New exception must be created or direct self-reference exception will be thrown
                 responseException = new RuntimeException(throwable.getMessage());
+            } else if (throwable instanceof IllegalArgumentException) {
+                status = HttpStatus.BAD_REQUEST;
+                responseException = new RuntimeException(describeRejection(throwable));
             } else {
                 status = HttpStatus.INTERNAL_SERVER_ERROR;
-                responseException = new RuntimeException("An exception occurred: " + ex.getClass().getName());
+                // The wrapper's own class name says only that a proxy was involved,
+                // which is never the exception the caller needs named.
+                responseException = new RuntimeException("An exception occurred: " + throwable.getClass().getName());
             }
         } else {
             status = HttpStatus.INTERNAL_SERVER_ERROR;

--- a/src/test/java/org/ohdsi/webapi/mvc/GlobalExceptionHandlerTest.java
+++ b/src/test/java/org/ohdsi/webapi/mvc/GlobalExceptionHandlerTest.java
@@ -3,6 +3,8 @@ package org.ohdsi.webapi.mvc;
 import org.junit.Test;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.dao.DataIntegrityViolationException;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.UndeclaredThrowableException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.test.util.ReflectionTestUtils;
@@ -92,5 +94,61 @@ public class GlobalExceptionHandlerTest {
 
         assertEquals(HttpStatus.CONFLICT, response.getStatusCode());
         assertTrue(response.getBody().message().startsWith("Violation of UNIQUE KEY"));
+    }
+
+    /**
+     * The service layer raises IllegalArgumentException for a generation,
+     * characterization, analysis or preset the caller named but that does not
+     * exist. With no handler for it these reached the generic fallback, which
+     * answers 500 and replaces the message with the class name, so the caller
+     * learned neither what was rejected nor that the fault was theirs
+     * (OHDSI/Atlas3#291).
+     */
+    @Test
+    public void reportsARejectedArgumentAsBadRequestAndKeepsItsReason() {
+        ResponseEntity<GlobalExceptionHandler.ErrorMessage> response =
+                handler.handleIllegalArgument(new IllegalArgumentException("There is no generation with id = 42."));
+
+        assertEquals(HttpStatus.BAD_REQUEST, response.getStatusCode());
+        assertNotNull(response.getBody());
+        assertEquals("There is no generation with id = 42.", response.getBody().message());
+    }
+
+    @Test
+    public void namesTheExceptionWhenARejectedArgumentCarriesNoReason() {
+        ResponseEntity<GlobalExceptionHandler.ErrorMessage> response =
+                handler.handleIllegalArgument(new IllegalArgumentException());
+
+        assertEquals(HttpStatus.BAD_REQUEST, response.getStatusCode());
+        assertNotNull(response.getBody());
+        assertTrue(response.getBody().message().contains("java.lang.IllegalArgumentException"));
+    }
+
+    @Test
+    public void unwrapsARejectedArgumentThatArrivesThroughAProxy() {
+        UndeclaredThrowableException wrapped = new UndeclaredThrowableException(
+                new InvocationTargetException(new IllegalArgumentException("Preset analysis with id=7 does not exist")));
+
+        ResponseEntity<GlobalExceptionHandler.ErrorMessage> response = handler.handleUndeclaredThrowable(wrapped);
+
+        assertEquals(HttpStatus.BAD_REQUEST, response.getStatusCode());
+        assertNotNull(response.getBody());
+        assertEquals("Preset analysis with id=7 does not exist", response.getBody().message());
+    }
+
+    /**
+     * The wrapper's own class name only says a proxy was involved. Naming the
+     * exception the caller actually hit is the point of the message.
+     */
+    @Test
+    public void namesTheUnderlyingExceptionRatherThanTheProxyWrapper() {
+        UndeclaredThrowableException wrapped = new UndeclaredThrowableException(
+                new InvocationTargetException(new IllegalStateException("boom")));
+
+        ResponseEntity<GlobalExceptionHandler.ErrorMessage> response = handler.handleUndeclaredThrowable(wrapped);
+
+        assertEquals(HttpStatus.INTERNAL_SERVER_ERROR, response.getStatusCode());
+        assertNotNull(response.getBody());
+        assertTrue(response.getBody().message().contains("java.lang.IllegalStateException"));
     }
 }


### PR DESCRIPTION
Reported in OHDSI/Atlas3#291.

## Problem

`CcServiceImpl` raises `IllegalArgumentException` in eighteen places for conditions the caller caused and can act on, each with a message naming exactly what was not found:

```java
throw new IllegalArgumentException(String.format("There is no generation with id = %d.", id));
() -> new IllegalArgumentException("Cohort characterization cannot be found by id: " + id)
() -> new IllegalArgumentException(String.format("Preset analysis with id=%s does not exist", feAnalysis.getId()))
```

None of it reaches the caller. `IllegalArgumentException` has no handler, so it falls to the generic `Throwable` fallback:

```java
RuntimeException sanitizedException = new RuntimeException("An exception occurred: " + ex.getClass().getName());
return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(errorMessage);
```

A `POST /cohort-characterization/generation/{id}/result` whose characterization references a preset that no longer resolves therefore answers **500** with

```json
{"message":"An exception occurred: java.lang.IllegalArgumentException"}
```

which says neither what was rejected nor that the fault lay with the request. In Atlas3#291 the reporter could not tell whether the generation itself had failed or only the results retrieval, and had to read the network tab to get even the class name.

## Change

- `IllegalArgumentException` is handled as **400** carrying the message the service layer already wrote.
- The same unwrapping applies when it arrives through a proxy as an `UndeclaredThrowableException`, matching how `BadRequestAtlasException` and `ConversionAtlasException` are already treated there.
- An exception with no message at all falls back to naming its class, so the body is never null, which would tell the caller less than the old behaviour did.

On exposure: these messages are written by this codebase for exactly this purpose. Anything not raised deliberately still reaches the generic handler and is still sanitised, and stack traces are still stripped.

### Incidental

The proxy branch reported `ex.getClass().getName()`, where `ex` is the `UndeclaredThrowableException` wrapper rather than the exception inside it, so every unexpected failure arriving through a proxy was described as `UndeclaredThrowableException`. It now names the real one.

## Scope

This does not change why a given characterization's results request is rejected; it makes the server say so. Atlas3 side, OHDSI/Atlas3#311 stops the client presenting a rejected results request as an empty table beside a healthy-looking run.

Related precedent: #2539 did the same for tag creation, moving a deliberate rejection off the generic 500 path.

## Tests

Four new cases in `GlobalExceptionHandlerTest`, all failing before the change:

- a rejected argument answers 400 and keeps its reason
- one with no message names its class instead of returning a null body
- one arriving through a proxy is unwrapped to 400 with its reason
- an unexpected proxied failure names the underlying exception, not the wrapper

`GlobalExceptionHandlerTest`: 9 run, 0 failures. The 3 `VocabularyServiceIT` failures in a full run are pre-existing on a clean checkout here (no vocabulary schema available) and unrelated.